### PR TITLE
Fix Copyright Links in Mobile Navigation

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/navigation_mobile.js
+++ b/app/assets/javascripts/pageflow/widgets/navigation_mobile.js
@@ -29,6 +29,10 @@
         $(element).removeClass('sharing');
       });
 
+      $('.imprint_mobile a', element).on('click touchstart', function(event) {
+        event.stopPropagation();
+      });
+
       $('.wrapper', element).each(function() {
         var sharingMobile = $(this).parents('.sharing_mobile');
 


### PR DESCRIPTION
iScroll prevents default on touch events causing links in the credits text and copyright links to be no-op. While there needs to be a more general solution to this problem, stopping propagation on those links
at least makes them clickable for now.