### PR TITLE
Fetch editor seed data in separate JSON request.

### DIFF
--- a/app/assets/javascripts/pageflow/editor/base.js
+++ b/app/assets/javascripts/pageflow/editor/base.js
@@ -49,3 +49,18 @@
 
 pageflow.app = new Backbone.Marionette.Application();
 pageflow.editor = new pageflow.EditorApi();
+
+pageflow.startEditor = function(options) {
+  jQuery(function() {
+    $.when(
+      $.getJSON('/editor/entries/' + options.entryId + '/seed'),
+      pageflow.features.detect()
+    )
+      .done(function(result) {
+        pageflow.app.start(result[0]);
+      })
+      .fail(function() {
+        alert('Error while starting editor.');
+      });
+  });
+};

--- a/app/controllers/pageflow/editor/entries_controller.rb
+++ b/app/controllers/pageflow/editor/entries_controller.rb
@@ -9,6 +9,11 @@ module Pageflow
         @entries = DraftEntry.accessible_by(current_ability, :use_files)
         respond_with(@entries)
       end
+
+      def seed
+        @entry = DraftEntry.find(params[:id])
+        authorize!(:edit, @entry.to_model)
+      end
     end
   end
 end

--- a/app/helpers/pageflow/files_helper.rb
+++ b/app/helpers/pageflow/files_helper.rb
@@ -24,5 +24,18 @@ module Pageflow
         "-"
       end
     end
+
+    def files_json_seeds(entry)
+      inner = Pageflow.config.file_types.map do |file_type, result|
+        json = render_json_partial(partial: 'pageflow/editor/files/file',
+                                   collection: entry.files(file_type.model),
+                                   locals: {file_type: file_type},
+                                   as: :file)
+
+        %'"#{file_type.collection_name}": #{json}'
+      end.join(',')
+
+      "{#{inner}}".html_safe
+    end
   end
 end

--- a/app/views/pageflow/editor/entries/seed.json.erb
+++ b/app/views/pageflow/editor/entries/seed.json.erb
@@ -1,0 +1,14 @@
+{
+  "root": "<%= edit_entry_path(@entry).html_safe %>",
+  "config": <%= editor_config_seeds %>,
+
+  "entry": <%= render_json_seed(@entry) %>,
+  "chapters": <%= @entry.chapters.to_json.html_safe %>,
+  "pages": <%= @entry.pages.to_json.html_safe %>,
+
+  "files": <%= files_json_seeds(@entry) %>,
+
+  "theming": <%= render_json_seed(@entry.theming) %>,
+  "widget_types": <%= widget_types_json_seeds %>,
+  "page_types": <%= page_type_json_seeds %>
+}

--- a/app/views/pageflow/entries/edit.html.erb
+++ b/app/views/pageflow/entries/edit.html.erb
@@ -28,28 +28,7 @@
   I18n.defaultLocale = "<%= I18n.default_locale %>";
   I18n.locale = "<%= I18n.locale %>";
 
-  jQuery(function() {
-    pageflow.features.detect().then(function() {
-      pageflow.app.start({
-        root: '<%= edit_entry_path(@entry).html_safe %>',
-        config: <%= editor_config_seeds %>,
-
-        entry: <%= render_json_seed(@entry) %>,
-        chapters: <%= @entry.chapters.to_json.html_safe %>,
-        pages: <%= @entry.pages.to_json.html_safe %>,
-
-        files: {
-          <% Pageflow.config.file_types.each do |file_type| %>
-            <%= file_type.collection_name %>: <%= render_json_partial(partial: 'pageflow/editor/files/file', collection: @entry.files(file_type.model), locals: {file_type: file_type}, as: :file) %>,
-          <% end %>
-        },
-
-        theming: <%= render_json_seed(@entry.theming) %>,
-        widget_types: <%= widget_types_json_seeds %>,
-        page_types: <%= page_type_json_seeds %>
-      });
-    });
-  });
+  pageflow.startEditor({entryId: <%= @entry.id %>})
 </script>
 
 <%= page_type_templates %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Pageflow::Engine.routes.draw do
 
     namespace :editor do
       resources :entries, :only => :index, :shallow => true do
+        get :seed, :on => :member
+
         resources :files, :path => 'files/:collection_name', :only => [:index, :create, :update] do
           get :retry, :on => :member
         end

--- a/spec/controllers/pageflow/editor/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/editor/entries_controller_spec.rb
@@ -23,5 +23,36 @@ module Pageflow
         expect(response.status).to eq(401)
       end
     end
+
+    describe '#seed' do
+      it 'reponds with success for members of the entry' do
+        user = create(:user)
+        entry = create(:entry, :with_member => user)
+
+        sign_in(user)
+        get(:seed, :id => entry, :format => 'json')
+
+        expect(response.status).to eq(200)
+        expect { JSON.parse(response.body) }.not_to raise_error
+      end
+
+      it 'requires the signed in user to be member of the parent entry' do
+        user = create(:user)
+        entry = create(:entry)
+
+        sign_in(user)
+        get(:seed, :id => entry, :format => 'json')
+
+        expect(response.status).to eq(403)
+      end
+
+      it 'requires authentication' do
+        entry = create(:entry)
+
+        get(:seed, :id => entry, :format => 'json')
+
+        expect(response.status).to eq(401)
+      end
+    end
   end
 end


### PR DESCRIPTION
* Prevents displaying obsolete seed data from cached page when
  returning to the editor via browser back.
* Prevents illegal syntax error (#191) when json seed contains
  unescaped UTF8 whitespace characters.