### PR TITLE
Fix Paperclip Version to 4.2 until 4.3 Issues are Resolved

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'state_machine_job', '~> 0.2.0'
 
   # File attachments
-  s.add_dependency 'paperclip', '~> 4.2'
+  s.add_dependency 'paperclip', '~> 4.2.4'
 
   # zencoder
   s.add_dependency 'zencoder', '~> 2.5'


### PR DESCRIPTION
Backport of #307 to 0.8 series

Paperclip 4.3 introduces some backward incompatible changes. See
thoughtbot/paperclip#1904.