### PR TITLE
Update Zencoder Gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 None so far.
 
+### Version 0.2.1
+
+- Update Zencoder gem to fix [Zencoder SSL issue](http://status.zencoder.com/events/84).
+
 ### Version 0.2.0
 
 ##### Breaking Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 PATH
   remote: .
   specs:
-    pageflow (0.2.0)
+    pageflow (0.2.1)
       activeadmin
       ar_after_transaction
       aws-sdk
@@ -51,7 +51,7 @@ PATH
       videojs_rails (= 4.1.0)
       wysihtml5-rails
       yajl-ruby
-      zencoder
+      zencoder (~> 2.5)
 
 GEM
   remote: https://rubygems.org/
@@ -86,7 +86,7 @@ GEM
     arbre (1.0.1)
       activesupport (>= 3.0.0)
     arel (4.0.2)
-    aws-sdk (1.48.1)
+    aws-sdk (1.49.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     backbone-rails (1.0.0.1)
@@ -315,7 +315,7 @@ GEM
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yajl-ruby (1.2.1)
-    zencoder (2.4.6)
+    zencoder (2.5.0)
       multi_json
 
 PLATFORMS

--- a/lib/pageflow/version.rb
+++ b/lib/pageflow/version.rb
@@ -1,3 +1,3 @@
 module Pageflow
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paperclip', '~> 3.5'
 
   # zencoder
-  s.add_dependency 'zencoder'
+  s.add_dependency 'zencoder', '~> 2.5'
 
   # Amazon AWS
   s.add_dependency 'aws-sdk'


### PR DESCRIPTION
Version 2.4 of the Zencoder gem contained expiring SSL certificates
bundled inside the gem. 2.5 relies on system installed certificates.
