### PR TITLE
Only process links with href in pageNavigationList widget

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/page_navigation_list.js
+++ b/app/assets/javascripts/pageflow/widgets/page_navigation_list.js
@@ -4,7 +4,7 @@
       var element = this.element;
       var options = this.options;
       var scroller = options.scroller;
-      var links = element.find('a');
+      var links = element.find('a[href]');
 
       pageflow.ready.then(function() {
         highlightUnvisitedPages(pageflow.visited.getUnvisitedPages());


### PR DESCRIPTION
Otherwise `substr` call fails for empty `href` when handling visited
pages.
