### PR TITLE
Fix Translation Key in FilesExplorerView

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/files_explorer_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/files_explorer_view.js
@@ -39,7 +39,7 @@ pageflow.FilesExplorerView = Backbone.Marionette.ItemView.extend({
 
     this.tabsView = new pageflow.TabsView({
       model: this.model,
-      i18n: 'editor.files.tabs',
+      i18n: 'pageflow.editor.files.tabs',
       defaultTab: this.options.tabName
     });
 


### PR DESCRIPTION
The recently added `pageflow` prefix was missing.