### PR TITLE
Duplicating Entries

### DIFF
--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -60,8 +60,30 @@ module Pageflow
         button_to(I18n.t('pageflow.admin.entries.depublish'),
                   pageflow.current_entry_revisions_path(entry),
                   :method => :delete,
-                  :data => {:rel => 'depublish', :confirm => I18n.t('pageflow.admin.entries.confirm_depublish')})
+                  :data => {
+                    :rel => 'depublish',
+                    :confirm => I18n.t('pageflow.admin.entries.confirm_depublish')
+                  })
       end
+    end
+
+    action_item :only => :show do
+      if authorized?(:duplicate, entry)
+        button_to(I18n.t('pageflow.admin.entries.duplicate'),
+                  duplicate_admin_entry_path(entry),
+                  :method => :post,
+                  :data => {
+                    :rel => 'duplicate',
+                    :confirm => I18n.t('pageflow.admin.entries.confirm_duplicate')
+                  })
+      end
+    end
+
+    member_action :duplicate, :method => :post do
+      entry = Entry.find(params[:id])
+      authorize!(:duplicate, entry)
+      new_entry = entry.duplicate
+      redirect_to(edit_admin_entry_path(new_entry))
     end
 
     member_action :snapshot, :method => :post do

--- a/app/models/pageflow/entry.rb
+++ b/app/models/pageflow/entry.rb
@@ -37,7 +37,9 @@ module Pageflow
     scope :published, -> { joins(:published_revision) }
     scope :editing, -> { joins(:edit_lock).merge(Pageflow::EditLock.active) }
 
-    after_create do
+    attr_accessor :skip_draft_creation
+
+    after_create unless: :skip_draft_creation do
       create_draft!(home_button_enabled: theming.home_button_enabled_by_default)
       theming.widgets.copy_all_to(draft)
     end
@@ -86,6 +88,10 @@ module Pageflow
         revision.published_until = nil
         revision.password_protected = nil
       end
+    end
+
+    def duplicate
+      EntryDuplicate.of(self).create!
     end
 
     def published?

--- a/app/models/pageflow/entry_duplicate.rb
+++ b/app/models/pageflow/entry_duplicate.rb
@@ -1,0 +1,50 @@
+module Pageflow
+  class EntryDuplicate < Struct.new(:original_entry)
+    def create!
+      create_entry
+
+      copy_draft
+      copy_memberships
+
+      new_entry
+    end
+
+    def self.of(entry)
+      new(entry)
+    end
+
+    private
+
+    attr_reader :new_entry
+
+    def create_entry
+      @new_entry = Entry.create!(new_attributes)
+    end
+
+    def copy_draft
+      original_entry.draft.copy do |revision|
+        revision.entry = new_entry
+      end
+    end
+
+    def copy_memberships
+      original_entry.users.each do |member|
+        new_entry.memberships.create(user: member)
+      end
+    end
+
+    def new_attributes
+      {
+        title: new_title,
+        account: original_entry.account,
+        theming: original_entry.theming,
+
+        skip_draft_creation: true
+      }
+    end
+
+    def new_title
+      I18n.t('pageflow.entry.duplicated_title', title: original_entry.title)
+    end
+  end
+end

--- a/config/locales/new/duplicate_entry.yml
+++ b/config/locales/new/duplicate_entry.yml
@@ -1,0 +1,17 @@
+de:
+  pageflow:
+    entry:
+      duplicated_title: "Kopie von %{title}"
+    admin:
+      entries:
+        duplicate: "Beitrag kopieren"
+        confirm_duplicate: "Beitrag wirklich duplizieren?"
+
+en:
+  pageflow:
+    entry:
+      duplicated_title: "Copy of %{title}"
+    admin:
+      entries:
+        duplicate: "Copy Story"
+        confirm_duplicate: "Duplicate this story?"

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -297,4 +297,50 @@ describe Admin::EntriesController do
       }.not_to change { entry.revisions.count }
     end
   end
+
+  describe '#duplicate' do
+    it 'does not allow account manager to duplicate entries of other account' do
+      account = create(:account)
+      entry = create(:entry)
+
+      sign_in(create(:user, :account_manager))
+
+      expect {
+        post(:duplicate, :id => entry.id)
+      }.not_to change { Pageflow::Entry.count }
+    end
+
+    it 'allows account manager to duplicate entries of own account' do
+      user = create(:user, :account_manager)
+      entry = create(:entry, :account => user.account)
+
+      sign_in(user)
+
+      expect {
+        post(:duplicate, :id => entry.id)
+      }.to change { Pageflow::Entry.count }
+    end
+
+    it 'allows admin to duplicate entries of other accounts' do
+      account = create(:account)
+      entry = create(:entry)
+
+      sign_in(create(:user, :admin))
+
+      expect {
+        post(:duplicate, :id => entry.id)
+      }.to change { Pageflow::Entry.count }
+    end
+
+    it 'does not allows editor to duplicate entries even as a member' do
+      user = create(:user, :editor)
+      entry = create(:entry, :with_member => user, :account => user.account)
+
+      sign_in(user)
+
+      expect {
+        post(:duplicate, :id => entry.id)
+      }.not_to change { Pageflow::Entry.count }
+    end
+  end
 end

