### PR TITLE
Restrict sass-rails Gem Version to ~> 4.0

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -72,6 +72,9 @@ Gem::Specification.new do |s|
   # Templating engine used to render jst tempaltes.
   s.add_dependency 'ejs'
 
+  # Templating engine used to compile scss templates.
+  s.add_dependency 'sass-rails', '~> 4.0'
+
   # Using translations from rails locales in javascript code.
   s.add_dependency 'i18n-js'
 


### PR DESCRIPTION
`sass-rails 5.0` no longer allows mixing sprockets `require` and scss
`@import`. Still `jquery-ui-rails` uses `require` which causes some
stylesheets not to be loaded.