### PR TITLE
iOS8 phone landscape fullscreen fix

### DIFF
--- a/app/assets/javascripts/pageflow/features/hashchange_support.js
+++ b/app/assets/javascripts/pageflow/features/hashchange_support.js
@@ -1,0 +1,8 @@
+pageflow.features.add('hashchange support', function() {
+  var iOS = parseFloat(
+  ('' + (/CPU.*OS ([0-9_]{1,5})|(CPU like).*AppleWebKit.*Mobile/i.exec(navigator.userAgent) || [0,''])[1])
+  .replace('undefined', '3_2').replace('_', '.').replace('_', '')
+) || false;
+
+  return !(iOS >=8);
+});

--- a/app/assets/javascripts/pageflow/history.js
+++ b/app/assets/javascripts/pageflow/history.js
@@ -1,6 +1,8 @@
 pageflow.History = function(slideshow) {
   slideshow.on('slideshowchangepage', function() {
-    window.location.hash = '#' + slideshow.currentPage().attr('id');
+    if(pageflow.features.has('hashchange support')) {
+      window.location.hash = '#' + slideshow.currentPage().attr('id');
+    }
   });
 
   $(window).on('hashchange', function() {


### PR DESCRIPTION
fullscreen landscape view now working properly on ios 8 phone size
devices. disabling history states due to strange "back-swipe"
behaviour and address bar issues
