### PR TITLE
Allow Widgets to Add Content To Page Head

### DIFF
--- a/app/helpers/pageflow/widgets_helper.rb
+++ b/app/helpers/pageflow/widgets_helper.rb
@@ -1,5 +1,13 @@
 module Pageflow
   module WidgetsHelper
+    def render_widget_head_fragments(entry, options = {})
+      fragments = entry.widgets.resolve(options).map do |widget|
+        widget.widget_type.render_head_fragment(self, entry)
+      end
+
+      safe_join(fragments)
+    end
+
     def render_widgets(entry, options = {})
       fragments = entry.widgets.resolve(options).map do |widget|
         widget.widget_type.render(self, entry)

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -1,12 +1,16 @@
 <% @page_title = @entry.title %>
 
 <% content_for(:head) do %>
-  <%= stylesheet_link_tag('pageflow/application', media: 'all', 'data-turbolinks-track' => true) %>
-  <%= entry_theme_stylesheet_link_tag(@entry) %>
-  <%= entry_stylesheet_link_tag(@entry) %>
-  <%= social_share_meta_tags_for(@entry.share_target) %>
+  <%= cache [@entry, :head] do %>
+    <%= stylesheet_link_tag('pageflow/application', media: 'all', 'data-turbolinks-track' => true) %>
+    <%= entry_theme_stylesheet_link_tag(@entry) %>
+    <%= entry_stylesheet_link_tag(@entry) %>
 
-  <%= tag :link, :rel => 'icon', :href => image_path("pageflow/themes/#{@entry.theming.theme.directory_name}/favicon.ico"), :type => 'image/ico' %>
+    <%= social_share_meta_tags_for(@entry.share_target) %>
+    <%= render_widget_head_fragments(@entry) %>
+
+    <%= tag :link, :rel => 'icon', :href => image_path("pageflow/themes/#{@entry.theming.theme.directory_name}/favicon.ico"), :type => 'image/ico' %>
+  <% end %>
 <% end %>
 
 <%= cache @entry do %>

--- a/doc/creating_widget_types.md
+++ b/doc/creating_widget_types.md
@@ -104,3 +104,21 @@ theming is required for a widget to be rendered in all entries:
 
 The default option registers the widget type as default choice for all
 roles supported by the widget type.
+
+### Adding Content to the Page Head
+
+Widget types can contribute to the head of a published entry to add
+script or meta tags.
+
+    module Pageflow
+      module ProgressNaviationBar
+        class WidgetType < Pageflow::WidgetType
+          # ...
+
+          def render_head_fragment(template, entry)
+            # return html representation. For example:
+            template.content_tag(:script, '', src: '//example.com/script.js')
+          end
+        end
+      end
+    end

--- a/lib/pageflow/widget_type.rb
+++ b/lib/pageflow/widget_type.rb
@@ -25,6 +25,12 @@ module Pageflow
       template.render(File.join('pageflow', name, 'widget'), entry: entry)
     end
 
+    # Override to return html that should be placed in the head
+    # element of the page. Not supported inside the editor.
+    def render_head_fragment(template, entry)
+      ''
+    end
+
     class Null < WidgetType
       def initialize(role)
         @role = role

--- a/spec/controllers/pageflow/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/entries_controller_spec.rb
@@ -177,6 +177,17 @@ module Pageflow
           expect(response.body).to have_selector('div.test_widget')
         end
 
+        it 'renders widgets head fragments for entry' do
+          Pageflow.config.widget_types.register(TestWidgetType.new(:name => 'test_widget',
+                                                                   :rendered_head_fragment => '<meta name="some_test" content="value">'))
+          entry = create(:entry, :published)
+          create(:widget, :subject => entry.published_revision, :type_name => 'test_widget')
+
+          get(:show, :id => entry)
+
+          expect(response.body).to have_selector('head meta[name=some_test]', :visible => false)
+        end
+
         context 'with configured entry_request_scope' do
           before do
             Pageflow.config.public_entry_request_scope = lambda do |entries, request|

--- a/spec/support/helpers/test_widget_type.rb
+++ b/spec/support/helpers/test_widget_type.rb
@@ -7,6 +7,7 @@ module Pageflow
       @roles = options.fetch(:roles, [])
       @enabled_in_editor = options.fetch(:enabled_in_editor, false)
       @rendered = options.fetch(:rendered, '')
+      @rendered_head_fragment = options.fetch(:rendered_head_fragment, '')
     end
 
     def enabled_in_editor?
@@ -15,6 +16,10 @@ module Pageflow
 
     def render(template, entry)
       @rendered.html_safe
+    end
+
+    def render_head_fragment(template, entry)
+      @rendered_head_fragment.html_safe
     end
   end
 end


### PR DESCRIPTION
Give widgets the possibility to include external scripts or add meta
tags.
