### PR TITLE
Remove window onload timeout

### DIFF
--- a/app/assets/javascripts/pageflow/ready.js
+++ b/app/assets/javascripts/pageflow/ready.js
@@ -1,5 +1,5 @@
 pageflow.ready = new $.Deferred(function(readyDeferred) {
-  onLoadWithTimeout(function() {
+  window.onload = function() {
     pageflow.features.detect().then(function() {
       $('body').one('pagepreloaded', function() {
         readyDeferred.resolve();
@@ -44,20 +44,5 @@ pageflow.ready = new $.Deferred(function(readyDeferred) {
         return false; }
       );
     });
-  });
-
-  function onLoadWithTimeout(callback) {
-    var invoked = false;
-    var invokeOnce = function() {
-      clearTimeout(timeout);
-
-      if (!invoked) {
-        callback();
-        invoked = true;
-      }
-    };
-
-    var timeout = setTimeout(invokeOnce, 10000);
-    window.onload = invokeOnce;
-  }
+  };
 }).promise();


### PR DESCRIPTION
Pull request #119 introduced a timeout which resolves the ready
promise if window.onload is not fired after 10 seconds, to solve #118
in Safari.  This change introduced a new problem though: When the dom
ready event takes longer than 10 seconds we start while some of the
widgets are not yet defined. This happens mostly in
development. Still, since #131 solved the onload issue in Safari, we
revert the timeout hack.
