### PR TITLE
add spec/fixtures path to gem files list

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://www.pageflow.io'
   s.summary     = 'Multimedia story telling for the web.'
 
-  s.files = Dir['{admins,app,config,db,lib,vendor,spec/factories}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
+  s.files = Dir['{admins,app,config,db,lib,vendor,spec/factories,spec/fixtures}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'rails', '>= 4.0.2', '< 4.2'


### PR DESCRIPTION
This fixes a problem where the host application's test fail when
FactoryGirl is used there.

Backport of #368