### PR TITLE
Improve Entry File Rights Helper

### DIFF
--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -7,11 +7,11 @@ module Pageflow
     end
 
     def entry_file_rights(entry)
-      rights = [:audio_files, :image_files, :video_files].map do |collection|
-        entry.send(collection).map do |file|
-          file.rights.presence || entry.account.default_file_rights
+      rights = Pageflow.config.file_types.map do |file_type|
+        entry.files(file_type.model).map do |file|
+          file.rights.presence || entry.account.default_file_rights.presence
         end
-      end.flatten.sort.uniq
+      end.flatten.compact.sort.uniq
 
       if rights.any?
         content_tag :p, class: 'rights' do

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -40,6 +40,51 @@ module Pageflow
       end
     end
 
+    describe '#entry_file_rights' do
+      it 'returns comma separated list of file rights' do
+        revision = create(:revision)
+        image_file = create(:image_file, rights: 'My Company', used_in: revision)
+        image_file = create(:image_file, rights: 'My Photographer', used_in: revision)
+        entry = PublishedEntry.new(create(:entry), revision)
+
+        result = helper.entry_file_rights(entry)
+
+        expect(result).to include(': My Company, My Photographer')
+      end
+
+      it 'falls back to default file rights' do
+        revision = create(:revision)
+        image_file = create(:image_file, used_in: revision)
+        account = create(:account, default_file_rights: 'My Account')
+        entry = PublishedEntry.new(create(:entry, account: account), revision)
+
+        result = helper.entry_file_rights(entry)
+
+        expect(result).to include(': My Account')
+      end
+
+      it 'does not insert extra comma if a file has no rights and defaults are not configured' do
+        revision = create(:revision)
+        image_file = create(:image_file, used_in: revision)
+        image_file = create(:image_file, rights: 'My Photographer', used_in: revision)
+        entry = PublishedEntry.new(create(:entry), revision)
+
+        result = helper.entry_file_rights(entry)
+
+        expect(result).to include(': My Photographer')
+      end
+
+      it 'returns empty string if no rights are defined' do
+        revision = create(:revision)
+        image_file = create(:image_file, used_in: revision)
+        entry = PublishedEntry.new(create(:entry), revision)
+
+        result = helper.entry_file_rights(entry)
+
+        expect(result).to eq('')
+      end
+    end
+
     describe '#entry_stylesheet_link_tag' do
       it 'returns revision css for published entry with custom revision' do
         revision = build_stubbed(:revision)


### PR DESCRIPTION
* Do not render a leading comma if no default file rights are defined
  for the account.
* Include rights of all registered file types.