### PR TITLE
add locale detection from http_accept_language header

### DIFF
--- a/app/controllers/pageflow/application_controller.rb
+++ b/app/controllers/pageflow/application_controller.rb
@@ -6,7 +6,7 @@ module Pageflow
     layout 'pageflow/application'
 
     before_filter do
-      I18n.locale = current_user.try(:locale) || I18n.default_locale
+      I18n.locale = current_user.try(:locale) || locale_from_accept_language_header || I18n.default_locale
     end
 
     # Prevent CSRF attacks by raising an exception.
@@ -58,6 +58,10 @@ module Pageflow
       if request.ssl?
         redirect_to("http://#{request.host}#{request.fullpath}", :status => :moved_permanently)
       end
+    end
+
+    def locale_from_accept_language_header
+      http_accept_language.compatible_language_from(I18n.available_locales)
     end
   end
 end

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -90,6 +90,9 @@ Gem::Specification.new do |s|
   # Build JSON APIs with ease.
   s.add_dependency 'jbuilder', '>= 1.5', '< 3.0'
 
+  # Browser language detection
+  s.add_dependency 'http_accept_language', '~> 2.0'
+
   # Used by the dummy rails application
   s.add_development_dependency 'mysql2', '~> 0.3.16'
 


### PR DESCRIPTION
While not logged in, the locale should be set from the browsers http_accept_language header. Only if this header is not set, use the default_locale as fallback.