### PR TITLE
Ensure Pictograms of new File Stages also Blink

### DIFF
--- a/app/assets/stylesheets/pageflow/editor/file_thumbnails.css.scss
+++ b/app/assets/stylesheets/pageflow/editor/file_thumbnails.css.scss
@@ -13,6 +13,7 @@
   .pictogram {
     background-color: #444;
     @include background-icon-center($color: #eee, $font-size: 30px);
+    @include background-icon-animation(blink);
 
     &.audio {
       @include note-icon;
@@ -20,43 +21,40 @@
 
     &.uploading {
       @include up-bold-icon;
-      @include background-icon-animation(blink);
     }
 
     &.uploading_to_s3 {
       @include cloud-icon;
-      @include background-icon-animation(blink);
     }
 
     &.fetching_meta_data {
       @include clipboard-icon;
-      @include background-icon-animation(blink);
     }
 
     &.processing,
     &.encoding {
       @include cog-icon;
-      @include background-icon-animation(blink);
     }
 
     &.empty {
       @include picture-icon;
+      @include background-icon-animation(none);
     }
 
     &.failed {
-      @include background-icon-animation(none);
       @include attention-icon;
+      @include background-icon-animation(none);
     }
 
     &.action_required {
       @include bell-icon;
-      @include background-icon-animation(blink);
     }
   }
 
   &.ready {
     .pictogram {
       display: none;
+      @include background-icon-animation(none);
     }
   }
 


### PR DESCRIPTION
Before the icon was only animated for a known set of stages.
