### PR TITLE
Make FileReferenceInputView Set Attribute to null

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/mixins/transient_references.js
+++ b/app/assets/javascripts/pageflow/editor/models/mixins/transient_references.js
@@ -22,7 +22,7 @@ pageflow.transientReferences = {
 
   unsetReference: function(attribute) {
     this._cleanUpReference(attribute);
-    this.unset(attribute);
+    this.set(attribute, null);
   },
 
   _setReference: function(attribute, record) {


### PR DESCRIPTION
Used to unset which caused the entry sharing image not be resetable.
