### PR TITLE
Include Share Target in Head Cache Key

### DIFF
--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -1,7 +1,7 @@
 <% @page_title = @entry.title %>
 
 <% content_for(:head) do %>
-  <%= cache [@entry, :head] do %>
+  <%= cache [@entry, :head, @entry.share_target] do %>
     <%= stylesheet_link_tag('pageflow/application', media: 'all', 'data-turbolinks-track' => true) %>
     <%= entry_theme_stylesheet_link_tag(@entry) %>
     <%= entry_stylesheet_link_tag(@entry) %>


### PR DESCRIPTION
Otherwise page specific share headers are not rendered.