### PR TITLE
Options for Configuration Editor Tab Groups

### DIFF
--- a/app/assets/javascripts/pageflow/ui/views/configuration_editor_tab_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/configuration_editor_tab_view.js
@@ -20,8 +20,8 @@ pageflow.ConfigurationEditorTabView = Backbone.Marionette.View.extend({
     }, options || {})));
   },
 
-  group: function(name) {
-    this.groups.apply(name, this);
+  group: function(name, options) {
+    this.groups.apply(name, this, options);
   },
 
   render: function() {
@@ -50,12 +50,12 @@ pageflow.ConfigurationEditorTabView.Groups = function() {
     groups[name] = fn;
   };
 
-  this.apply = function(name, context) {
+  this.apply = function(name, context, options) {
     if (!(name in groups)) {
       throw 'Undefined group named "' + name + '".';
     }
 
-    groups[name].call(context);
+    groups[name].call(context, options || {});
   };
 };
 


### PR DESCRIPTION
Allow passing options when using predefined configuration editor tab
groups.