### PR TITLE
Fix bug related to Underscore.js

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/mixins/stage_provider.js
+++ b/app/assets/javascripts/pageflow/editor/models/mixins/stage_provider.js
@@ -1,8 +1,9 @@
 pageflow.stageProvider = {
   initialize: function() {
     var finishedStates = [this.readyState];
+    var stages = _.result(this, 'stages') || [];
 
-    this.stages = new Backbone.Collection(_.chain(this).result('stages').slice().reverse().map(function (options) {
+    this.stages = new Backbone.Collection(_.chain(stages).slice().reverse().map(function (options) {
       var name = options.name;
 
       options.file = this;


### PR DESCRIPTION
Calling `slice` in an Underscore chain on an undefined value works in some browsers, but fails in others. Some tests rely on `UploadedFile` models with an undefined `stages` array. Then the `stageProvider` failed while trying to process stages.