### PR TITLE
Introduce PositionedFile Decorator

### DIFF
--- a/app/helpers/pageflow/file_thumbnails_helper.rb
+++ b/app/helpers/pageflow/file_thumbnails_helper.rb
@@ -12,7 +12,7 @@ module Pageflow
 
     def file_thumbnail_css_class(file, style)
       return if file.blank?
-      [file.class.model_name.singular, style, file.id] * '_'
+      [file.to_model.class.model_name.singular, style, file.to_model.id] * '_'
     end
   end
 end

--- a/app/models/pageflow/positioned_file.rb
+++ b/app/models/pageflow/positioned_file.rb
@@ -1,0 +1,45 @@
+module Pageflow
+  class PositionedFile
+    attr_reader :file, :position_x, :position_y
+
+    delegate :thumbnail_url, to: :file
+
+    def initialize(file, position_x = nil, position_y = nil)
+      @file = file
+      @position_x = position_x.presence || 50
+      @position_y = position_y.presence || 50
+    end
+
+    def ==(other)
+      super(other) ||
+        other == file ||
+        (other.is_a?(PositionedFile) && other.file == file)
+    end
+
+    def to_model
+      file
+    end
+
+    def self.wrap(file, position_x, position_y)
+      file ? new(file, position_x, position_y) : nil
+    end
+
+    def self.null
+      Null.new
+    end
+
+    class Null < PositionedFile
+      def initialize
+        super(nil)
+      end
+
+      def thumbnail_url(*args)
+        ImageFile.new.processed_attachment.url(*args)
+      end
+
+      def blank?
+        true
+      end
+    end
+  end
+end

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -31,7 +31,13 @@ module Pageflow
     end
 
     def thumbnail_url(*args)
-      pages.first.try(:thumbnail_url, *args) || ImageFile.new.processed_attachment.url(*args)
+      thumbnail_file.thumbnail_url(*args)
+    end
+
+    def thumbnail_file
+      share_image_file ||
+        pages.first.try(:thumbnail_file) ||
+        PositionedFile.null
     end
 
     def self.find(id, scope = Entry)
@@ -50,6 +56,10 @@ module Pageflow
 
     def custom_revision?
       @custom_revision
+    end
+
+    def share_image_file
+      PositionedFile.wrap(ImageFile.find_by_id(share_image_id), share_image_x, share_image_y)
     end
   end
 end

--- a/app/models/pageflow/thumbnail_file_resolver.rb
+++ b/app/models/pageflow/thumbnail_file_resolver.rb
@@ -1,22 +1,22 @@
 module Pageflow
   class ThumbnailFileResolver < Struct.new(:candidates, :configuration)
-    class Null
-      def thumbnail_url(*args)
-        ImageFile.new.processed_attachment.url(*args)
-      end
-
-      def blank?
-        true
-      end
-    end
-
     def find
       candidates.reduce(nil) do |result, candidate|
-        result || file_model(candidate).find_by_id(record_id(candidate))
-      end || Null.new
+        result || find_positioned_file_by_candiate(candidate)
+      end || PositionedFile.null
     end
 
     private
+
+    def find_positioned_file_by_candiate(candidate)
+      PositionedFile.wrap(find_file_by_candidate(candidate),
+                          file_position(candidate, :x),
+                          file_position(candidate, :y))
+    end
+
+    def find_file_by_candidate(candidate)
+      file_model(candidate).find_by_id(record_id(candidate))
+    end
 
     def file_model(candidate)
       file_type(candidate).model
@@ -28,6 +28,14 @@ module Pageflow
 
     def record_id(candidate)
       configuration[candidate.fetch(:attribute)]
+    end
+
+    def file_position(candidate, coordinate)
+      configuration[file_position_attribute(candidate, coordinate)]
+    end
+
+    def file_position_attribute(candidate, coordinate)
+      candidate.fetch(:attribute).gsub(/_id$/, "_#{coordinate}")
     end
   end
 end

--- a/spec/helpers/pageflow/file_thumbnails_helper_spec.rb
+++ b/spec/helpers/pageflow/file_thumbnails_helper_spec.rb
@@ -39,5 +39,24 @@ module Pageflow
         expect(result).not_to include(".pageflow_audio_file_link_thumbnail_#{audio_file.id}")
       end
     end
+
+    describe '#file_thumbnail_css_class' do
+      it 'concats class name, style and id' do
+        image_file = create(:image_file)
+
+        result = helper.file_thumbnail_css_class(image_file, :thumbnail)
+
+        expect(result).to eq("pageflow_image_file_thumbnail_#{image_file.id}")
+      end
+
+      it 'supportes positioned files' do
+        image_file = create(:image_file)
+        positioned_file = PositionedFile.new(image_file, 50, 50)
+
+        result = helper.file_thumbnail_css_class(positioned_file, :thumbnail)
+
+        expect(result).to eq("pageflow_image_file_thumbnail_#{image_file.id}")
+      end
+    end
   end
 end

