### PR TITLE
fix theme name replacement in generator

### DIFF
--- a/lib/generators/pageflow/theme/theme_generator.rb
+++ b/lib/generators/pageflow/theme/theme_generator.rb
@@ -13,9 +13,10 @@ module Pageflow
         directory('images/pageflow/themes/default', themes_path('images', name))
 
         template('stylesheets/pageflow/themes/default.css.scss', themes_path('stylesheets', "#{name}.css.scss")) do |content|
-          content.gsub!('$theme-name: "default";', %Q'$theme-name: "#{name}";')
           content.gsub!('@import "./default/', %Q'@import "./#{name}/')
         end
+
+        gsub_file themes_path('stylesheets', "#{name}/variables.css.scss"), '$theme-name: "default";', %Q'$theme-name: "#{name}";'
       end
 
       private


### PR DESCRIPTION
fixes #384 

In commit a0ad811 the generator was refactored, the contents of the main
stylesheet were moved into variables.css.scss. This change fixes the
generator so that the generated theme name is replaced again.