### PR TITLE
Set lock-showing Class Initially

### DIFF
--- a/app/assets/javascripts/pageflow/page_types/video.js
+++ b/app/assets/javascripts/pageflow/page_types/video.js
@@ -185,6 +185,8 @@ pageflow.pageType.register('video', _.extend({
           scrollIndicator = $('.entry .scroll_indicator'),
           pageContent = pageElement.find('.scroller, .controls, .shadow');
 
+      pageContent.addClass('lock-showing');
+
       videoPlayer.on("pause", function() {
         pageContent.addClass('lock-showing');
 


### PR DESCRIPTION
The state before playback starts should be equal to when playback
paused.