### PR TITLE
Only Protect HTML Format with Password

### DIFF
--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -22,7 +22,9 @@ module Pageflow
           @entry = PublishedEntry.find(params[:id], entry_request_scope)
           I18n.locale = @entry.locale
 
-          check_entry_password(@entry) if @entry.password_protected?
+          if request.format.html? && @entry.password_protected?
+            check_entry_password(@entry)
+          end
 
           if params[:page].present?
             @entry.share_target = Page.find_by_perma_id(params[:page])

--- a/spec/controllers/pageflow/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/entries_controller_spec.rb
@@ -263,6 +263,14 @@ module Pageflow
           expect(response.status).to eq(200)
         end
 
+        it 'responds with success for entry published with password' do
+          entry = create(:entry, :published_with_password, password: 'abc123abc')
+
+          get(:show, :id => entry, :format => 'css')
+
+          expect(response.status).to eq(200)
+        end
+
         it 'responds with not found for not published entry' do
           entry = create(:entry)
 


### PR DESCRIPTION
CDNs cannot handle basic auth protected origin.