### PR TITLE
Allow Excluding Widgets from Being Rendered in Preview

### DIFF
--- a/app/controllers/pageflow/revisions_controller.rb
+++ b/app/controllers/pageflow/revisions_controller.rb
@@ -13,6 +13,7 @@ module Pageflow
       @entry = PublishedEntry.new(revision.entry, revision)
       I18n.locale = @entry.locale
 
+      @widget_scope = :preview
       render :template => 'pageflow/entries/show'
     end
 

--- a/app/models/pageflow/widget.rb
+++ b/app/models/pageflow/widget.rb
@@ -11,7 +11,13 @@ module Pageflow
     end
 
     def enabled?(options)
-      options[:only] != :editor || widget_type.enabled_in_editor?
+      if options[:scope] == :editor
+        widget_type.enabled_in_editor?
+      elsif options[:scope] == :preview
+        widget_type.enabled_in_preview?
+      else
+        true
+      end
     end
 
     def widget_type

--- a/app/views/pageflow/entries/_entry.html.erb
+++ b/app/views/pageflow/entries/_entry.html.erb
@@ -16,5 +16,5 @@
 
   <%= render 'pageflow/entries/header', :entry => entry %>
   <%= render 'pageflow/entries/overview', :entry => entry %>
-  <%= render_widgets(entry) %>
+  <%= render_widgets(entry, :scope => widget_scope) %>
 <% end %>

--- a/app/views/pageflow/entries/partials.html.erb
+++ b/app/views/pageflow/entries/partials.html.erb
@@ -1,3 +1,3 @@
 <%= render 'pageflow/entries/header', :entry => @entry %>
 <%= render 'pageflow/entries/overview', :entry => @entry %>
-<%= render_widgets(@entry, only: :editor) %>
+<%= render_widgets(@entry, scope: :editor) %>

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -13,12 +13,12 @@
   <% end %>
 <% end %>
 
-<%= cache @entry do %>
+<%= cache [@entry, :body, @widget_scope] do %>
 
   <%= render 'pageflow/entries/ie8_hint' %>
   <%= render 'pageflow/entries/loading_spinner' %>
   <%= render 'pageflow/entries/multimedia_alert' %>
-  <%= render @entry %>
+  <%= render @entry, :widget_scope => @widget_scope %>
 
   <script>
     pageflow.manualStart.enabled = <%= @entry.manual_start ? 'true' : 'false' %>;

--- a/doc/creating_widget_types.md
+++ b/doc/creating_widget_types.md
@@ -76,11 +76,11 @@ attribute matching the widget name.
 
 ## Advanced Options
 
-### Excluding Widgets from Being Rendered in the Editor
+### Excluding Widgets from Being Rendered in certain Scopes
 
-Some widgets do not make sense in the context of the editor,
-i.e. analytics snippets. Simply override `enabled_in_editor?` inside
-your widget type and return false.
+Some widgets do not make sense in the context of the editor or the
+preview, i.e. analytics snippets. Simply override `enabled_in_editor?`
+or `enabled_in_preview?` inside your widget type and return `false`.
 
     module Pageflow
       module MyAnalytics

--- a/lib/pageflow/widget_type.rb
+++ b/lib/pageflow/widget_type.rb
@@ -20,6 +20,11 @@ module Pageflow
       true
     end
 
+    # Override to return false to hide widget in entry preview.
+    def enabled_in_preview?
+      true
+    end
+
     # Override to return html as string.
     def render(template, entry)
       template.render(File.join('pageflow', name, 'widget'), entry: entry)

--- a/spec/controllers/pageflow/revisions_controller_spec.rb
+++ b/spec/controllers/pageflow/revisions_controller_spec.rb
@@ -21,6 +21,39 @@ module Pageflow
         expect(response.status).to eq(200)
       end
 
