### PR TITLE
Enable Scroller only after Page Transition has Finished

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/page_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/page_widget.js
@@ -24,6 +24,7 @@
     reactivate: function() {
       if (this.element.hasClass('active')) {
         this.content.scroller('enable');
+        this.content.scroller('resetPosition');
         this.content.scroller('afterAnimationHook');
 
         this._triggerPageTypeHook('activating');
@@ -43,6 +44,7 @@
       this.element.addClass('active');
 
       this.content.scroller('enable');
+      this.content.scroller('resetPosition');
       this.content.scroller('afterAnimationHook');
 
       this._trigger('activate', null, {page: this});
@@ -84,13 +86,14 @@
       }, this), 5);
 
       setTimeout(_.bind(function() {
+        this.content.scroller('enable');
         this.content.scroller('afterAnimationHook');
         this.element.removeClass('animate-in-forwards animate-in-backwards');
 
         this._triggerDelayedPageTypeHook('activated');
       }, this), 1100);
 
-      this.content.scroller('enable', {position: options.position});
+      this.content.scroller('resetPosition', {position: options.position});
       this._trigger('activate', null, {page: this});
       this._triggerPageTypeHook('activating');
 

--- a/app/assets/javascripts/pageflow/slideshow/scroller_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/scroller_widget.js
@@ -31,11 +31,13 @@
       this._initMoveEvents();
     },
 
-    enable: function(options) {
-      options = options || {};
-
+    enable: function() {
       this.iscroll.enable();
       this.iscroll.refresh();
+    },
+
+    resetPosition: function(options) {
+      options = options || {};
 
       if (options.position === 'bottom') {
         this.iscroll.scrollTo(0, this.iscroll.maxScrollY, 0);


### PR DESCRIPTION
Some page type do not animate in the scroller. So mouse wheel events
are triggered too early causing the text to already scroll even though
the page transition animation has not finished yet.
