### PR TITLE
Add config option #public_entry_url_options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   ([#78](https://github.com/codevise/pageflow/pull/78))
 - Bug fix: Update jbuilder gem dependency
   ([#79](https://github.com/codevise/pageflow/pull/79))
+- `public_entry_url_options` option to configure urls of published entries.
 
 ### Version 0.2.1
 

--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -25,7 +25,7 @@ module Pageflow
         end
         span(link_to(I18n.t("admin.entries.preview"), preview_admin_entry_path(entry), :class => 'preview button'))
         if entry.published?
-          span(link_to(I18n.t("admin.entries.show_public"), pageflow.entry_path(entry), :class => 'show_public button'))
+          span(link_to(I18n.t("admin.entries.show_public"), pretty_entry_url(entry), :class => 'show_public button'))
         end
       end
     end
@@ -89,6 +89,7 @@ module Pageflow
 
     controller do
       helper FoldersHelper
+      helper EntriesHelper
       helper Admin::RevisionsHelper
 
       def scoped_collection

--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -1,11 +1,14 @@
 module Pageflow
   module EntriesHelper
+    DEFAULT_PUBLIC_ENTRY_OPTIONS = lambda do |entry|
+      entry.theming.cname.present? ? {host: entry.theming.cname} : nil
+    end
+
     def pretty_entry_url(entry)
-      if entry.theming.cname.present?
-        short_entry_url(entry.to_model, :host => entry.theming.cname)
-      else
-        short_entry_url(entry.to_model)
-      end
+      options = Pageflow.config.public_entry_url_options
+      options = options.call(entry) if options.respond_to?(:call)
+
+      pageflow.short_entry_url(entry.to_model, options)
     end
 
     def entry_collection_for_parent(parent)

--- a/app/views/admin/entries/_attributes_table.html.arb
+++ b/app/views/admin/entries/_attributes_table.html.arb
@@ -19,6 +19,6 @@ attributes_table_for entry do
     end
   end
   row :url do
-    pageflow.short_entry_url(entry)
+    pretty_entry_url(entry)
   end
 end

--- a/app/views/admin/entries/_links.html.arb
+++ b/app/views/admin/entries/_links.html.arb
@@ -4,6 +4,6 @@ para do
   end
   span(link_to(I18n.t("admin.entries.preview"), preview_admin_entry_path(entry), :class => 'preview button'))
   if entry.published?
-    span(link_to(I18n.t("admin.entries.show_public"), pageflow.short_entry_path(entry), :class => 'show_public button'))
+    span(link_to(I18n.t("admin.entries.show_public"), pretty_entry_url(entry), :class => 'show_public button'))
   end
 end

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -76,6 +76,9 @@ module Pageflow
     # Used by all public actions that display entires to restrict the
     # available entries by hostname or other request attributes.
     #
+    # Use {#public_entry_url_options} to make sure urls of published
+    # entries conform twith the restrictions.
+    #
     # Example:
     #
     #     # Only make entries of one account available under <account.name>.example.com
@@ -83,6 +86,20 @@ module Pageflow
     #       entries.includes(:account).where(pageflow_accounts: {name: request.subdomain})
     #     end
     attr_accessor :public_entry_request_scope
+
+    # Either a lambda or an object with a `call` method taking an
+    # {Entry} as paramater and returing a hash of options used to
+    # construct the url of a published entry.
+    #
+    # Can be used to change the host of the url under which entries
+    # are available.
+    #
+    # Example:
+    #
+    #     config.public_entry_url_options = lambda do |entry|
+    #       {host: "#{entry.account.name}.example.com"}
+    #     end
+    attr_accessor :public_entry_url_options
 
     # Submit video/audio encoding jobs only after the user has
     # explicitly confirmed in the editor. Defaults to false.
@@ -101,6 +118,7 @@ module Pageflow
       @themes = Themes.new
 
       @public_entry_request_scope = lambda { |entries, request| entries }
+      @public_entry_url_options = Pageflow::EntriesHelper::DEFAULT_PUBLIC_ENTRY_OPTIONS
 
       @confirm_encoding_jobs = false
     end

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -5,6 +5,41 @@ ActionView::TestCase::TestController.send(:include, Pageflow::Engine.routes.url_
 
 module Pageflow
   describe EntriesHelper do
+    describe '#pretty_entry_url' do
+      it 'uses default host' do
+        theming = create(:theming, cname: '')
+        entry = PublishedEntry.new(create(:entry, title: 'test', theming: theming),
+                                   create(:revision))
+
+        expect(helper.pretty_entry_url(entry)).to eq('http://test.host/test')
+      end
+
+      it 'uses theming cname if present' do
+        theming = create(:theming, cname: 'my.example.com')
+        entry = PublishedEntry.new(create(:entry, title: 'test', theming: theming),
+                                   create(:revision))
+
+        expect(helper.pretty_entry_url(entry)).to eq('http://my.example.com/test')
+      end
+
+      it 'can be configured via hash in public_entry_url_options' do
+        Pageflow.config.public_entry_url_options = {host: 'public.example.com'}
+        entry = PublishedEntry.new(create(:entry, title: 'test'),
+                                   create(:revision))
+
+        expect(helper.pretty_entry_url(entry)).to eq('http://public.example.com/test')
+      end
+
+      it 'can be configured via lambda in public_entry_url_options' do
+        Pageflow.config.public_entry_url_options = lambda { |entry| {host: "#{entry.account.name}.example.com" } }
+        account = create(:account, name: 'myaccount')
+        entry = PublishedEntry.new(create(:entry, title: 'test', account: account),
+                                   create(:revision))
+
+        expect(helper.pretty_entry_url(entry)).to eq('http://myaccount.example.com/test')
+      end
+    end
+
     describe '#entry_stylesheet_link_tag' do
       it 'returns revision css for published entry with custom revision' do
         revision = build_stubbed(:revision)


### PR DESCRIPTION
Allow to use custom host names for published entries.
