### PR TITLE
Disable Bandwidth Feature Detection in Test Environment

### DIFF
--- a/app/assets/javascripts/pageflow/browser.js
+++ b/app/assets/javascripts/pageflow/browser.js
@@ -78,7 +78,7 @@ pageflow.browser = (function(){
 
       var asyncHas = function(name) {
         var runTest = function() {
-          if (pageflow.debugMode() &&
+          if ((pageflow.debugMode() || pageflow.ALLOW_FEATURE_OVERRIDES) &&
               window.localStorage &&
               typeof window.localStorage['override ' + name] !== 'undefined') {
             var value = (window.localStorage['override ' + name] === 'on');

--- a/spec/javascripts/support/fake_browser_features.js
+++ b/spec/javascripts/support/fake_browser_features.js
@@ -1,0 +1,2 @@
+pageflow.ALLOW_FEATURE_OVERRIDES = true;
+pageflow.browser.on.high_bandwidth();


### PR DESCRIPTION
Make sure feature detection finishes synchronously. Otherwise
components depending on features cannot be tested before detection is
finished.