### PR TITLE
Remove test_files Attribute from Gemspec

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = 'Multimedia story telling for the web.'
 
   s.files = Dir['{admins,app,config,db,lib,vendor,spec/factories,spec/fixtures}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
-  s.test_files = Dir['test/**/*']
 
   s.add_dependency 'rails', '>= 4.0.2', '< 4.2'
 


### PR DESCRIPTION
* The glob given so far did not match any files.
* The `test_files` attribute it self is no longer present in the gemspec docs and does not serve any special purpose in our case.