### PR TITLE
Make EditWidgetView handle widgets with no available widget types

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/edit_widget_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_widget_view.js
@@ -12,7 +12,7 @@ pageflow.EditWidgetView = Backbone.Marionette.Layout.extend({
   },
 
   onRender: function() {
-    var widgetTypes = this.options.widgetTypes[this.model.role()];
+    var widgetTypes = this.options.widgetTypes[this.model.role()] || [];
 
     this.widgetTypeContainer.show(new pageflow.SelectInputView({
       model: this.model,


### PR DESCRIPTION
Do not fail if the entry has a a widget with current widget type null
and no available widget types. Simply hide the select.