### PR TITLE
Add Plugin API to Configuration

### DIFF
--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -182,6 +182,14 @@ module Pageflow
       @available_locales = Engine.config.i18n.available_locales
     end
 
+    # Activate a plugin.
+    #
+    # @param [Plugin] plugin
+    # @since 0.7
+    def plugin(plugin)
+      plugin.configure(self)
+    end
+
     # Make a page type available for use in the system.
     def register_page_type(page_type)
       page_types << page_type

--- a/lib/pageflow/plugin.rb
+++ b/lib/pageflow/plugin.rb
@@ -1,0 +1,13 @@
+module Pageflow
+  # Base class for Pageflow extensions which perform more complex
+  # configuration changes.
+  #
+  # @since 0.7
+  class Plugin
+    # Override to configure Pageflow
+    #
+    # @param [Configuration] config
+    def configure(config)
+    end
+  end
+end

--- a/spec/pageflow/configuration_spec.rb
+++ b/spec/pageflow/configuration_spec.rb
@@ -2,6 +2,16 @@ require 'spec_helper'
 
 module Pageflow
   describe Configuration do
+    describe '#plugin' do
+      it 'calls configure method on plugin' do
+        configuration = Configuration.new
+        plugin = Class.new(Pageflow::Plugin).new
+
+        expect(plugin).to receive(:configure).with(configuration)
+
+        configuration.plugin(plugin)
+      end
+    end
 
     describe '#revision_components' do
       let(:page_type_class) do


### PR DESCRIPTION
Allow Pageflow extensions to group multiple configuration changes in a
single method. This allows extensions authors to change the way their
plugin integrates with Pageflow without changing the Pageflow
initializer of the host application.