+      it 'renders widgets which are enabled in preview' do
+        Pageflow.config.widget_types.register(TestWidgetType.new(:name => 'test_widget',
+                                                                 :enabled_in_preview => true,
+                                                                 :rendered_head_fragment => '<meta name="some_test" content="value">',
+                                                                 :rendered => '<div class="test_widget"></div>'))
+        user = create(:user)
+        entry = create(:entry, :with_member => user)
+        revision = create(:revision, :entry => entry)
+        create(:widget, :subject => revision, :type_name => 'test_widget')
+
+        sign_in(user)
+        get(:show, :id => revision)
+
+        expect(response.body).to have_selector('div.test_widget')
+        expect(response.body).to have_selector('head meta[name=some_test]', :visible => false)
+      end
+
+      it 'does not render widgets which are disabled in preview' do
+        Pageflow.config.widget_types.register(TestWidgetType.new(:name => 'test_widget',
+                                                                 :enabled_in_preview => false,
+                                                                 :rendered_head_fragment => '<meta name="some_test" content="value">',
+                                                                 :rendered => '<div class="test_widget"></div>'))
+        user = create(:user)
+        entry = create(:entry, :with_member => user)
+        revision = create(:revision, :entry => entry)
+        create(:widget, :subject => revision, :type_name => 'test_widget')
+
+        sign_in(user)
+        get(:show, :id => revision)
+
+        expect(response.body).not_to have_selector('div.test_widget')
+      end
+
       it 'requires the signed in user to be member of the parent entry' do
         user = create(:user)
         revision = create(:revision)

--- a/spec/models/pageflow/widget_spec.rb
+++ b/spec/models/pageflow/widget_spec.rb
@@ -54,13 +54,28 @@ module Pageflow
         expect(revision.widgets.resolve).to include_record_with(type_name: 'custom_header', role: 'header')
       end
 
-      it 'filters disabled widgets' do
-        widget_type = TestWidgetType.new(name: 'non_editor_header', enabled_in_editor: false)
-        Pageflow.config.widget_types.register(widget_type)
+      it 'filters widgets disabled in editor' do
+        non_editor_widget_type = TestWidgetType.new(name: 'non_editor', enabled_in_editor: false)
+        non_preview_widget_type = TestWidgetType.new(name: 'non_preview', enabled_in_preview: false)
+        Pageflow.config.widget_types.register(non_editor_widget_type)
+        Pageflow.config.widget_types.register(non_preview_widget_type)
         revision = create(:revision)
-        create(:widget, subject: revision, role: 'header', type_name: 'non_editor_header')
+        create(:widget, subject: revision, role: 'header', type_name: 'non_editor')
+        non_preview_widget = create(:widget, subject: revision, role: 'footer', type_name: 'non_preview')
 
-        expect(revision.widgets.resolve(only: :editor)).to eq([])
+        expect(revision.widgets.resolve(scope: :editor)).to eq([non_preview_widget])
+      end
+
+      it 'filters widgets disabled in preview' do
+        non_editor_widget_type = TestWidgetType.new(name: 'non_editor', enabled_in_editor: false)
+        non_preview_widget_type = TestWidgetType.new(name: 'non_preview', enabled_in_preview: false)
+        Pageflow.config.widget_types.register(non_editor_widget_type)
+        Pageflow.config.widget_types.register(non_preview_widget_type)
+        revision = create(:revision)
+        non_editor_widget = create(:widget, subject: revision, role: 'header', type_name: 'non_editor')
+        create(:widget, subject: revision, role: 'footer', type_name: 'non_preview')
+
+        expect(revision.widgets.resolve(scope: :preview)).to eq([non_editor_widget])
       end
 
       it 'supports adding placeholders for missing role' do

--- a/spec/support/helpers/test_widget_type.rb
+++ b/spec/support/helpers/test_widget_type.rb
@@ -5,13 +5,18 @@ module Pageflow
     def initialize(options = {})
       @name = options.fetch(:name, 'test_widget')
       @roles = options.fetch(:roles, [])
-      @enabled_in_editor = options.fetch(:enabled_in_editor, false)
+      @enabled_in_editor = options.fetch(:enabled_in_editor, true)
+      @enabled_in_preview = options.fetch(:enabled_in_preview, true)
       @rendered = options.fetch(:rendered, '')
       @rendered_head_fragment = options.fetch(:rendered_head_fragment, '')
     end
 
     def enabled_in_editor?
       @enabled_in_editor
+    end
+
+    def enabled_in_preview?
+      @enabled_in_preview
     end
 
     def render(template, entry)


### PR DESCRIPTION
Add `enabled_in_preview?` method in widget type.