### PR TITLE
Ensure page property is set on Configuration

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/page.js
+++ b/app/assets/javascripts/pageflow/editor/models/page.js
@@ -16,7 +16,7 @@ pageflow.Page = Backbone.Model.extend({
 
   initialize: function() {
     this.configuration = new pageflow.Configuration(this.get('configuration') || {});
-    this.configuration.parent = this;
+    this.configuration.parent = this.configuration.page = this;
 
     this.listenTo(this.configuration, 'change', function() {
       this.trigger('change:configuration');


### PR DESCRIPTION
We cannot rename to `parent` since other parts of the application depend on `configuration.page` to be present.
