### PR TITLE
Impove Image Preloading

### DIFF
--- a/app/assets/javascripts/pageflow/preload.js
+++ b/app/assets/javascripts/pageflow/preload.js
@@ -12,17 +12,20 @@
     },
 
     backgroundImage: function(element) {
-      $(element).parent().addClass('load_images');
+      var that = this;
+      var promises = [];
 
-      if ($(element).length) {
-        var propertyValue = window.getComputedStyle($(element)[0]).getPropertyValue('background-image');
+      $(element).addClass('load_image');
+
+      $(element).each(function() {
+        var propertyValue = window.getComputedStyle(this).getPropertyValue('background-image');
 
         if (propertyValue.match(/^url/)) {
-          return this.image(propertyValue.replace(/^url\(['"]?/, '').replace(/['"]?\)$/, ''));
+          promises.push(that.image(propertyValue.replace(/^url\(['"]?/, '').replace(/['"]?\)$/, '')));
         }
-      }
+      });
 
-      return $.Deferred().resolve().promise();
+      return $.when.apply(null, promises);
     }
   };
 }());

--- a/app/helpers/pageflow/background_image_helper.rb
+++ b/app/helpers/pageflow/background_image_helper.rb
@@ -16,6 +16,11 @@ module Pageflow
       end
     end
 
+    def background_image_lazy_loading_css_class(prefix, model)
+      css_class = [prefix, model.id].join('_')
+      ".load_all_images .#{css_class}, .load_image.#{css_class}"
+    end
+
     class Div
       FILE_TYPE_CSS_CLASS_PREFIXES = {
         'image_file' => 'image',

--- a/app/views/layouts/pageflow/application.html.erb
+++ b/app/views/layouts/pageflow/application.html.erb
@@ -17,9 +17,9 @@
 
   <%= render 'layouts/pageflow/ie_include_tags' %>
 </head>
-<%= content_tag :body, :class => [@body_class, 'load_images has_no_mobile_platform non_js'].compact.flatten.join(' ') do %>
+<%= content_tag :body, :class => [@body_class, 'load_all_images has_no_mobile_platform non_js'].compact.flatten.join(' ') do %>
   <script>
-    jQuery('body').removeClass('load_images');
+    jQuery('body').removeClass('load_all_images');
     jQuery("body").removeClass('non_js').addClass('js');
   </script>
   <%= yield %>

--- a/app/views/pageflow/entries/show.css.erb
+++ b/app/views/pageflow/entries/show.css.erb
@@ -3,13 +3,13 @@
     <% page_media_breakpoints.each do |style, condition| %>
       <%= media_query(condition) do %>
         <% @entry.image_files.each do |image_file| %>
-          .load_images .image_<%= image_file.id %> {
+          <%= background_image_lazy_loading_css_class('image', image_file) %> {
             background-image: url('<%= image_file.attachment.url(style) %>');
           }
         <% end %>
 
         <% @entry.video_files.each do |video_file| %>
-          .load_images .video_poster_<%= video_file.id %> {
+          <%= background_image_lazy_loading_css_class('video_poster', video_file) %> {
             background-image: url('<%= video_file.poster.url(style) %>');
           }
         <% end %>
@@ -19,7 +19,7 @@
     <% page_media_breakpoints.each do |style, condition| %>
       <%= media_query(condition) do %>
         <% @entry.image_files.each do |image_file| %>
-          .load_images .image_panorama_<%= image_file.id %> {
+          <%= background_image_lazy_loading_css_class('image_panorama', image_file) %> {
             background-image: url('<%= image_file.attachment.url("panorama_#{style}") %>');
           }
         <% end %>

--- a/spec/helpers/pageflow/background_image_helper_spec.rb
+++ b/spec/helpers/pageflow/background_image_helper_spec.rb
@@ -82,5 +82,15 @@ module Pageflow
         expect(html).to have_selector('div.background_image[data-width="123"][data-height="456"]')
       end
     end
+
+    describe '#background_image_lazy_loading_css_class' do
+      it 'returns css classes prefixed with .load_all_images and .load_image' do
+        image_file = create(:image_file)
+
+        css_class = helper.background_image_lazy_loading_css_class('image', image_file)
+
+        expect(css_class).to eq(".load_all_images .image_#{image_file.id}, .load_image.image_#{image_file.id}")
+      end
+    end
   end
 end


### PR DESCRIPTION
* Trigger preloading of all matched images not only first
* Use css class on same element not parent, to workaround cases were
  chrome does not notice that a parent class changed and fails to
  load images.