### PR TITLE
Start at Bottom or Page when Scrolling Back

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow.js
+++ b/app/assets/javascripts/pageflow/slideshow.js
@@ -42,7 +42,7 @@ pageflow.Slideshow = function($el, configurations) {
   };
 
   this.back = function() {
-    this.goTo(currentPage.prev('.page'));
+    this.goTo(currentPage.prev('.page'), {position: 'bottom'});
   };
 
   this.next = function() {
@@ -59,7 +59,9 @@ pageflow.Slideshow = function($el, configurations) {
     }
   };
 
-  this.goTo = function(page) {
+  this.goTo = function(page, options) {
+    options = options || {};
+
     if (page.length && !page.is(currentPage)) {
       transitionMutex(function() {
         var previousPage = currentPage;
@@ -69,7 +71,7 @@ pageflow.Slideshow = function($el, configurations) {
         var direction = currentPageIndex > previousPage.index() ? 'forwards' : 'backwards';
 
         previousPage.page('deactivate', {direction: direction});
-        currentPage.page('activate', {direction: direction});
+        currentPage.page('activate', {direction: direction, position: options.position});
 
         preload.start(currentPage);
         $el.trigger('slideshowchangepage');

--- a/app/assets/javascripts/pageflow/slideshow/page_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/page_widget.js
@@ -73,6 +73,8 @@
     },
 
     activate: function(options) {
+      options = options || {};
+
       this.element
         .removeClass('animate-out-forwards animate-out-backwards')
         .addClass('animate-in-' + options.direction);
@@ -88,7 +90,7 @@
         this._triggerDelayedPageTypeHook('activated');
       }, this), 1100);
 
-      this.content.scroller('enable');
+      this.content.scroller('enable', {position: options.position});
       this._trigger('activate', null, {page: this});
       this._triggerPageTypeHook('activating');
 

--- a/app/assets/javascripts/pageflow/slideshow/scroller_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/scroller_widget.js
@@ -31,10 +31,18 @@
       this._initMoveEvents();
     },
 
-    enable: function() {
+    enable: function(options) {
+      options = options || {};
+
       this.iscroll.enable();
       this.iscroll.refresh();
-      this.iscroll.scrollTo(0, 0, 0);
+
+      if (options.position === 'bottom') {
+        this.iscroll.scrollTo(0, this.iscroll.maxScrollY, 0);
+      }
+      else {
+        this.iscroll.scrollTo(0, 0, 0);
+      }
     },
 
     refresh: function() {


### PR DESCRIPTION
When returning to a page by scrolling up, make sure we end up at the
bottom of the page. This is more intuitive than starting at the top of
the page if pages are longer.
