### PR TITLE
Stop Edit Lock Polling when Unauthenticated

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/locked_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/locked_view.js
@@ -17,6 +17,8 @@ pageflow.LockedView = Backbone.Marionette.ItemView.extend({
     aquired: 'hide',
 
     locked: 'show',
+
+    unauthenticated: 'goBack'
   },
 
   breakLock: function() {


### PR DESCRIPTION
When authentication for the edit lock aquire request fails, redirect
to login page. Prevent clients from indefinitely polling from an
expired session.