### PR TITLE
Ensure Target Blank for Content Links

### DIFF
--- a/app/assets/javascripts/pageflow/base.js
+++ b/app/assets/javascripts/pageflow/base.js
@@ -41,6 +41,7 @@
 //= require ./manual_start
 //= require ./widget_types
 //= require ./built_in_widget_types
+//= require ./links
 
 //= require ./settings
 

--- a/app/assets/javascripts/pageflow/editor/views/page_preview_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/page_preview_view.js
@@ -58,9 +58,12 @@ pageflow.PagePreviewView = Backbone.Marionette.View.extend({
 
   update: function() {
     this.$el.removeClass(pageflow.Page.transitions.join(' ')).addClass(this.model.configuration.get('transition'));
+
     this.pageType().update(this.$el, this.model.configuration);
     _.extend(this.$el.data('configuration'), this.model.configuration.attributes);
+
     this.refreshScroller();
+    this.ensureTargetBlankForContentLinks();
   },
 
   updateChapterBeginningClass: function() {
@@ -78,6 +81,10 @@ pageflow.PagePreviewView = Backbone.Marionette.View.extend({
 
   refreshScroller: function() {
     this.$el.page('refreshScroller');
+  },
+
+  ensureTargetBlankForContentLinks: function() {
+    pageflow.links.ensureTargetBlankForContentLinks(this.el);
   },
 
   initEmbeddedViews: function() {

--- a/app/assets/javascripts/pageflow/links.js
+++ b/app/assets/javascripts/pageflow/links.js
@@ -1,0 +1,42 @@
+pageflow.links = {
+  setup: function() {
+    this.preventFocusRectOnClick();
+    this.ensureClickOnEnterKeyPress();
+    this.setupContentSkipLinks();
+    this.ensureTargetBlankForContentLinks();
+  },
+
+  preventFocusRectOnClick: function() {
+    $('body').on('click mousedown', 'a, [tabindex]', function() {
+      $(this).blur();
+    });
+  },
+
+  ensureClickOnEnterKeyPress: function() {
+    $('body').on('keypress', 'a, [tabindex]', function(e) {
+      if (e.which == 13) {
+        $(this).click();
+      }
+    });
+
+    $('body').on('keyup', 'a, [tabindex]', function (e) {
+      e.stopPropagation();
+    });
+  },
+
+  setupContentSkipLinks: function() {
+    $('.content_link').attr('href', '#firstContent');
+
+    $('.content_link').click(function(e) {
+      $('#firstContent').focus();
+      e.preventDefault();
+      return false;
+    });
+  },
+
+  // There was a time when the rich text editor did not add target
+  // attributes to inline links even though it should have.
+  ensureTargetBlankForContentLinks: function(context) {
+    $('.contentText p a', context).attr('target', '_blank');
+  }
+};

--- a/app/assets/javascripts/pageflow/ready.js
+++ b/app/assets/javascripts/pageflow/ready.js
@@ -25,26 +25,7 @@ pageflow.ready = new $.Deferred(function(readyDeferred) {
         pageflow.history = new pageflow.History(pageflow.slides);
       });
 
-      $("body").on('click mousedown', 'a, [tabindex]', function() {
-        $(this).blur();
-      });
-
-      $("body").on('keypress', 'a, [tabindex]', function(e) {
-        if (e.which == 13) {
-          $(this).click();
-        }
-      });
-
-      $("body").on("keyup", "a, [tabindex]", function (e) {
-        e.stopPropagation();
-      });
-
-      $(".content_link").attr("href","#firstContent");
-      $(".content_link").click(function(e) {
-        $("#firstContent").focus();
-        e.preventDefault();
-        return false; }
-      );
+      pageflow.links.setup();
     });
   };
 }).promise();


### PR DESCRIPTION
The rich text editor used so far sometimes failed to set the target
attribute on anchor tags. Extract all link behaviour related
functionality from ready.js to a separate file and enforce target
blank attribute.
