### PR TITLE
Save TextInputView on Close

### DIFF
--- a/app/assets/javascripts/pageflow/ui/views/inputs/text_input_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/inputs/text_input_view.js
@@ -24,6 +24,10 @@ pageflow.TextInputView = Backbone.Marionette.ItemView.extend({
     this.save();
   },
 
+  onClose: function() {
+    this.save();
+  },
+
   save: function() {
     this.model.set(this.options.propertyName, this.ui.input.val());
   },


### PR DESCRIPTION
Sometimes the change event is not fired even though the view has been
edited.