### PR TITLE
Slideshow Position Absolute

### DIFF
--- a/app/assets/stylesheets/pageflow/slideshow.css.scss
+++ b/app/assets/stylesheets/pageflow/slideshow.css.scss
@@ -244,3 +244,6 @@
     }
   }
 }
+.js .slideshow {
+  position: absolute;
+}


### PR DESCRIPTION
Slideshow relative positioning results in initially wrong calculated pageheight of new text-page on chrome.
Seems to be a browser bug that can be bypassed by positioning absolute
