### PR TITLE
fix file reuse feature in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 - Bug fix: Improve video playback support on iOS and Android.
 - Bug fix: Missing translations for attribute/model names in admin.
+- Bug fix: Reusing files from other entries was broken in editor.
 
 ### Version 0.1.0
 

--- a/app/assets/javascripts/pageflow/editor/models/entry.js
+++ b/app/assets/javascripts/pageflow/editor/models/entry.js
@@ -85,7 +85,11 @@ pageflow.Entry = Backbone.Model.extend({
   },
 
   getFileCollection: function(filetype) {
-    return this[lowerCaseFirst(filetype) + 's'];
+    return this[lowerCaseFirst(removeNamespace(filetype)) + 's'];
+
+    function removeNamespace(string) {
+      return string.split('::').pop();
+    }
 
     function lowerCaseFirst(string) {
       return string.charAt(0).toLowerCase() + string.slice(1);

--- a/app/assets/javascripts/pageflow/editor/views/files_explorer_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/files_explorer_view.js
@@ -111,17 +111,17 @@ pageflow.FilesExplorerView = Backbone.Marionette.ItemView.extend({
         file;
 
     if ((file = sel.get('image_file'))) {
-      file.set('typeName', 'ImageFile');
+      file.set('typeName', 'Pageflow::ImageFile');
       return file;
     }
 
     if ((file = sel.get('audio_file'))) {
-      file.set('typeName', 'AudioFile');
+      file.set('typeName', 'Pageflow::AudioFile');
       return file;
     }
 
     if ((file = sel.get('video_file'))) {
-      file.set('typeName', 'VideoFile');
+      file.set('typeName', 'Pageflow::VideoFile');
       return file;
     }
   }

--- a/spec/features/editor/reusing_a_file_spec.rb
+++ b/spec/features/editor/reusing_a_file_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+feature 'editor reusing a file', js: true do
+  scenario 'from a another entry in account' do
+    user = Dom::Admin::Page.sign_in_as(:editor)
+    entry = create(:entry, title: 'Test Entry', with_member: user)
+    other_entry = create(:entry, title: 'Other Entry', with_member: user)
+    file = create(:image_file, used_in: other_entry.draft)
+
+    visit(pageflow.edit_entry_path(entry))
+    Dom::Editor::Sidebar.find!.manage_files_menu_item.click
+    Dom::Editor::ManageFilesPanel.find!.request_file_reuse
+    Dom::Editor::FilesExplorer.find!.select_file(entry, file)
+
+    expect(Dom::Editor::FileItem.find_by_file!(file)).to be_present
+  end
+end

--- a/spec/support/domino.rb
+++ b/spec/support/domino.rb
@@ -1,5 +1,5 @@
 class Domino
-  def self.find!
-    new(Capybara.current_session.find(@selector))
+  def self.find!(options = {})
+    new(Capybara.current_session.find(@selector, options))
   end
 end

--- a/spec/support/dominos/editor/file_item.rb
+++ b/spec/support/dominos/editor/file_item.rb
@@ -1,0 +1,17 @@
+module Dom
+  module Editor
+    class FileItem < Domino
+      selector '.editor .manage_files ul.files > li'
+
+      attribute :file_name, '.file_name'
+
+      def self.find_by_file!(file)
+        find_by_file_name!(file.attachment.original_filename)
+      end
+
+      def self.find_by_file_name!(file_name)
+        find!(text: file_name)
+      end
+    end
+  end
+end

--- a/spec/support/dominos/editor/files_explorer.rb
+++ b/spec/support/dominos/editor/files_explorer.rb
@@ -1,0 +1,20 @@
+module Dom
+  module Editor
+    class FilesExplorer < Domino
+      selector 'div.files_explorer'
+
+      def ok_button
+        node.find('button.ok')
+      end
+
+      def find_file_gallery_item(file)
+        node.find("ul.files_gallery li[data-id='#{file.id}']")
+      end
+
+      def select_file(entry, file)
+        find_file_gallery_item(file).click
+        ok_button.click
+      end
+    end
+  end
+end

--- a/spec/support/dominos/editor/manage_files_panel.rb
+++ b/spec/support/dominos/editor/manage_files_panel.rb
@@ -1,0 +1,20 @@
+module Dom
+  module Editor
+    class ManageFilesPanel < Domino
+      selector '.editor div.manage_files'
+
+      def add_button
+        node.find('.select_button button')
+      end
+
+      def reuse_file_menu_item
+        node.find('.select_button li:last-child a')
+      end
+
+      def request_file_reuse
+        add_button.click
+        reuse_file_menu_item.click
+      end
+    end
+  end
+end

--- a/spec/support/dominos/editor/publish_entry_panel.rb
+++ b/spec/support/dominos/editor/publish_entry_panel.rb
@@ -3,6 +3,8 @@ module Dom
     class PublishEntryPanel < Domino
       selector 'div.publish_entry'
 
+      attribute :exhausted_message, '.exhausted_message'
+
       def save_button
         node.find('button.save')
       end

--- a/spec/support/dominos/editor/sidebar.rb
+++ b/spec/support/dominos/editor/sidebar.rb
@@ -18,6 +18,10 @@ module Dom
       def publish_button
         node.find('.publish')
       end
+
+      def manage_files_menu_item
+        node.find('.menu .manage_files')
+      end
     end
   end
 end


### PR DESCRIPTION
there still was a reference to ImageFile instead of
Pageflow::ImageFile causing file usages not to be created.

Improve feature level spec coverage.