--- a/spec/features/account_manager/duplicating_an_entry_spec.rb
+++ b/spec/features/account_manager/duplicating_an_entry_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+feature 'account manager duplicating an entry' do
+  scenario 'from own account' do
+    account = create(:account)
+    entry = create(:entry, :title => 'Test Entry', :account => account)
+
+    Dom::Admin::Page.sign_in_as(:account_manager, :account => account)
+
+    visit(admin_entry_path(entry))
+    Dom::Admin::EntryPage.first.duplicate_button.click
+    Dom::Admin::EntryForm.first.submit_with(:title => 'My Copy of Test Title')
+
+    expect(Dom::Admin::EntryPage.first.title).to eq('My Copy of Test Title')
+  end
+end

--- a/spec/features/admin/duplicating_an_entry_spec.rb
+++ b/spec/features/admin/duplicating_an_entry_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+feature 'admin duplicating an entry' do
+  scenario 'from other account' do
+    entry = create(:entry, :title => 'Test Entry')
+
+    Dom::Admin::Page.sign_in_as(:admin)
+
+    visit(admin_entry_path(entry))
+    Dom::Admin::EntryPage.first.duplicate_button.click
+    Dom::Admin::EntryForm.first.submit_with(:title => 'My Copy of Test Title')
+
+    expect(Dom::Admin::EntryPage.first.title).to eq('My Copy of Test Title')
+  end
+end

--- a/spec/models/pageflow/entry_duplicate_spec.rb
+++ b/spec/models/pageflow/entry_duplicate_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+module Pageflow
+  describe EntryDuplicate do
+    describe '#create!' do
+      it 'creates an entry with a title containing the original title' do
+        entry = create(:entry, title: 'Some Title')
+
+        duplicate = EntryDuplicate.of(entry).create!
+
+        expect(duplicate).to be_persisted
+        expect(duplicate.title).to include('Some Title')
+      end
+
+      it 'creates entry with same account and theming' do
+        entry = create(:entry)
+
+        duplicate = EntryDuplicate.of(entry).create!
+
+        expect(duplicate.account).to eq(entry.account)
+        expect(duplicate.theming).to eq(entry.theming)
+      end
+
+      it 'copies draft' do
+        entry = create(:entry, title: 'Some Title')
+        create(:chapter, revision: entry.draft, title: 'Original Chapter')
+
+        duplicate = EntryDuplicate.of(entry).create!
+
+        expect(duplicate.draft.chapters.map(&:title)).to eq(['Original Chapter'])
+      end
+
+      it 'copies memberships' do
+        user = create(:user)
+        entry = create(:entry, with_member: user)
+
+        duplicate = EntryDuplicate.of(entry).create!
+
+        expect(duplicate.users.first).to eq(user)
+      end
+    end
+  end
+end

--- a/spec/models/pageflow/entry_spec.rb
+++ b/spec/models/pageflow/entry_spec.rb
@@ -9,6 +9,12 @@ module Pageflow
         expect(entry.draft).to be_present
       end
 
+      it 'can skip draft creation' do
+        entry = create(:entry, skip_draft_creation: true)
+
+        expect(entry.draft).to be_blank
+      end
+
       it 'sets draft home_button_enabled to home_button_enabled_by_default of accounts default_theming' do
         theming = create(:theming, home_button_enabled_by_default: true)
         entry = create(:entry, theming: theming)
@@ -347,6 +353,16 @@ module Pageflow
 
         expect(revision.snapshot_type).to eq('user')
       end
+    end
+  end
+
+  describe '#duplicate' do
+    it 'creates a new entry' do
+      entry = create(:entry)
+
+      expect {
+        entry.duplicate
+      }.to change { Entry.count }
     end
   end
 end

--- a/spec/support/dominos/admin/entry_page.rb
+++ b/spec/support/dominos/admin/entry_page.rb
@@ -47,6 +47,12 @@ module Dom
         end
       end
 
+      def duplicate_button
+        within(node) do
+          find('[data-rel=duplicate]')
+        end
+      end
+
       def self.visit_revisions(entry)
         url_helpers = Rails.application.routes.url_helpers
         visit(url_helpers.admin_entry_path(entry, tab: 'revisions'))


### PR DESCRIPTION
Let admin and account manager user create copies of existing
entries. Copy draft and memberships to new entry.

This feature can used to create a collection of template entries.