--- a/spec/models/pageflow/positioned_file_spec.rb
+++ b/spec/models/pageflow/positioned_file_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+module Pageflow
+  describe PositionedFile do
+    describe '#thumbnail_url' do
+      it 'delegates to wrapped file' do
+        image_file = create(:image_file)
+        result = PositionedFile.wrap(image_file, 60, 40)
+
+        expect(result.thumbnail_url(:thumbnail)).to eq(image_file.thumbnail_url(:thumbnail))
+      end
+    end
+
+    describe '.wrap' do
+      it 'returns nil for nil' do
+        result = PositionedFile.wrap(nil, 50, 50)
+
+        expect(result).to be(nil)
+      end
+
+      it 'returns PositionedFile for file' do
+        image_file = create(:image_file)
+        result = PositionedFile.wrap(image_file, 60, 40)
+
+        expect(result).to eq(image_file)
+        expect(result.position_x).to be(60)
+        expect(result.position_y).to be(40)
+      end
+    end
+
+    describe PositionedFile::Null do
+      describe '#thumbnail_url' do
+        it 'returns placeholder url' do
+          file = PositionedFile::Null.new
+
+          expect(file.thumbnail_url).to match(/placeholder/)
+        end
+      end
+
+      describe '#position_x/positions_y' do
+        it 'returns default value' do
+          file = PositionedFile::Null.new
+
+          expect(file.position_x).to eq(50)
+          expect(file.position_y).to eq(50)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/pageflow/published_entry_spec.rb
+++ b/spec/models/pageflow/published_entry_spec.rb
@@ -2,6 +2,53 @@ require 'spec_helper'
 
 module Pageflow
   describe PublishedEntry do
+    describe '#thumbnail_file' do
+      it 'returns positioned share image of published revision' do
+        entry = create(:entry)
+        image_file = create(:image_file)
+        revision = create(:revision,
+                          :published,
+                          :entry => entry,
+                          :share_image_id => image_file.id,
+                          :share_image_x => 10,
+                          :share_image_y => 30)
+        chapter = create(:chapter, :revision => revision)
+        page = create(:page, :chapter => chapter)
+        published_entry = PublishedEntry.new(entry)
+
+        expect(published_entry.thumbnail_file).to eq(image_file)
+        expect(published_entry.thumbnail_file.position_x).to eq(10)
+        expect(published_entry.thumbnail_file.position_y).to eq(30)
+      end
+
+      it 'returns positioned thumbnail file of first page of published revision' do
+        entry = create(:entry)
+        revision = create(:revision, :published, :entry => entry)
+        chapter = create(:chapter, :revision => revision)
+        image_file = create(:image_file)
+        page = create(:page, :chapter => chapter, :configuration => {
+                        'background_image_id' => image_file.id,
+                        'background_image_x' => 20,
+                        'background_image_y' => 40
+                      })
+        published_entry = PublishedEntry.new(entry)
+
+        expect(published_entry.thumbnail_file).to eq(image_file)
+        expect(published_entry.thumbnail_file.position_x).to eq(20)
+        expect(published_entry.thumbnail_file.position_y).to eq(40)
+      end
+
+      it 'returns blank null positioned file for published revision without pages' do
+        entry = create(:entry)
+        revision = create(:revision, :published, :entry => entry)
+        published_entry = PublishedEntry.new(entry)
+
+        expect(published_entry.thumbnail_file).to be_blank
+        expect(published_entry.thumbnail_file.position_x).to eq(50)
+        expect(published_entry.thumbnail_file.position_y).to eq(50)
+      end
+    end
+
     describe '#thumbnail_url' do
       it 'returns thumbnail of first page of published revision' do
         entry = create(:entry)

--- a/spec/models/pageflow/thumbnail_file_resolver_spec.rb
+++ b/spec/models/pageflow/thumbnail_file_resolver_spec.rb
@@ -54,16 +54,36 @@ module Pageflow
         file = resolver.find
 
         expect(file).to be_blank
+        expect(file.position_x).to eq(50)
+        expect(file.position_y).to eq(50)
       end
-    end
 
-    describe ThumbnailFileResolver::Null do
-      describe '#thumbnail_url' do
-        it 'returns placeholder url' do
-          file = ThumbnailFileResolver::Null.new
+      it 'returns positioned file with coordinates from configuration' do
+        image_file = create(:image_file)
+        candidates = [
+          {attribute: 'thumbnail_id', file_collection: 'image_files'}
+        ]
+        configuration = {'thumbnail_id' => image_file.id, 'thumbnail_x' => 20, 'thumbnail_y' => 30}
+        resolver = ThumbnailFileResolver.new(candidates, configuration)
 
-          expect(file.thumbnail_url).to match(/placeholder/)
-        end
+        file = resolver.find
+
+        expect(file.position_x).to eq(20)
+        expect(file.position_y).to eq(30)
+      end
+
+      it 'returns positioned file with default coordinates' do
+        image_file = create(:image_file)
+        candidates = [
+          {attribute: 'thumbnail_id', file_collection: 'image_files'}
+        ]
+        configuration = {'thumbnail_id' => image_file.id}
+        resolver = ThumbnailFileResolver.new(candidates, configuration)
+
+        file = resolver.find
+
+        expect(file.position_x).to eq(50)
+        expect(file.position_y).to eq(50)
       end
     end
   end


### PR DESCRIPTION
Let `Page#thumbnail_file` and `Entry#thumbnail_file` return
`PositionedFile` objects which provide a `thumbnail_url` and also
background positioning information. The positions are either read from
the sharing image or the corresponding file positions of the page
thumbnail candidate.
