### PR TITLE
Fix Configuration Duplication on Page Creation

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/page.js
+++ b/app/assets/javascripts/pageflow/editor/models/page.js
@@ -3,11 +3,13 @@ pageflow.Page = Backbone.Model.extend({
   paramRoot: 'page',
   i18nKey: 'pageflow/page',
 
-  defaults: {
-    template: 'background_image',
-    configuration: {},
-    active: false,
-    perma_id: ''
+  defaults: function() {
+    return {
+      template: 'background_image',
+      configuration: {},
+      active: false,
+      perma_id: ''
+    };
   },
 
   mixins: [pageflow.failureTracking, pageflow.delayedDestroying],


### PR DESCRIPTION
Turn `pageflow.Page#defaults` into a function. Otherwise new pages share
the same object as their `configuration` attribute causing modification
of the default page configuration when page is edited.
