### PR TITLE
Prevent Edit Lock Conflict when Reopening Editor

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/edit_lock_container.js
+++ b/app/assets/javascripts/pageflow/editor/models/edit_lock_container.js
@@ -66,6 +66,7 @@ pageflow.EditLockContainer = Backbone.Model.extend({
   release: function() {
     if (this.lock) {
       var promise = this.lock.destroy();
+      delete sessionStorage[this.storageKey];
       this.lock = null;
       return promise;
     }


### PR DESCRIPTION
Edit lock id was not purged from session store causing the first
aquire to refresh a lock that was no longer there.
