### PR TITLE
Ensure Top Margin in Additional Info box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Improved generation of of credits box.
 - Bug fix: Respond with 404 for unknown format.
 - Bug fix: Decrease margin of links in text in default theme.
+- Bug fix: Ensure top margin in additional info box even if no title
+  is present.
 
 ##### Admin/Editor
 

--- a/app/assets/stylesheets/pageflow/player_controls.css.scss
+++ b/app/assets/stylesheets/pageflow/player_controls.css.scss
@@ -6,14 +6,10 @@
   font-size: 0.8em;
   color: white;
 
+  h3,
   p {
-    margin: 0 3% 15px 3%;
-    width: 94%;
-  }
-
-  h3 {
     margin: 15px 3%;
-    width: 100%;
+    width: 94%;
   }
 
   &.empty {


### PR DESCRIPTION
When no title is present the paragraph used to have zero margin top.
