### PR TITLE
Allow to Scope Entries by Request Attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - More configurable default theme.
 - Option to require explicit confirmation of video/audio encoding by user
   before submitting jobs to Zencoder.
+- `public_entry_request_scope` option to restrict the published
+  entries available under a certain host name.
 
 - Bug fix: Improve video playback support on iOS and Android.
 - Bug fix: Missing translations for attribute/model names in admin.

--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -24,7 +24,7 @@ module Pageflow
     def show
       respond_to do |format|
         format.any(:html, :css) do
-          @entry = PublishedEntry.find(params[:id])
+          @entry = PublishedEntry.find(params[:id], entry_request_scope)
         end
         format.json do
           authenticate_user!
@@ -38,7 +38,7 @@ module Pageflow
     end
 
     def page
-      entry = PublishedEntry.find(params[:id])
+      entry = PublishedEntry.find(params[:id], entry_request_scope)
       index = params[:page_index].split('-').first.to_i
 
       redirect_to(short_entry_path(entry.to_model, :anchor => entry.pages[index].try(:perma_id)))
@@ -72,6 +72,10 @@ module Pageflow
 
     def entry_params
       params.require(:entry).permit(:title, :summary, :credits, :manual_start)
+    end
+
+    def entry_request_scope
+      Pageflow.config.public_entry_request_scope.call(Entry, request)
     end
   end
 end

--- a/app/controllers/pageflow/video_files_controller.rb
+++ b/app/controllers/pageflow/video_files_controller.rb
@@ -5,10 +5,16 @@ module Pageflow
     def show
       respond_to do |format|
         format.html do
-          entry = PublishedEntry.find(params[:entry_id])
+          entry = PublishedEntry.find(params[:entry_id], entry_request_scope)
           @video_file = entry.video_files.find(params[:id])
         end
       end
+    end
+
+    protected
+
+    def entry_request_scope
+      Pageflow.config.public_entry_request_scope.call(Entry, request)
     end
   end
 end

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -26,8 +26,8 @@ module Pageflow
       pages.first.try(:thumbnail) || ImageFile.new.processed_attachment
     end
 
-    def self.find(id)
-      PublishedEntry.new(Entry.published.find(id))
+    def self.find(id, scope = Entry)
+      PublishedEntry.new(scope.published.find(id))
     end
 
     def cache_key

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -68,6 +68,22 @@ module Pageflow
     # accessible via one official url.
     attr_accessor :editor_routing_constraint
 
+    # Either a lambda or an object with a `call` method taking two
+    # parameters: An `ActiveRecord` scope of `Pageflow::Entry` records
+    # and an `ActionDispatch::Request` object. Has to return the scope
+    # in which to find entries.
+    #
+    # Used by all public actions that display entires to restrict the
+    # available entries by hostname or other request attributes.
+    #
+    # Example:
+    #
+    #     # Only make entries of one account available under <account.name>.example.com
+    #     config.public_entry_request_scope = lambda do |entries, request|
+    #       entries.includes(:account).where(pageflow_accounts: {name: request.subdomain})
+    #     end
+    attr_accessor :public_entry_request_scope
+
     # Submit video/audio encoding jobs only after the user has
     # explicitly confirmed in the editor. Defaults to false.
     attr_accessor :confirm_encoding_jobs
@@ -83,6 +99,8 @@ module Pageflow
       @hooks = Hooks.new
       @quotas = Quotas.new
       @themes = Themes.new
+
+      @public_entry_request_scope = lambda { |entries, request| entries }
 
       @confirm_encoding_jobs = false
     end

--- a/spec/controllers/pageflow/video_files_controller_spec.rb
+++ b/spec/controllers/pageflow/video_files_controller_spec.rb
@@ -25,6 +25,35 @@ module Pageflow
 
         expect(response.status).to eq(404)
       end
+
+      context 'with configured entry_request_scope' do
+        before do
+          Pageflow.config.public_entry_request_scope = lambda do |entries, request|
+            entries.includes(:account).where(pageflow_accounts: {name: request.subdomain})
+          end
+        end
+
+        it 'responds with success for matching entry' do
+          account = create(:account, :name => 'news')
+          entry = create(:entry, :published, :account => account)
+          video_file = create(:video_file, :entry => entry, :used_in => entry.published_revision)
+
+          request.host = 'news.example.com'
+          get(:show, :entry_id => entry.id, :id => video_file.id)
+
+          expect(response.status).to eq(200)
+        end
+
+        it 'responds with not found for non matching entry' do
+          entry = create(:entry, :published)
+          video_file = create(:video_file, :entry => entry, :used_in => entry.published_revision)
+
+          request.host = 'news.example.com'
+          get(:show, :entry_id => entry.id, :id => video_file.id)
+
+          expect(response.status).to eq(404)
+        end
+      end
     end
   end
 end

--- a/spec/models/pageflow/published_entry_spec.rb
+++ b/spec/models/pageflow/published_entry_spec.rb
@@ -39,5 +39,37 @@ module Pageflow
         expect(published_entry.stylesheet_model).to be(revision)
       end
     end
+
+    describe '.find' do
+      it 'finds published entry' do
+        entry = create(:entry, :published)
+
+        expect(PublishedEntry.find(entry.id).to_model).to eq(entry)
+      end
+
+      it 'finds entry in scope' do
+        account = create(:account)
+        entry = create(:entry, :published, account: account)
+
+        expect(PublishedEntry.find(entry.id, account.entries).to_model).to eq(entry)
+      end
+
+      it 'does not find entries not in scope' do
+        account = create(:account)
+        entry = create(:entry, :published)
+
+        expect {
+          PublishedEntry.find(entry.id, account.entries)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'does not find not published entries' do
+        entry = create(:entry)
+
+        expect {
+          PublishedEntry.find(entry.id)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds a `public_entry_request_scope` configuration setting which allows
restricting the avaiable published entries under a specific host. For
example, the entries accessible under an account's CNAME can be
restricted to those of the account.
