### PR TITLE
Allow Authorizing Admin Tabs

### DIFF
--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -83,6 +83,7 @@ module Pageflow
 
       tabs_view(Pageflow.config.admin_resource_tabs.find_by_resource(:entry),
                 :i18n => 'pageflow.admin.resource_tabs',
+                :authorize => true,
                 :build_args => [entry])
     end
 

--- a/app/views/components/pageflow/admin/tabs_view.rb
+++ b/app/views/components/pageflow/admin/tabs_view.rb
@@ -8,14 +8,22 @@ module Pageflow
       def build(tabs, options = {})
         super(class: 'admin_tabs_view')
 
-        @tabs = tabs
         @options = options
+        @tabs = filter_tabs(tabs)
 
         build_tab_list
         build_tab_containers
       end
 
       private
+
+      def filter_tabs(tabs)
+        return tabs unless options[:authorize]
+
+        tabs.select do |tab_options|
+          authorized?(:view, tab_options[:component])
+        end
+      end
 
       def build_tab_list
         ul(class: 'tabs') do

--- a/lib/pageflow/ability_mixin.rb
+++ b/lib/pageflow/ability_mixin.rb
@@ -29,6 +29,8 @@ module Pageflow
         can_edit_entry?(user, revision.entry)
       end
 
+      can :view, [Admin::MembersTab, Admin::RevisionsTab]
+
       if user.admin?
         can [:read, :create, :update], Account
         can :destroy, Account do |account|

--- a/lib/pageflow/admin/tabs.rb
+++ b/lib/pageflow/admin/tabs.rb
@@ -5,11 +5,14 @@ module Pageflow
         @tabs = {}
       end
 
-      def register(resource_name, view_component)
+      # @param [Symbol] resource_name  A resource name like `:entry` or `:account`
+      # @param [Hash] tab_options
+      def register(resource_name, tab_options)
         @tabs[resource_name] ||= []
-        @tabs[resource_name] << view_component
+        @tabs[resource_name] << tab_options
       end
 
+      # @api private
       def find_by_resource(name)
         @tabs.fetch(name, [])
       end

--- a/spec/pageflow/admin/tabs_spec.rb
+++ b/spec/pageflow/admin/tabs_spec.rb
@@ -17,10 +17,10 @@ module Pageflow
         it 'allows to register multiple view components per resource' do
           tabs = Tabs.new
 
-          tabs.register(:entry, ViewComponent)
+          tabs.register(:entry, component: ViewComponent)
           components = tabs.find_by_resource(:entry)
 
-          expect(components).to eq([ViewComponent])
+          expect(components).to eq([{component: ViewComponent}])
         end
       end
     end

--- a/spec/support/helpers/view_component_example_group.rb
+++ b/spec/support/helpers/view_component_example_group.rb
@@ -12,6 +12,10 @@ module ViewComponentExampleGroup
     Arbre::Context.new({}, _view)
   end
 
+  def helper
+    _view
+  end
+
   def render(*args)
     @rendered = arbre.send(described_class.builder_method_name, *args)
   end

--- a/spec/views/components/pageflow/admin/tabs_view_spec.rb
+++ b/spec/views/components/pageflow/admin/tabs_view_spec.rb
@@ -93,6 +93,38 @@ module Pageflow
 
         expect(rendered).to have_selector('.admin_tabs_view .tab_container .tab_view_component[data-custom="custom"]')
       end
+
+      context 'with :authorize options' do
+        it 'does not render links for tabs we are not authorized for' do
+          tabs = [{name: :some_tab, component: tab_view_component}]
+
+          helper.stub(:authorized?) { false }
+
+          render(tabs, authorize: true)
+
+          expect(rendered).not_to have_selector('.admin_tabs_view ul.tabs li.some_tab a')
+        end
+
+        it 'renders links for tabs we are authorized for' do
+          tabs = [{name: :some_tab, component: tab_view_component}]
+
+          helper.stub(:authorized?) { true }
+
+          render(tabs, authorize: true)
+
+          expect(rendered).to have_selector('.admin_tabs_view ul.tabs li.some_tab a')
+        end
+
+        it 'passes :view action and component class to authorized? method' do
+          tabs = [{name: :some_tab, component: tab_view_component}]
+
+          helper.stub(:authorized?) { true }
+
+          render(tabs, authorize: true)
+
+          expect(helper).to have_received(:authorized?).with(:view, tab_view_component)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add option to `tabs_view` component that uses ActiveAdmin authorization
adapter to determine which tabs are visible for a user.