### PR TITLE
Find Share Target Page in Published Revision

### DIFF
--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -27,7 +27,7 @@ module Pageflow
           end
 
           if params[:page].present?
-            @entry.share_target = Page.find_by_perma_id(params[:page])
+            @entry.share_target = @entry.pages.find_by_perma_id(params[:page])
           else
             @entry.share_target = @entry
           end

--- a/spec/controllers/pageflow/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/entries_controller_spec.rb
@@ -223,7 +223,7 @@ module Pageflow
 
           get(:show, :id => entry)
 
-          expect(response.body).to have_selector('head meta[name=some_test]', :visible => false)
+          expect(response.body).to have_meta_tag.with_name('some_test')
         end
 
         context 'with configured entry_request_scope' do
@@ -250,6 +250,20 @@ module Pageflow
             get(:show, :id => entry)
 
             expect(response.status).to eq(404)
+          end
+        end
+
+        context 'with page parameter' do
+          it 'renders social sharing meta tags for page' do
+            entry = create(:entry, :published)
+            chapter = create(:chapter, :revision => entry.published_revision)
+            page = create(:page, :configuration => {:title => 'Shared page'}, :chapter => chapter)
+
+            get(:show, :id => entry, :page => page.perma_id)
+
+            expect(response.body).to have_meta_tag
+              .for_property('og:title')
+              .with_content_including('Shared page')
           end
         end
       end

--- a/spec/controllers/pageflow/revisions_controller_spec.rb
+++ b/spec/controllers/pageflow/revisions_controller_spec.rb
@@ -35,7 +35,7 @@ module Pageflow
         get(:show, :id => revision)
 
         expect(response.body).to have_selector('div.test_widget')
-        expect(response.body).to have_selector('head meta[name=some_test]', :visible => false)
+        expect(response.body).to have_meta_tag.with_name('some_test')
       end
 
       it 'does not render widgets which are disabled in preview' do

--- a/spec/support/matchers/have_meta_tag.rb
+++ b/spec/support/matchers/have_meta_tag.rb
@@ -1,0 +1,21 @@
+RSpec::Matchers.define :have_meta_tag do
+  match do |body|
+    Capybara.string(body).has_selector?(selectors.join(''), visible: false)
+  end
+
+  chain :with_name do |value|
+    selectors << "[name='#{value}']"
+  end
+
+  chain :for_property do |value|
+    selectors << "[property='#{value}']"
+  end
+
+  chain :with_content_including do |value|
+    selectors << "[content~='#{value}']"
+  end
+
+  def selectors
+    @selectors ||= ['head meta']
+  end
+end


### PR DESCRIPTION
fixes #373

The find was not scoped before causing pages from the draft to be used in the social media tags when a page share target was passed.