### PR TITLE
Do not Display Blue Links in Additional Info Box

### DIFF
--- a/app/assets/stylesheets/pageflow/player_controls.css.scss
+++ b/app/assets/stylesheets/pageflow/player_controls.css.scss
@@ -12,6 +12,10 @@
     width: 94%;
   }
 
+  a {
+    color: white;
+  }
+
   &.empty {
     display: none;
   }


### PR DESCRIPTION
Links need to be styled as color white explicitly.
