### PR TITLE
Focussed CSS Class For Video Player Controls

### DIFF
--- a/app/assets/javascripts/pageflow/page_types/video.js
+++ b/app/assets/javascripts/pageflow/page_types/video.js
@@ -158,6 +158,16 @@ pageflow.pageType.register('video', _.extend({
         }
       });
 
+      controls.find('a, [tabindex]').on({
+        focus: function() {
+          controls.addClass('focussed');
+        },
+
+        blur: function() {
+          controls.removeClass('focussed');
+        }
+      });
+
       videoPlayer.on('bufferunderrun', function() {
         loadingSpinner.addClass('showing-for-underrun');
       });


### PR DESCRIPTION
Allow to display faded video controls when focus enters.