### PR TITLE
Escape illegal UTF8 Characters in Entry JSON Seed

### DIFF
--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -1,5 +1,7 @@
 module Pageflow
   module EntriesHelper
+    include RenderJsonHelper
+
     def pretty_entry_url(entry)
       pageflow.short_entry_url(entry.to_model, Pageflow.config.theming_url_options(entry.theming))
     end
@@ -70,6 +72,10 @@ module Pageflow
     def entry_summary(entry)
       return '' if entry.summary.blank?
       strip_tags(entry.summary.gsub(/<br ?\/?>/, ' ').squish)
+    end
+
+    def entry_pages_json_seed(entry)
+      sanitize_json(entry.pages.to_json(only: [:id, :perma_id, :configuration])).html_safe
     end
   end
 end

--- a/app/helpers/pageflow/render_json_helper.rb
+++ b/app/helpers/pageflow/render_json_helper.rb
@@ -21,6 +21,17 @@ module Pageflow
       end
     end
 
+    ESCAPED_CHARS = {
+      "\u2028" => '\u2028',
+      "\u2029" => '\u2029'
+    }
+
+    ESCAPED_CHARS_REGEX = /[\u2028\u2029]/u
+
+    def sanitize_json(json)
+      json.gsub(ESCAPED_CHARS_REGEX, ESCAPED_CHARS)
+    end
+
     def render_html_partial(*args)
       render_with_format(:html) do
         render(*args)

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -23,7 +23,7 @@
   <script>
     pageflow.manualStart.enabled = <%= @entry.manual_start ? 'true' : 'false' %>;
     pageflow.visited.enabled = <%= @entry.emphasize_new_pages ? 'true' : 'false' %>;
-    pageflow.pages = <%= @entry.pages.to_json(:only => [:id, :perma_id, :configuration]).html_safe %>;
+    pageflow.pages = <%= entry_pages_json_seed(@entry) %>;
     pageflow.entryId = <%= @entry.id %>;
   </script>
 

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -76,5 +76,31 @@ module Pageflow
         expect(helper.entry_stylesheet_link_tag(entry)).to include(%Q'href="/revisions/#{revision.id}.css?v=#{ERB::Util.url_encode(revision.cache_key)}')
       end
     end
+
+    describe '#entry_pages_json_seed' do
+      it 'includes id, perma_id and configuration' do
+        revision = create(:revision, :published)
+        chapter = create(:chapter, revision: revision)
+        page = create(:page, chapter: chapter, configuration: {text: 'some text'})
+        entry = PublishedEntry.new(create(:entry, published_revision: revision))
+
+        result = JSON.parse(helper.entry_pages_json_seed(entry))
+
+        expect(result[0]['id']).to eq(page.id)
+        expect(result[0]['perma_id']).to eq(page.perma_id)
+        expect(result[0]['configuration']['text']).to eq('some text')
+      end
+
+      it 'escapes illegal characters' do
+        revision = create(:revision, :published)
+        chapter = create(:chapter, revision: revision)
+        page = create(:page, chapter: chapter, configuration: {text: "some\u2028text"})
+        entry = PublishedEntry.new(create(:entry, published_revision: revision))
+
+        result = helper.entry_pages_json_seed(entry)
+
+        expect(result).to include('some\\u2028text')
+      end
+    end
   end
 end


### PR DESCRIPTION
The UTF8 characters \u2028 and u2029 are treated as whitespace in
javascript blocks and may therefore not appear in string literals of
JSON fragments that are embedded into javascript.

Prevent illegal syntax error in seed data script tag of entries.

See also #191.