### PR TITLE
Ensure hidden text indicator is only visible on mobile

### DIFF
--- a/app/assets/stylesheets/pageflow/entries.css.scss
+++ b/app/assets/stylesheets/pageflow/entries.css.scss
@@ -108,17 +108,25 @@
       z-index: 0;
     }
   }
+
+  .hidden_text_indicator {
+    display: none;
+    left: 8%;
+
+    &:before {
+      background-image: image-url("pageflow/touch_indicator.png");
+    }
+
+    &.invert {
+      &:before {
+        background-image: image-url("pageflow/touch_indicator_invert.png");
+      }
+    }
+  }
 }
 
-.has_mobile_platform .hidden_text_indicator {
-  left: 8%;
-  &:before {
-    background-image: image-url('pageflow/touch_indicator.png');
-  }
-
-  &.invert {
-    &:before {
-      background-image: image-url('pageflow/touch_indicator_invert.png');
-    }
+.has_mobile_platform .entry {
+  .hidden_text_indicator {
+    display: block;
   }
 }


### PR DESCRIPTION
Before the i18n changes it used to only have a background image on
mobile platform. But since texts are localized, the text also became
visible on desktop browsers.