### PR TITLE
Use Paperclip 4.2

### DIFF
--- a/app/models/concerns/pageflow/hosted_file.rb
+++ b/app/models/concerns/pageflow/hosted_file.rb
@@ -7,6 +7,9 @@ module Pageflow
       has_attached_file(:attachment_on_filesystem, Pageflow.config.paperclip_filesystem_default_options)
       has_attached_file(:attachment_on_s3, Pageflow.config.paperclip_s3_default_options)
 
+      do_not_validate_attachment_file_type(:attachment_on_filesystem)
+      do_not_validate_attachment_file_type(:attachment_on_s3)
+
       state_machine initial: 'not_uploaded_to_s3' do
         extend StateMachineJob::Macro
 

--- a/app/models/pageflow/image_file.rb
+++ b/app/models/pageflow/image_file.rb
@@ -17,6 +17,9 @@ module Pageflow
                                  :large => "-quality 70 -interlace Plane"
                                }))
 
+    do_not_validate_attachment_file_type(:unprocessed_attachment)
+    do_not_validate_attachment_file_type(:processed_attachment)
+
     after_unprocessed_attachment_post_process :save_image_dimensions
 
     def attachment

--- a/app/models/pageflow/video_file.rb
+++ b/app/models/pageflow/video_file.rb
@@ -28,6 +28,10 @@ module Pageflow
                                  :large => "-quality 60 -interlace Plane"
                                }))
 
+
+    do_not_validate_attachment_file_type(:poster)
+    do_not_validate_attachment_file_type(:thumbnail)
+
     def thumbnail_url(*args)
       poster.url(*args)
     end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -5,12 +5,12 @@ Pageflow.configure do |config|
   config.paperclip_filesystem_root = Rails.root.join('tmp/attachments/production/')
 
   if Rails.env.test?
-    config.paperclip_s3_default_options = {
+    config.paperclip_s3_default_options.merge!({
       :storage => :filesystem,
       :path => ':rails_root/tmp/attachments/test/s3/:class/:attachment/:id_partition/:style/:filename'
-    }
+    })
   else
-    config.paperclip_s3_default_options = {
+    config.paperclip_s3_default_options.merge!({
       :storage => :s3,
       :s3_headers => {'Expires' => 1.year.from_now.httpdate},
       :s3_options => {:max_retries => 10},
@@ -24,14 +24,14 @@ Pageflow.configure do |config|
       # master, but for us not deleting old files is good enough. They
       # might be in the CDN anyway.
       :keep_old_files => true
-    }
+    })
   end
 
-  config.paperclip_filesystem_default_options = {
+  config.paperclip_filesystem_default_options.merge!({
     :storage => :filesystem,
     :path => ':pageflow_filesystem_root/:class/:attachment/:id_partition/:style/:filename',
     :url => 'not_uploaded_yet'
-  }
+  })
 
   config.thumbnail_styles = {
     thumbnail: {

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -168,8 +168,8 @@ module Pageflow
     attr_accessor :available_locales
 
     def initialize
-      @paperclip_filesystem_default_options = {}
-      @paperclip_s3_default_options = {}
+      @paperclip_filesystem_default_options = {validate_media_type: false}
+      @paperclip_s3_default_options = {validate_media_type: false}
 
       @zencoder_options = {}
 

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'state_machine_job', '~> 0.2.0'
 
   # File attachments
-  s.add_dependency 'paperclip', '~> 3.5'
+  s.add_dependency 'paperclip', '~> 4.2'
 
   # zencoder
   s.add_dependency 'zencoder', '~> 2.5'


### PR DESCRIPTION
* Paperclip 3.5 did not clean up tempfiles correctly when processing
  thumbnails
* Disable all content type checks for now to prevent regressions.