### PR TITLE
Blank Slate for Editor Entry Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   ([#107](https://github.com/codevise/pageflow/pull/107))
 - Improve encoding confirmation in editor.
   ([#113](https://github.com/codevise/pageflow/pull/113))
+- Blank slate for editor.
+  ([#110](https://github.com/codevise/pageflow/pull/110))
 - Bug fix: Editing a newly created page altered the default attribute
   values of subsequently created pages.
   ([#103](https://github.com/codevise/pageflow/pull/103))

--- a/app/assets/javascripts/pageflow/editor/templates/blank_entry.jst.ejs
+++ b/app/assets/javascripts/pageflow/editor/templates/blank_entry.jst.ejs
@@ -1,0 +1,8 @@
+<h2><%= I18n.t('editor.blank_entry.header') %></h2>
+<p><%= I18n.t('editor.blank_entry.intro') %></p>
+<ol>
+  <li><%= I18n.t('editor.blank_entry.create_chapter') %></li>
+  <li><%= I18n.t('editor.blank_entry.create_page') %></li>
+  <li><%= I18n.t('editor.blank_entry.edit_page') %></li>
+</ol>
+<p><%= I18n.t('editor.blank_entry.outro') %></p>

--- a/app/assets/javascripts/pageflow/editor/views/blank_entry_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/blank_entry_view.js
@@ -1,0 +1,4 @@
+pageflow.BlankEntryView = Backbone.Marionette.ItemView.extend({
+  template: 'templates/blank_entry',
+  className: 'blank_entry'
+});

--- a/app/assets/javascripts/pageflow/editor/views/entry_preview_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/entry_preview_view.js
@@ -14,7 +14,8 @@ pageflow.EntryPreviewView = Backbone.Marionette.ItemView.extend({
     this.pageViews = this.subview(new pageflow.CollectionView({
       el: this.ui.entry,
       collection: this.model.pages,
-      itemViewConstructor: pageflow.PagePreviewView
+      itemViewConstructor: pageflow.PagePreviewView,
+      blankSlateViewConstructor: pageflow.BlankEntryView
     }));
 
     this.ui.entry.append($('<div class="scroll_indicator indicator">Scrollen, um weiterzulesen</div>'));

--- a/app/assets/stylesheets/pageflow/editor/base.css.scss
+++ b/app/assets/stylesheets/pageflow/editor/base.css.scss
@@ -3,6 +3,7 @@
 @import "pageflow/animations";
 
 @import 'pageflow/jquery_ui';
+@import "./blank_entry";
 @import "./dialogs";
 @import "./colors";
 @import "./embedded";

--- a/app/assets/stylesheets/pageflow/editor/blank_entry.css.scss
+++ b/app/assets/stylesheets/pageflow/editor/blank_entry.css.scss
@@ -1,0 +1,46 @@
+.blank_entry {
+  margin: 0 auto;
+  top: 5%;
+  position: relative;
+  font-family: "SourceSansPro";
+  font-size: 17px;
+  letter-spacing: 0.01em;
+  text-align: center;
+  width: 50%;
+  color: #333;
+
+  h2 {
+    font-size: 30px;
+    font-weight: normal;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: #999;
+
+    &:before {
+      content: "";
+      display: block;
+      margin: 0 auto 30px auto;
+      width: 61px;
+      height: 60px;
+      background-image: image-url('pageflow/themes/default/logo_header.png');
+      opacity: 0.3;
+    }
+  }
+
+  em {
+    font-weight: bold;
+    font-style: normal;
+  }
+
+  ol {
+    display: inline-block;
+    text-align: left;
+    padding: 20px 50px;
+    border-bottom: solid 1px #aaa;
+    border-top: solid 1px #aaa;
+  }
+
+  li {
+    padding: 15px 0;
+  }
+}

--- a/config/locales/editor/blank_entry.yml
+++ b/config/locales/editor/blank_entry.yml
@@ -1,0 +1,9 @@
+de:
+  editor:
+    blank_entry:
+      header: "Dies ist ein leerer Pageflow"
+      intro: "Pageflows bestehen aus Kapiteln und Seiten. In der Seitenleiste rechts findest Du die Gliederung."
+      create_chapter: "Klicke jetzt auf <em>Neues Kapitel</em>, um ein erstes Kapitel zu erstellen."
+      create_page: "Klicke dann auf <em>Neue Seite</em>, um dem Kapitel eine erste Seite hinzuzufügen."
+      edit_page: "Klicke auf eine Seite, um ihren Inhalt zu bearbeiten."
+      outro: "Hier siehst Du dann eine Vorschau deines Pageflows."


### PR DESCRIPTION
Display a blank slate with some instructions instead of a white void
when viewing an empty entry in the editor.
