### PR TITLE
Upgrade Rich Text Editor

### DIFF
--- a/app/assets/javascripts/pageflow/ui.js
+++ b/app/assets/javascripts/pageflow/ui.js
@@ -1,7 +1,6 @@
 //= require_self
 
-//= require wysihtml5
-//= require parser_rules/simple
+//= require wysihtml5x-toolbar
 
 //= require i18n
 //= require i18n/translations

--- a/lib/pageflow/engine.rb
+++ b/lib/pageflow/engine.rb
@@ -19,7 +19,7 @@ require 'videojs_rails'
 require 'backbone-rails'
 require 'marionette-rails'
 require 'jquery-fileupload-rails'
-require 'wysihtml5-rails'
+require 'wysihtml5x/rails'
 require 'i18n-js'
 
 module Pageflow

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -73,7 +73,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n-js'
 
   # WYSIWYG editor
-  s.add_dependency 'wysihtml5-rails'
+  s.add_dependency 'wysihtml5x-rails', '0.4.17'
 
   s.add_dependency 'bourbon', '~> 3.1.8'
 


### PR DESCRIPTION
The priorly used version from xing/wysihtml5 is no longer
maintained. Switch to Voog/wysihtml. 0.4.x series is available as
wysihtml5x gem.
