### PR TITLE
add mobile poster image feature for video and background_video pages

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/configuration_editors/background_video.js
+++ b/app/assets/javascripts/pageflow/editor/views/configuration_editors/background_video.js
@@ -14,6 +14,10 @@ pageflow.ConfigurationEditorView.register('background_video', {
         collection: pageflow.imageFiles,
         imagePositioning: false
       });
+      this.input('mobile_poster_image_id', pageflow.FileInputView, {
+        collection: pageflow.imageFiles,
+        imagePositioning: false
+      });
     });
 
     this.tab('options', function() {

--- a/app/assets/javascripts/pageflow/editor/views/configuration_editors/video.js
+++ b/app/assets/javascripts/pageflow/editor/views/configuration_editors/video.js
@@ -17,6 +17,10 @@ pageflow.ConfigurationEditorView.register('video', {
         collection: pageflow.imageFiles,
         imagePositioning: false
       });
+      this.input('mobile_poster_image_id', pageflow.FileInputView, {
+        collection: pageflow.imageFiles,
+        imagePositioning: false
+      });
     });
 
     this.tab('options', function() {

--- a/app/assets/javascripts/pageflow/page_types/mixins/video_helpers.js
+++ b/app/assets/javascripts/pageflow/page_types/mixins/video_helpers.js
@@ -1,20 +1,4 @@
 pageflow.videoHelpers = {
-  updateVideoTagForHighBandwidth: function(video) {
-    if (pageflow.features.has('high bandwidth') && !pageflow.features.has('mobile platform')) {
-      video.attr('poster', video.attr('data-large-poster'));
-
-      if (pageflow.features.has('rewrite video sources support')) {
-        video.find('source').each(function() {
-          var source = $(this);
-          source.attr('src', source.attr('data-high-src'));
-        });
-      }
-    }
-    else {
-      video.attr('poster', video.attr('data-poster'));
-    }
-  },
-
   updateVideoPoster: function(pageElement, imageUrl) {
     pageElement.find('.vjs-poster').css('background-image', 'url(' + imageUrl + ')');
   }

--- a/app/assets/javascripts/pageflow/video_player/lazy.js
+++ b/app/assets/javascripts/pageflow/video_player/lazy.js
@@ -109,7 +109,10 @@ pageflow.VideoPlayer.Lazy = function(template, options) {
 
     var element = $(htmlWithPreload);
 
-    if (pageflow.features.has('high bandwidth') && !pageflow.features.has('mobile platform')) {
+    if (pageflow.features.has('mobile platform') && element.attr('data-mobile-poster')) {
+      element.attr('poster', element.attr('data-mobile-poster'));
+    }
+    else if (pageflow.features.has('high bandwidth') && !pageflow.features.has('mobile platform')) {
       element.attr('poster', element.attr('data-large-poster'));
 
       element.find('source').each(function() {

--- a/app/helpers/pageflow/pages_helper.rb
+++ b/app/helpers/pageflow/pages_helper.rb
@@ -13,12 +13,20 @@ module Pageflow
       content_tag(:div, '', :class => 'shadow', :style => style)
     end
 
-    def poster_image_div(video_id, poster_image_id)
-      if poster_image_id.present?
-        content_tag(:div, '', :class => "background background_image image_#{poster_image_id}")
+    def mobile_poster_image_div(options = {})
+      classes = ['background', 'background_image']
+
+      if options[:mobile_poster_image_id]
+        classes << "image_#{options[:mobile_poster_image_id]}"
+      elsif options[:poster_image_id]
+        classes << "image_#{options[:poster_image_id]}"
+      elsif options[:video_file_id]
+        classes << "video_poster_#{options[:video_file_id]}"
       else
-        content_tag(:div, '', :class => "background background_image video_poster_#{video_id || 'none'}")
+        classes << 'video_poster_none'
       end
+
+      content_tag(:div, '', :class => classes.join(' '))
     end
 
     def poster_image_tag(video_id, poster_image_id, options = {})
@@ -46,9 +54,15 @@ module Pageflow
 
       video_file = VideoFile.find_by_id(video_id)
       poster = ImageFile.find_by_id(poster_image_id)
+      mobile_poster = ImageFile.find_by_id(options.delete(:mobile_poster_image_id))
 
       options[:data] = {}
       script_tag_data = {:template => 'video'}
+
+      if mobile_poster
+        options[:data][:mobile_poster] = mobile_poster.attachment.url(:medium)
+        options[:data][:mobile_large_poster] = mobile_poster.attachment.url(:large)
+      end
 
       if poster
         options[:data][:poster] = poster.attachment.url(:medium)
@@ -58,7 +72,7 @@ module Pageflow
         options[:data][:large_poster] = video_file.poster.url(:large)
       end
 
-      if (video_file && video_file.width.present? && video_file.height.present?)
+      if video_file && video_file.width.present? && video_file.height.present?
         script_tag_data[:video_width] = options[:data][:width] = video_file.width
         script_tag_data[:video_height] = options[:data][:height] = video_file.height
       end

--- a/app/views/pageflow/pages/templates/_background_video.html.erb
+++ b/app/views/pageflow/pages/templates/_background_video.html.erb
@@ -1,7 +1,9 @@
 <div class="blackLayer"></div>
 <div class="content_and_background backgroundVideo">
   <div class="backgroundArea">
-    <%= poster_image_div(configuration['video_file_id'], configuration['poster_image_id']) %>
+    <%= mobile_poster_image_div({:video_file_id => configuration['video_file_id'],
+                                 :poster_image_id => configuration['poster_image_id'],
+                                 :mobile_poster_image_id => configuration['mobile_poster_image_id']}) %>
     <span class="hint">Video Loop</span>
     <%= lookup_video_tag(configuration['video_file_id'],
         configuration['poster_image_id'], :class => 'background', :loop => true, :unique_id => page.id, :preload => page.is_first) %>
@@ -16,7 +18,7 @@
             <span class="title"><%= configuration['title'] %></span>
             <span class="subtitle"><%= configuration['subtitle'] %></span>
           </h2>
-          <%= poster_image_tag(configuration['video_file_id'], configuration['poster_image_id'], {"class" => "print_image"}) %>
+          <%= poster_image_tag(configuration['video_file_id'], configuration['poster_image_id'], {:class => "print_image"}) %>
         </div>
         <div class="contentText">
           <p><%= raw configuration['text'] %></p>

--- a/app/views/pageflow/pages/templates/_video.html.erb
+++ b/app/views/pageflow/pages/templates/_video.html.erb
@@ -1,4 +1,3 @@
-
 <div class="blackLayer"></div>
 <div class="content_and_background videoPage">
   <div class="page_header">
@@ -7,11 +6,13 @@
       <span class="title"><%= configuration['title'] %></span>
       <span class="subtitle"><%= configuration['subtitle'] %></span>
     </h2>
-    <%= poster_image_tag(configuration['video_file_id'], configuration['poster_image_id'], {"class" => "print_image"}) %>
+    <%= poster_image_tag(configuration['video_file_id'], configuration['poster_image_id'], {:class => "print_image"}) %>
   </div>
   <div class="backgroundArea">
     <div class="videoWrapper">
-      <%= lookup_video_tag(configuration['video_file_id'], configuration['poster_image_id'], :unique_id => page.id, :preload => page.is_first) %>
+      <%= lookup_video_tag(configuration['video_file_id'], configuration['poster_image_id'],
+                           :mobile_poster_image_id => configuration['mobile_poster_image_id'],
+                           :unique_id => page.id, :preload => page.is_first) %>
     </div>
     <%= shadow_div :opacity => configuration['gradient_opacity'] %>
   </div>

--- a/config/locales/activerecord.de.yml
+++ b/config/locales/activerecord.de.yml
@@ -134,6 +134,7 @@ de:
         video_file_id: "Video"
         audio_file_id: "Audio"
         poster_image_id: "Posterbild"
+        mobile_poster_image_id: "Posterbild (mobil)"
         linked_page_ids: "Seiten verknüpfen"
         linked_pages_layout: "Hervorgehobenes Element"
         hide_title: "Titel ausblenden"

--- a/config/locales/editor.de.yml
+++ b/config/locales/editor.de.yml
@@ -50,6 +50,7 @@ de:
         additional_title: "Die Infobox wird über den Steuerelementen zum Starten und Stoppen der Wiedegabe angezeigt."
         text: "Empfohlene Textlänge: 220 Zeichen"
         thumbnail_image_id: "Dieses Bild wird in der Navigationsleiste und anderen Verweisen auf die Seite gezeigt."
+        mobile_poster_image_id: "Dieses Bild wird in der Mobilvariante der Seite als Posterbild gezeigt."
       "pageflow/entry":
         title: "Vom Browser angezeigter Titel der Seite."
         summary: "Zusammenfassung die an Soziale Netzwerke weitergeben wird."


### PR DESCRIPTION
Extend editor for "video" and "background video" page types to add another poster image to be shown on mobile platforms.
