### PR TITLE
fix colored area behind loading spinner on startup

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/loading_spinner.css.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/loading_spinner.css.scss
@@ -14,6 +14,16 @@
     position: absolute;
     z-index: 0;
     background-color: $main-color;
+    animation: fadeInLoadingSpinner  linear 2s;
+    animation-iteration-count: 1;
+    -webkit-animation: fadeInLoadingSpinner linear 2s;
+    -webkit-animation-iteration-count: 1;
+    -moz-animation: fadeInLoadingSpinner linear 2s;
+    -moz-animation-iteration-count: 1;
+    -o-animation: fadeInLoadingSpinner linear 2s;
+    -o-animation-iteration-count: 1;
+    -ms-animation: fadeInLoadingSpinner linear 2s;
+    -ms-animation-iteration-count: 1;
 
     &:before {
       content: " ";
@@ -36,6 +46,66 @@
       @include animation-iteration-count(infinite);
       @include animation-timing-function(linear);
     }
+  }
+}
+
+@keyframes fadeInLoadingSpinner {
+  0% {
+    opacity:0;
+  }
+  48% {
+    opacity:0;
+  }
+  100% {
+    opacity:1;
+  }
+}
+
+@-moz-keyframes fadeInLoadingSpinner {
+  0% {
+    opacity:0;
+  }
+  48% {
+    opacity:0;
+  }
+  100% {
+    opacity:1;
+  }
+}
+
+@-webkit-keyframes fadeInLoadingSpinner {
+  0% {
+    opacity:0;
+  }
+  48% {
+    opacity:0;
+  }
+  100% {
+    opacity:1;
+  }
+}
+
+@-o-keyframes fadeInLoadingSpinner {
+  0% {
+    opacity:0;
+  }
+  48% {
+    opacity:0;
+  }
+  100% {
+    opacity:1;
+  }
+}
+
+@-ms-keyframes fadeInLoadingSpinner {
+  0% {
+    opacity:0;
+  }
+  48% {
+    opacity:0;
+  }
+  100% {
+    opacity:1;
   }
 }
 


### PR DESCRIPTION
when displaying the loading spinner there appears to be a short moment when css is loaded but images are not which results in showing a colored area in the middle of the loading screen.

this is pretty ugly and should be fixed by this pull request through fading in the loading spinner after short delay
