### PR TITLE
Do not Rely on Events to Set Audio Player Playing State

### DIFF
--- a/vendor/assets/javascripts/audio5.min.js
+++ b/vendor/assets/javascripts/audio5.min.js
@@ -546,14 +546,12 @@
      * Audio play event handler. Triggered when audio starts playing.
      */
     onPlay: function () {
-      this.playing = true;
       this.trigger('play');
     },
     /**
      * Audio pause event handler. Triggered when audio is paused.
      */
     onPause: function () {
-      this.playing = false;
       this.trigger('pause');
     },
     /**
@@ -640,12 +638,14 @@
      * Play audio
      */
     play: function () {
+      this.playing = true;
       this.audio.play();
     },
     /**
      * Pause audio
      */
     pause: function () {
+      this.playing = false;
       this.audio.pause();
     },
     /**
@@ -816,6 +816,7 @@
      */
     play: function () {
       if(!this.playing){
+        this.playing = true;
         this.audio.play();
       }
     },
@@ -824,6 +825,7 @@
      */
     pause: function () {
       if(this.playing){
+        this.playing = false;
         this.audio.pause();
       }
     },
@@ -881,24 +883,26 @@
      * Audio play event handler
      */
     onPlay: function () {
-      this.playing = true;
       this.trigger('play');
     },
     /**
      * Audio pause event handler
      */
     onPause: function () {
-      this.playing = false;
       this.trigger('pause');
     },
     /**
      * Playback end event handler
      */
     onEnded: function () {
-      this.playing = false;
-      this.trigger('ended');
-      if(this.settings.loop) {
-        this.play();
+      var wasPlaying = this.playing;
+
+      if (this.settings.loop && wasPlaying) {
+        this.audio.play();
+      }
+      else {
+        this.playing = false;
+        this.trigger('ended');
       }
     },
     /**


### PR DESCRIPTION
* Events sometimes fire late
* If loop option was set, the audio restarted even though it was
  paused.