### PR TITLE
Add Cache Key Param to Entry CSS Link

### DIFF
--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -32,7 +32,7 @@ module Pageflow
     end
 
     def entry_stylesheet_link_tag(entry)
-      stylesheet_link_tag(polymorphic_path(entry.stylesheet_model, :format => 'css'), :media => 'all')
+      stylesheet_link_tag(polymorphic_path(entry.stylesheet_model, v: entry.stylesheet_cache_key, format: 'css'), media: 'all')
     end
 
     def entry_mobile_navigation_pages(entry)

--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -63,7 +63,11 @@ module Pageflow
     end
 
     def stylesheet_model
-      @draft
+      draft
+    end
+
+    def stylesheet_cache_key
+      draft.cache_key
     end
 
     private

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -22,6 +22,10 @@ module Pageflow
       custom_revision? ? revision : entry
     end
 
+    def stylesheet_cache_key
+      revision.cache_key
+    end
+
     def thumbnail
       pages.first.try(:thumbnail) || ImageFile.new.processed_attachment
     end

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -49,9 +49,31 @@ module Pageflow
       end
 
       it 'returns entry css for published entry without custom revision' do
-        entry = PublishedEntry.new(build_stubbed(:entry))
+        revision = build_stubbed(:revision, :published)
+        entry = PublishedEntry.new(build_stubbed(:entry, published_revision: revision))
 
         expect(helper.entry_stylesheet_link_tag(entry)).to include(%Q'href="/entries/#{entry.entry.id}.css')
+      end
+
+      it 'appends revision cache key for published entry without custom revision' do
+        revision = build_stubbed(:revision, :published)
+        entry = PublishedEntry.new(build_stubbed(:entry, published_revision: revision))
+
+        expect(helper.entry_stylesheet_link_tag(entry)).to include(%Q'href="/entries/#{entry.entry.id}.css?v=#{ERB::Util.url_encode(revision.cache_key)}')
+      end
+
+      it 'appends revision cache key for published entry with custom revision' do
+        revision = build_stubbed(:revision, :published)
+        entry = PublishedEntry.new(build_stubbed(:entry), revision)
+
+        expect(helper.entry_stylesheet_link_tag(entry)).to include(%Q'href="/revisions/#{revision.id}.css?v=#{ERB::Util.url_encode(revision.cache_key)}')
+      end
+
+      it 'appends revision cache key for draft entry' do
+        revision = build_stubbed(:revision)
+        entry = DraftEntry.new(build_stubbed(:entry, draft: revision))
+
+        expect(helper.entry_stylesheet_link_tag(entry)).to include(%Q'href="/revisions/#{revision.id}.css?v=#{ERB::Util.url_encode(revision.cache_key)}')
       end
     end
   end


### PR DESCRIPTION
Make sure the URL of the entry stylesheet changes on publication so
static assets can be cached by a CDN.
