### PR TITLE
Improve Facebook Open Graph Meta Tags

### DIFF
--- a/app/views/pageflow/entries/_social_meta_tags.html.erb
+++ b/app/views/pageflow/entries/_social_meta_tags.html.erb
@@ -1,9 +1,9 @@
 <%= tag :link, :rel => "canonical", :href => pretty_entry_url(entry) %>
 
-<%= tag :meta, :property => "og:image:url", :content => entry.thumbnail_url(:medium).gsub('https://', 'http://') %>
+<%= tag :meta, :property => "og:image", :content => entry.thumbnail_url(:medium).gsub('https://', 'http://') %>
 
 <%= tag :meta, :property => "og:title", :content => "#{entry.title} - #{entry.theming.cname_domain}" %>
 <%= tag :meta, :property => "og:description", :name => "description", :content => entry_summary(entry) %>
 <%= tag :meta, :property => "og:url", :content => pretty_entry_url(entry) %>
 <%= tag :meta, :property => "og:site_name", :content => entry.theming.cname_domain %>
-<%= tag :meta, :property => "og:type", :content => "article" %>
+<%= tag :meta, :property => "og:type", :content => "website" %>


### PR DESCRIPTION
- Use `og:image` instead of `og:image:url`
- Change `og:type` to `"website"`
