### PR TITLE
Add hidden_by_overlay CSS Class

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/overview.js
+++ b/app/assets/javascripts/pageflow/widgets/overview.js
@@ -23,7 +23,7 @@ jQuery(function($) {
           .toggleClass('active', state)
           .updateTitle();
 
-        $('.page .content').toggleClass('hidden', state);
+        $('section.page').toggleClass('hidden_by_overlay', state);
         scrollIndicator.toggleClass('hidden', state);
       };
 

--- a/app/assets/stylesheets/pageflow/slideshow.css.scss
+++ b/app/assets/stylesheets/pageflow/slideshow.css.scss
@@ -65,7 +65,7 @@
     @include transition(0.5s ease);
   }
 
-  .content.hidden {
+  .page.hidden_by_overlay .content {
     opacity: 0;
     pointer-events: 0;
   }


### PR DESCRIPTION
- Hide page contents while overview is visible.
- Fix naming conflict with `hidden` class used to
  move elements off screen for accessibility.
- Set class on `section.page` not on `.content` to
  allow hiding text outside of content.
