### PR TITLE
use ENV for secret keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For a high level introduction and example Pageflow stories see
 [pageflow.io](http://pageflow.io).
 
 In addition to this README, there is also a [Getting Started Wiki page](https://github.com/codevise/pageflow/wiki/Getting-Started)
-to guide you through the steps of setting up a Rails application with Pageflow 
+to guide you through the steps of setting up a Rails application with Pageflow
 on your development machine.
 
 ## Updating
@@ -115,31 +115,35 @@ Pageflow stores files in S3 buckets also in development
 mode. Otherwise there's no way to have Zencoder encode them. See the
 wiki page [Setting up external services](https://github.com/codevise/pageflow/wiki/Setting-up-External-Services).
 
+API keys are configured using environment variables. It's assumed that the
+host application uses [dotenv](https://github.com/bkeepers/dotenv) or [Figaro](https://github.com/laserlemon/figaro) to configure them. You can also
+hard-code the keys in the configuration file directly.
+
 For available configuration options and examples see the inline docs
 in `config/initializers/pageflow.rb` in your generated rails app.
 
 ## Running Pageflow
 
-In addition to the Rails server, you need to start two Rake tasks for 
+In addition to the Rails server, you need to start two Rake tasks for
 the background job processing. First, start a Resque worker which handles
 jobs from all queues:
 
     $ QUEUE=* rake resque:work
-    
+
 Image and video processing are examples of jobs that are executes by these workers.
 
 Some jobs need to be executed repeatedly. For example, while videos are being
-encoded by Zencoder, there is a job that runs every few seconds to fetch the 
+encoded by Zencoder, there is a job that runs every few seconds to fetch the
 current progress. This delayed invocation of jobs is handled by the Resque
 Scheduler Rake task:
 
      $ QUEUE=* rake resque:scheduler
 
 Consider using the [foreman gem](https://github.com/ddollar/foreman) to start all of
-these processes (including the Rails server) with a single command in your 
+these processes (including the Rails server) with a single command in your
 development environment.
 
 ## Troubleshooting
 
-If you run into problems during the installation of Pageflow, please refer to the [Troubleshooting](https://github.com/codevise/pageflow/wiki/Troubleshooting) wiki 
+If you run into problems during the installation of Pageflow, please refer to the [Troubleshooting](https://github.com/codevise/pageflow/wiki/Troubleshooting) wiki
 page. If that doesn't help, consider [filing an issue](https://github.com/codevise/pageflow/issues?state=open).

--- a/lib/generators/pageflow/initializer/templates/pageflow.rb
+++ b/lib/generators/pageflow/initializer/templates/pageflow.rb
@@ -48,23 +48,23 @@ Pageflow.configure do |config|
   # calls are allowed.
   config.paperclip_s3_default_options.merge!(
     :s3_credentials => {
-      :bucket => 'com-example-pageflow-development',
-      :access_key_id => 'xxx',
-      :secret_access_key => 'xxx',
-      :s3_host_name => 's3-eu-west-1.amazonaws.com'
+      :bucket => ENV['S3_BUCKET'],
+      :access_key_id => ENV['S3_ACCESS_KEY'],
+      :secret_access_key => ENV['S3_SECRET_KEY'],
+      :s3_host_name => ENV['S3_HOST_NAME']
     },
-    :s3_host_alias => 'com-example-pageflow.s3-website-eu-west-1.amazonaws.com',
-    :s3_protocol => 'http'
+    :s3_host_alias => ENV['S3_HOST_ALIAS'],
+    :s3_protocol => ENV['S3_PROTOCOL'] || 'http'
   )
 
   # Default options for paperclip attachments which are supposed to
   # use filesystem storage. All options allowed in paperclip has_attached_file
   # calls are allowed.
   config.zencoder_options.merge!(
-    :api_key => 'xxx',
-    :output_bucket => 'com-example-pageflow-out',
-    :s3_host_alias => 'com-example-pageflow-out.s3-website-eu-west-1.amazonaws.com',
-    :s3_protocol => 'http',
+    :api_key => env['ZENCODER_API_KEY'],
+    :output_bucket => ENV['S3_OUTPUT_BUCKET'],
+    :s3_host_alias => ENV['S3_OUTPUT_HOST_ALIAS'],
+    :s3_protocol => ENV['S3_PROTOCOL'] || 'http',
     :attachments_version => 'v1'
   )
 end


### PR DESCRIPTION
Hard-coding secret keys in configuration files isn't good practice.

This pull request assumes the secrets are present in ENV instead. People who are not using ENV can still hard-code them in the file if they want.