### PR TITLE
Require pageflow/object.js from pageflow/ui.js

### DIFF
--- a/app/assets/javascripts/pageflow/ui.js
+++ b/app/assets/javascripts/pageflow/ui.js
@@ -6,6 +6,7 @@
 //= require i18n/translations
 
 //= require ./ui/renderer
+//= require ./ui/object
 
 //= require_tree ./ui/views/mixins
 //= require ./ui/views/inputs/select_input_view


### PR DESCRIPTION
Some plugins expect `pageflow.Object` to be defined after requiring
`pageflow/ui`.