### PR TITLE
Include Readme and Changelog in Gemspec

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://www.pageflow.io'
   s.summary     = 'Multimedia story telling for the web.'
 
-  s.files = Dir['{admins,app,config,db,lib,vendor,spec/factories,spec/fixtures}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
+  s.files = Dir['{admins,app,config,db,lib,vendor,spec/factories,spec/fixtures}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md', 'CHANGELOG.md']
 
   s.add_dependency 'rails', '>= 4.0.2', '< 4.2'
 


### PR DESCRIPTION
Change `files` attribute in gemspec to include the readme and the changelog file.