### PR TITLE
Don't provide alternative images for open graph if share image is picked

### DIFF
--- a/app/helpers/pageflow/social_share_helper.rb
+++ b/app/helpers/pageflow/social_share_helper.rb
@@ -32,14 +32,16 @@ module Pageflow
     def social_share_entry_image_tags(entry)
       image_urls = []
 
-      image_urls << ImageFile.find(entry.share_image_id).thumbnail_url(:medium) if entry.share_image_id.present?
-
-      entry.pages.each do |page|
-        if image_urls.size >= 4
-          break
-        else
-          image_urls << page.thumbnail_url(:medium)
-          image_urls.uniq!
+      if entry.share_image_id.present?
+        image_urls << ImageFile.find(entry.share_image_id).thumbnail_url(:medium)
+      else
+        entry.pages.each do |page|
+          if image_urls.size >= 4
+            break
+          else
+            image_urls << page.thumbnail_url(:medium)
+            image_urls.uniq!
+          end
         end
       end
 

--- a/spec/factories/image_files.rb
+++ b/spec/factories/image_files.rb
@@ -19,6 +19,10 @@ module Pageflow
         create(:file_usage, :file => file, :revision => evaluator.used_in) if evaluator.used_in
       end
 
+      trait :processed do
+        processed_attachment File.open(Engine.root.join('spec', 'fixtures', 'image.jpg'))
+      end
+
       trait :unprocessed do
         unprocessed_attachment File.open(Engine.root.join('spec', 'fixtures', 'image.jpg'))
         processed_attachment nil

--- a/spec/helpers/pageflow/social_share_helper_spec.rb
+++ b/spec/helpers/pageflow/social_share_helper_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+module Pageflow
+  describe SocialShareHelper do
+    before :each do
+      @entry = create(:entry, :published)
+      @image1 = create(:image_file, :processed, entry: @entry)
+      @image2 = create(:image_file, :processed, entry: @entry)
+      @image3 = create(:image_file, :processed, entry: @entry)
+    end
+
+    describe '#social_share_entry_image_tags', stub_paperclip: true do
+      it 'renders share image meta tags if share image was chosen' do
+        @entry.published_revision.share_image_id = @image1.id
+        published_entry = PublishedEntry.new(@entry)
+
+        html = helper.social_share_entry_image_tags(published_entry)
+
+        expect(html).to have_css("meta[content=\"#{@image1.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
+        expect(html).to have_css("meta[content=\"#{@image1.thumbnail_url(:medium)}\"][name=\"twitter:image:src\"]", visible: false, count: 1)
+      end
+
+      it 'renders up to three open graph image meta tags for page thumbnails' do
+        published_entry = PublishedEntry.new(@entry)
+        chapter = create(:chapter, revision: @entry.published_revision)
+        create(:page, configuration: { thumbnail_image_id: @image1.id }, chapter: chapter)
+        create(:page, configuration: { thumbnail_image_id: @image2.id }, chapter: chapter)
+        create(:page, configuration: { thumbnail_image_id: @image3.id }, chapter: chapter)
+
+        html = helper.social_share_entry_image_tags(published_entry)
+
+        expect(html).to have_css("meta[content=\"#{@image1.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
+        expect(html).to have_css("meta[content=\"#{@image2.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
+        expect(html).to have_css("meta[content=\"#{@image3.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
+        expect(html).to have_css('meta[property="og:image"]', visible: false, maximum: 3)
+      end
+
+      it 'renders one twitter image meta tag with first page thumbnail' do
+        published_entry = PublishedEntry.new(@entry)
+        chapter = create(:chapter, revision: @entry.published_revision)
+        create(:page, configuration: { thumbnail_image_id: @image1.id }, chapter: chapter)
+        create(:page, configuration: { thumbnail_image_id: @image2.id }, chapter: chapter)
+
+        html = helper.social_share_entry_image_tags(published_entry)
+
+        expect(html).to have_css("meta[content=\"#{@image1.thumbnail_url(:medium)}\"][name=\"twitter:image:src\"]", visible: false)
+        expect(html).to have_css('meta[name="twitter:image:src"]', visible: false, count: 1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the user picks a share image, that very image should be used to share the pageflow. facebook does not offer to choose between multiple images when sharing, so we shouldn't provide alternative images.