### PR TITLE
Fragment Caching for Editor File Polling

### DIFF
--- a/app/views/pageflow/entries/show.json.jbuilder
+++ b/app/views/pageflow/entries/show.json.jbuilder
@@ -1,8 +1,10 @@
 Pageflow.config.file_types.each do |file_type|
-  json.set!(file_type.collection_name) do
-    json.partial!(collection: @entry.files(file_type.model),
-                  partial: 'pageflow/editor/files/file',
-                  locals: {file_type: file_type},
-                  as: :file)
+  json.set!(file_type.collection_name, @entry.files(file_type.model)) do |file|
+    json.cache!(file) do
+      json.partial!(object: file,
+                    partial: 'pageflow/editor/files/file',
+                    locals: {file_type: file_type},
+                    as: :file)
+    end
   end
 end


### PR DESCRIPTION
While files are processed, the editor polls for changes to progress and state fields. For large pageflows the time needed to render this info for all files can get long. Cache fragments for individual files to speed things up.