### PR TITLE
pass theming to public_entry_url_options

### DIFF
--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -1,14 +1,7 @@
 module Pageflow
   module EntriesHelper
-    DEFAULT_PUBLIC_ENTRY_OPTIONS = lambda do |entry|
-      entry.theming.cname.present? ? {host: entry.theming.cname} : nil
-    end
-
     def pretty_entry_url(entry)
-      options = Pageflow.config.public_entry_url_options
-      options = options.call(entry) if options.respond_to?(:call)
-
-      pageflow.short_entry_url(entry.to_model, options)
+      pageflow.short_entry_url(entry.to_model, Pageflow.config.theming_url_options(entry.theming))
     end
 
     def entry_collection_for_parent(parent)

--- a/app/helpers/pageflow/themings_helper.rb
+++ b/app/helpers/pageflow/themings_helper.rb
@@ -1,0 +1,11 @@
+module Pageflow
+  module ThemingsHelper
+    DEFAULT_PUBLIC_ENTRY_OPTIONS = lambda do |theming|
+      theming.cname.present? ? {host: theming.cname} : nil
+    end
+
+    def pretty_theming_url(theming)
+      public_root_url(Pageflow.config.theming_url_options(theming))
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Pageflow::Engine.routes.draw do
 
   resources :entries, :only => [:show]
   get ':id', :to => 'entries#show', :as => :short_entry
+  get '/', :to => 'entries#index', :as => :public_root
 
   get ':id/pages/:page_index', :to => 'entries#page'
 end

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -87,8 +87,8 @@ module Pageflow
     #     end
     attr_accessor :public_entry_request_scope
 
-    # Either a lambda or an object with a `call` method taking an
-    # {Entry} as paramater and returing a hash of options used to
+    # Either a lambda or an object with a `call` method taking a
+    # {Theming} as paramater and returing a hash of options used to
     # construct the url of a published entry.
     #
     # Can be used to change the host of the url under which entries
@@ -96,8 +96,8 @@ module Pageflow
     #
     # Example:
     #
-    #     config.public_entry_url_options = lambda do |entry|
-    #       {host: "#{entry.account.name}.example.com"}
+    #     config.public_entry_url_options = lambda do |theming|
+    #       {host: "#{theming.account.name}.example.com"}
     #     end
     attr_accessor :public_entry_url_options
 
@@ -118,7 +118,7 @@ module Pageflow
       @themes = Themes.new
 
       @public_entry_request_scope = lambda { |entries, request| entries }
-      @public_entry_url_options = Pageflow::EntriesHelper::DEFAULT_PUBLIC_ENTRY_OPTIONS
+      @public_entry_url_options = Pageflow::ThemingsHelper::DEFAULT_PUBLIC_ENTRY_OPTIONS
 
       @confirm_encoding_jobs = false
     end
@@ -145,6 +145,12 @@ module Pageflow
 
     def revision_components
       page_types.map(&:revision_components).flatten.uniq
+    end
+
+    # @api private
+    def theming_url_options(theming)
+      options = public_entry_url_options
+      options.respond_to?(:call) ? options.call(theming) : options
     end
   end
 end

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -31,7 +31,7 @@ module Pageflow
       end
 
       it 'can be configured via lambda in public_entry_url_options' do
-        Pageflow.config.public_entry_url_options = lambda { |entry| {host: "#{entry.account.name}.example.com" } }
+        Pageflow.config.public_entry_url_options = lambda { |theming| {host: "#{theming.account.name}.example.com" } }
         account = create(:account, name: 'myaccount')
         entry = PublishedEntry.new(create(:entry, title: 'test', account: account),
                                    create(:revision))

--- a/spec/helpers/pageflow/themings_helper_spec.rb
+++ b/spec/helpers/pageflow/themings_helper_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+# TODO
+ActionView::TestCase::TestController.send(:include, Pageflow::Engine.routes.url_helpers)
+
+module Pageflow
+  describe ThemingsHelper do
+    describe '#pretty_theming_url' do
+      it 'uses default host' do
+        theming = create(:theming, cname: '')
+
+        expect(helper.pretty_theming_url(theming)).to eq('http://test.host/')
+      end
+
+      it 'uses theming cname if present' do
+        theming = create(:theming, cname: 'my.example.com')
+
+        expect(helper.pretty_theming_url(theming)).to eq('http://my.example.com/')
+      end
+
+      it 'can be configured via hash in public_entry_url_options' do
+        Pageflow.config.public_entry_url_options = {host: 'public.example.com'}
+        theming = create(:theming, cname: 'my.example.com')
+
+        expect(helper.pretty_theming_url(theming)).to eq('http://public.example.com/')
+      end
+
+      it 'can be configured via lambda in public_entry_url_options' do
+        Pageflow.config.public_entry_url_options = lambda { |theming| {host: "#{theming.account.name}.example.com" } }
+        account = create(:account, name: 'myaccount')
+
+        expect(helper.pretty_theming_url(account.default_theming)).to eq('http://myaccount.example.com/')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of entry. Allows reuse when generating pretty urls for theming.
