### PR TITLE
Fix audio player time display

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/player_controls.js
+++ b/app/assets/javascripts/pageflow/widgets/player_controls.js
@@ -21,8 +21,9 @@ jQuery.widget('pageflow.playerControls', {
 
     player.on('timeupdate', function (position, duration) {
       var percent = duration > 0 ? (player.position / player.duration) * 100 : 0;
-      if(!isNaN(position)) {
-        if(durationDisplay.html().length === 5 && durationDisplay.html().charAt(0) === "0") {
+
+      if (!isNaN(position)) {
+        if (player.duration < 600) {
           $(currentTimeDisplay).html(player.formatTime(position).substr(1));
           $(durationDisplay).html(player.formatTime(duration).substr(1));
         }


### PR DESCRIPTION
fixes #17

Display short timestamps if duration is shorter than 10 minutes.
