### PR TITLE
Update jbuilder dependency to require ~> 1.5.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
       ejs
       friendly_id (~> 5.0)
       i18n-js
-      jbuilder (~> 1.2)
+      jbuilder (~> 1.5)
       jquery-fileupload-rails (~> 0.4.1)
       jquery-layout-rails (~> 0.1.0)
       jquery-rails (~> 3.0)

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -81,7 +81,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'friendly_id', '~> 5.0'
 
   # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-  s.add_dependency 'jbuilder', '~> 1.2'
+  s.add_dependency 'jbuilder', '~> 1.5'
 
   # Used by the dummy rails application
   s.add_development_dependency 'mysql2'


### PR DESCRIPTION
refs #75

jbuilder 1.2 behaves differently when providing locals to partials.
