### PR TITLE
Implement scroll position auto-adjustment in editor outline

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/chapter_item_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/chapter_item_view.js
@@ -24,10 +24,35 @@ pageflow.ChapterItemView = Backbone.Marionette.ItemView.extend({
     }));
 
     this.update();
+    this.adjustScrollPosition();
   },
 
   update: function() {
     this.ui.title.text(this.model.get('title') || I18n.t('pageflow.editor.views.chapter_item_view.unnamed'));
     this.ui.number.text(I18n.t('pageflow.editor.views.chapter_item_view.chapter') + ' ' + (this.model.get('position') + 1));
+  },
+
+  adjustScrollPosition: function() {
+    var active = this.$el.find('li.active')[0];
+    if (active !== undefined) {
+      var scrolling = $('.scrolling')[0];
+      if (scrolling !== undefined) {
+        this._scroll(active, scrolling);
+      }
+    }
+  },
+
+  _scroll: function(element, parent) {
+    setTimeout(function() {
+
+      $(parent).animate({
+        scrollTop: $(parent).scrollTop() + $(element).offset().top - $(parent).offset().top
+        - $(element).height()
+      }, {
+        duration: 'slow',
+        easing: 'easeOutBack'
+      });
+
+    }, 0); // setTimeout
   }
 });


### PR DESCRIPTION
When returning to the entry outline inside the editor, the list scrolls automatically to the currently selected entry. Solves #378.