### PR TITLE
Remove Additional Info Box Fields for Audio Loop Page

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/configuration_editors/audio_loop.js
+++ b/app/assets/javascripts/pageflow/editor/views/configuration_editors/audio_loop.js
@@ -2,9 +2,6 @@ pageflow.ConfigurationEditorView.register('audio_loop', {
   configure: function() {
     this.tab('general', function() {
       this.group('general');
-
-      this.input('additional_title', pageflow.TextInputView);
-      this.input('additional_description', pageflow.TextAreaInputView, {size: 'short'});
     });
 
     this.tab('files', function() {


### PR DESCRIPTION
Not supported by this page type. Copied over from audio page.
