### PR TITLE
Resolve Ready Promise after Timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   ([#116](https://github.com/codevise/pageflow/pull/116))
 - Bug fix: Correct color of links in additional info box.
   ([#117](https://github.com/codevise/pageflow/pull/117))
+- Bug fix: iOS 8 window.onload bug workaround.
 
 ### Version 0.4.0
 

--- a/app/assets/javascripts/pageflow/ready.js
+++ b/app/assets/javascripts/pageflow/ready.js
@@ -1,5 +1,5 @@
 pageflow.ready = new $.Deferred(function(readyDeferred) {
-  window.onload = function() {
+  onLoadWithTimeout(function() {
     pageflow.features.detect().then(function() {
       $('body').one('pagepreloaded', function() {
         readyDeferred.resolve();
@@ -44,5 +44,24 @@ pageflow.ready = new $.Deferred(function(readyDeferred) {
         return false; }
       );
     });
-  };
+  });
+
+  function onLoadWithTimeout(callback) {
+    var invoked = false;
+    var invokeOnce = function() {
+      clearTimeout(timeout);
+
+      if (!invoked) {
+        callback();
+        invoked = true;
+      }
+    };
+
+    var iOS8 = navigator.userAgent.match(/(iPad|iPhone|iPod).*OS 8_\d/i);
+
+    // iOS 8 fails to trigger window.onload when audio tags are present
+    // on the page. Make sure we do not get stuck at the loading spinner.
+    var timeout = setTimeout(invokeOnce, iOS8 ? 3000 : 10000);
+    window.onload = invokeOnce;
+  }
 }).promise();


### PR DESCRIPTION
iOS 8 sometimes fails to trigger `window.onload` (see #118). Add
timeout to eventually start app regradless of `onload`. Use shorter
timeout on iOS 8.
