### PR TITLE
Also mention teaspoon version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'formtastic', '2.3.0'
 
 # Ensure that teaspoon is required via Bundler.require inside the
 # dummy app. Otherwise teaspoon fails to initialize correctly.
-gem 'teaspoon'
+gem 'teaspoon', '~> 0.9.0'
 
 gem 'spring-commands-rspec', group: :development
 gem 'spring-commands-teaspoon', group: :development


### PR DESCRIPTION
Seems to override version given in gemspec. Causing it to use
arbitrary teaspoon versions when running tests.