### PR TITLE
Make Page Navigation List Widget Work in Editor for New Pages

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/page_navigation_list.js
+++ b/app/assets/javascripts/pageflow/widgets/page_navigation_list.js
@@ -17,7 +17,7 @@
       });
 
       function getPageId(section) {
-        return $(section).attr('id') || ($(section).data('permaId') || '').toString();
+        return $(section).attr('id') || ($(section).attr('data-perma-id') || '').toString();
       }
 
       function highlightActivePage(id) {
@@ -38,7 +38,7 @@
 
           if (active) {
             if (link.data('chapterId')) {
-              highlightChapter(link.data('chapterId'))
+              highlightChapter(link.data('chapterId'));
             }
 
             if (options.scrollToActive) {


### PR DESCRIPTION
Sometimes jQuery cached data attributes too eagerly causing the page
id read from the page element to be undefined. This lead to broken
highlighting of current page in editor. Read attribute directly
instead.
