### PR TITLE
Ensure current Configuration is passed to Page Types in Editor

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/page_preview_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/page_preview_view.js
@@ -46,10 +46,7 @@ pageflow.PagePreviewView = Backbone.Marionette.View.extend({
     this.$el.page('cleanup');
 
     this.$el.html(this.pageTemplate());
-    this.$el.attr('data-id', this.model.id);
-    this.$el.attr('data-perma-id', this.model.get('perma_id'));
     this.$el.data('template', this.model.get('template'));
-    this.$el.data('configuration', this.model.get('configuration'));
 
     this.$el.page('reinit');
     this.updateChapterBeginningClass();


### PR DESCRIPTION
After changing the page template, page type hooks were passed obsolete
configuration objects.
