### PR TITLE
Fix jquery-fileupload-rails version to 0.4.1

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails', '~> 3.0'
   s.add_dependency 'jquery-ui-rails', '~> 4.2'
   s.add_dependency 'jquery-layout-rails', '~> 0.1.0'
-  s.add_dependency 'jquery-fileupload-rails', '~> 0.4.1'
+  s.add_dependency 'jquery-fileupload-rails', '0.4.1'
 
   s.add_dependency 'backbone-rails', '~> 1.0.0'
 


### PR DESCRIPTION
0.4.2 causes an error: Sprockets::FileNotFound: couldn't find file
'jquery-fileupload/vendor/load-image'