### PR TITLE
Ensure Failed Pictogram is Displayed for New File Types

### DIFF
--- a/app/assets/stylesheets/pageflow/editor/file_thumbnails.css.scss
+++ b/app/assets/stylesheets/pageflow/editor/file_thumbnails.css.scss
@@ -41,14 +41,14 @@
       @include background-icon-animation(none);
     }
 
-    &.failed {
-      @include attention-icon;
-      @include background-icon-animation(none);
-    }
-
     &.action_required {
       @include bell-icon;
     }
+  }
+
+  div.pictogram.failed {
+    @include attention-icon;
+    @include background-icon-animation(none);
   }
 
   &.ready {


### PR DESCRIPTION
CSS rule was not specific enough to outrule file stage pictogram rules
created with the `pageflow-hosted-file-stage` mixin.
