### PR TITLE
Reset Locale to Default Locale Before Each Spec

### DIFF
--- a/spec/support/config/i18n.rb
+++ b/spec/support/config/i18n.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each) do
+    I18n.locale = I18n.default_locale
+  end
+end


### PR DESCRIPTION
Some specs might change I18n.locale. Some JavaScript specs though rely
on the fact that the locale in the test process is the same as in the
server used for the headless tests.