### PR TITLE
Allow Overriding Attachments Scope Name

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -72,7 +72,7 @@ if Rails.env.development?
   end
 
   Paperclip.interpolates(:host) do |attachment, style|
-    Socket.gethostname
+    ENV.fetch('PAGEFLOW_ATTACHMENTS_SCOPE_NAME') { Socket.gethostname }
   end
 end
 


### PR DESCRIPTION
Inside the development buckets assets are stored in developer specific
directories to prevent id clashes. By default the host name of the
development machine is used. This variable allows overriding the
directory name.