### PR TITLE
Implement loading spinner for file reuse panel

### DIFF
--- a/app/assets/javascripts/pageflow/editor/templates/files_explorer.jst.ejs
+++ b/app/assets/javascripts/pageflow/editor/templates/files_explorer.jst.ejs
@@ -2,8 +2,8 @@
   <h2><%= I18n.t('pageflow.editor.templates.files_explorer.reuse_files') %></h2>
 
   <div class="panels">
-    <div class="entries_panel">
-    </div>
+    <ul class="entries_panel">
+    </ul>
 
     <div class="files_panel">
     </div>

--- a/app/assets/javascripts/pageflow/editor/templates/loading.jst.ejs
+++ b/app/assets/javascripts/pageflow/editor/templates/loading.jst.ejs
@@ -1,1 +1,7 @@
-<li class="loading"><%= I18n.t('pageflow.editor.templates.loading.loading') %></li>
+<div class="spinner">
+  <div class="rect1"></div>
+  <div class="rect2"></div>
+  <div class="rect3"></div>
+  <div class="rect4"></div>
+  <div class="rect5"></div>
+</div>

--- a/app/assets/javascripts/pageflow/editor/templates/other_entries_blank_slate.jst.ejs
+++ b/app/assets/javascripts/pageflow/editor/templates/other_entries_blank_slate.jst.ejs
@@ -1,1 +1,1 @@
-<li class="blank_slate"><%= I18n.t('pageflow.editor.templates.other_entries_blank_slate.none_available') %><li>
+<%= I18n.t('pageflow.editor.templates.other_entries_blank_slate.none_available') %>

--- a/app/assets/javascripts/pageflow/editor/views/loading_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/loading_view.js
@@ -1,0 +1,5 @@
+pageflow.LoadingView = Backbone.Marionette.ItemView.extend({
+  template: 'pageflow/editor/templates/loading',
+  className: 'loading',
+  tagName: 'li'
+});

--- a/app/assets/javascripts/pageflow/editor/views/other_entries_collection_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/other_entries_collection_view.js
@@ -18,11 +18,11 @@ pageflow.OtherEntriesCollectionView = Backbone.Marionette.View.extend({
         selection: this.options.selection
       },
       blankSlateViewConstructor: Backbone.Marionette.ItemView.extend({
-        template: 'templates/other_entries_blank_slate'
+        template: 'templates/other_entries_blank_slate',
+        tagName: 'li',
+        className: 'blank_slate'
       }),
-      loadingViewConstructor: Backbone.Marionette.ItemView.extend({
-        template: 'templates/loading'
-      })
+      loadingViewConstructor: pageflow.LoadingView
     }));
 
     this.otherEntries.fetch();

--- a/app/assets/javascripts/pageflow/editor/views/other_entry_item_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/other_entry_item_view.js
@@ -1,6 +1,7 @@
 pageflow.OtherEntryItemView = Backbone.Marionette.ItemView.extend({
   template: 'templates/other_entry_item',
   className: 'other_entry_item',
+  tagName: 'li',
 
   mixins: [pageflow.selectableView],
 
@@ -9,7 +10,7 @@ pageflow.OtherEntryItemView = Backbone.Marionette.ItemView.extend({
   },
 
   events: {
-   'click': 'select'
+    'click': 'select'
   },
 
   onRender: function() {

--- a/app/assets/stylesheets/pageflow/animations.css.scss
+++ b/app/assets/stylesheets/pageflow/animations.css.scss
@@ -2,3 +2,4 @@
 @import "animations/bounce";
 @import "animations/fade";
 @import "animations/scroll";
+@import "animations/loading";

--- a/app/assets/stylesheets/pageflow/animations/loading.css.scss
+++ b/app/assets/stylesheets/pageflow/animations/loading.css.scss
@@ -1,0 +1,8 @@
+@include keyframes(loading) {
+  0%, 40%, 100% {
+    @include transform(scaleY(0.4));
+  }
+  20% {
+    @include transform(scaleY(1));
+  }
+}

--- a/app/assets/stylesheets/pageflow/editor/base.css.scss
+++ b/app/assets/stylesheets/pageflow/editor/base.css.scss
@@ -71,6 +71,7 @@
   @import "./back_button_decorator";
   @import "./widgets";
   @import "./page_links";
+  @import "./loading";
 
   a.publish {
     @include eye-icon;

--- a/app/assets/stylesheets/pageflow/editor/files_explorer.css.scss
+++ b/app/assets/stylesheets/pageflow/editor/files_explorer.css.scss
@@ -33,6 +33,12 @@
 
   .entries_panel {
     width: 20%;
+
+    li.blank_slate {
+      text-align: center;
+      padding: 10px 5px 20px 5px;
+      color: #888;
+    }
   }
 
   .files_panel {

--- a/app/assets/stylesheets/pageflow/editor/loading.css.scss
+++ b/app/assets/stylesheets/pageflow/editor/loading.css.scss
@@ -1,0 +1,31 @@
+.spinner > div {
+  background-color: #ddd;
+  height: 100%;
+  width: 6px;
+  display: inline-block;
+  @include animation(loading 1.2s infinite ease-in-out);
+}
+
+.loading .spinner {
+  margin: 20px auto;
+  width: 50px;
+  height: 40px;
+  text-align: center;
+  font-size: 10px;
+
+  .rect2 {
+    @include animation-delay(-1.1s);
+  }
+
+  .rect3 {
+    @include animation-delay(-1.0s);
+  }
+
+  .rect4 {
+    @include animation-delay(-0.9s);
+  }
+
+  .rect5 {
+    @include animation-delay(-0.8s);
+  }
+}


### PR DESCRIPTION
Editor's file reuse panel/dialog displays a loading animation during template retrieval instead of a text message. Solves #379.