### PR TITLE
Rails 4.1 Compatibility

### DIFF
--- a/app/helpers/pageflow/page_types_helper.rb
+++ b/app/helpers/pageflow/page_types_helper.rb
@@ -7,13 +7,13 @@ module Pageflow
     end
 
     def page_type_templates
-      Pageflow.config.page_types.map do |page_type|
-        content_tag(:script, :type => 'text/html', :data => {:template => "#{page_type.name}_page"}) do
-          render_to_string(:template => page_type.template_path,
-                           :locals => {:configuration => {}, :page => Page.new},
-                           :layout => false)
-        end
-      end.join(' ').html_safe
+      safe_join(Pageflow.config.page_types.map do |page_type|
+        content_tag(:script,
+                    render_to_string(:template => page_type.template_path,
+                                     :locals => {:configuration => {}, :page => Page.new},
+                                     :layout => false).to_str,
+                    :type => 'text/html', :data => {:template => "#{page_type.name}_page"})
+      end)
     end
   end
 end

--- a/app/views/pageflow/entries/navigation/_page.html.erb
+++ b/app/views/pageflow/entries/navigation/_page.html.erb
@@ -5,6 +5,6 @@
   <div class="navigation_site_detail">
     <%= page.title %>
 
-    <%= image_tag("pageflow/#{page.template}_pictogram.png", :style => "background-image: url('#{page.thumbnail_url(:navigation_thumbnail_large)}')") %>
+    <%= image_tag("pageflow/#{page.template}_pictogram.png", :style => "background-image: url('#{asset_path(page.thumbnail_url(:navigation_thumbnail_large))}')") %>
   </div>
 </li>

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -107,7 +107,7 @@ Paperclip.interpolates(:class_basename) do |attachment, style|
 end
 
 Paperclip.interpolates(:pageflow_placeholder) do |attachment, style|
-  ActionController::Base.helpers.asset_path("pageflow/placeholder_#{style}.jpg")
+  "pageflow/placeholder_#{style}.jpg"
 end
 
 Paperclip.interpolates(:pageflow_attachments_version) do |attachment, style|


### PR DESCRIPTION
- Use `safe_join` to concat page tempalte strings
- Change placeholder interpolation to return unresolved asset path.
