### PR TITLE
Automatically Return to Previous Tab on File Selection

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
@@ -50,10 +50,7 @@ pageflow.EditMetaDataView = Backbone.Marionette.Layout.extend({
     configurationEditor.tab('social', function() {
       this.input('share_image_id', pageflow.FileInputView, {
         collection: pageflow.imageFiles,
-        fileSelectionHandler: 'entryConfiguration',
-        fileSelectionHandlerOptions: {
-          returnToTab: 'social'
-        }
+        fileSelectionHandler: 'entryConfiguration'
       });
       this.input('summary', pageflow.TextAreaInputView);
     });

--- a/app/assets/javascripts/pageflow/ui/views/configuration_editor_tab_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/configuration_editor_tab_view.js
@@ -16,6 +16,7 @@ pageflow.ConfigurationEditorTabView = Backbone.Marionette.View.extend({
     this.inputs = this.inputs || new Backbone.ChildViewContainer();
     this.inputs.add(new view(_.extend({
       model: this.model,
+      parentTab: this.options.tab
     }, options || {})));
   },
 

--- a/app/assets/javascripts/pageflow/ui/views/configuration_editor_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/configuration_editor_view.js
@@ -15,7 +15,8 @@ pageflow.ConfigurationEditorView = Backbone.Marionette.View.extend({
     this.tabsView.tab(name, _.bind(function() {
       var tabView = new pageflow.ConfigurationEditorTabView({
         model: this.model,
-        placeholderModel: this.options.placeholderModel
+        placeholderModel: this.options.placeholderModel,
+        tab: name
       });
 
       callback.call(tabView);

--- a/app/assets/javascripts/pageflow/ui/views/inputs/file_input_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/inputs/file_input_view.js
@@ -20,7 +20,8 @@ pageflow.FileInputView = Backbone.Marionette.ItemView.extend({
         this.options.fileSelectionHandler || 'pageConfiguration',
         _.extend({
           id: this.model.getRoutableId ? this.model.getRoutableId() : this.model.id,
-          attributeName: this.options.propertyName
+          attributeName: this.options.propertyName,
+          returnToTab: this.options.parentTab
         }, this.options.fileSelectionHandlerOptions || {})
       );
 


### PR DESCRIPTION
Pass tab name to inputs on configuration editor tabs, so file input
view can pass it as default `returnToTab` option to file selection
handler.
