### PR TITLE
Allow Inverting Scrolling Indicator on Page Basis

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/scroll_indicator_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/scroll_indicator_widget.js
@@ -5,7 +5,14 @@
           that = this;
 
       parent.on('pageactivate', function(event) {
-        that.element.toggleClass('invert', $(event.target).hasClass('invert'));
+        var page = $(event.target);
+        var invertIndicator = page.data('invertIndicator');
+
+        if (typeof invertIndicator === 'undefined') {
+          invertIndicator = page.hasClass('invert');
+        }
+
+        that.element.toggleClass('invert', invertIndicator);
       });
 
       parent.on('scrollerhintdown', function() {


### PR DESCRIPTION
Allow page types to set an `invertIndicator` attribute on the page
element to control whether the scrolling indicator should be
inverted. Determined by presence of `invert` css class on page element
by default.
