### PR TITLE
Replace <sidebar> with <aside id="sidebar">

### DIFF
--- a/app/assets/javascripts/pageflow/editor/initializers/boot.js
+++ b/app/assets/javascripts/pageflow/editor/initializers/boot.js
@@ -18,8 +18,8 @@ pageflow.app.addRegions({
   previewRegion: '#entry_preview',
   mainRegion: '#main_content',
   indicatorsRegion: '#editor_indicators',
-  sidebarRegion: 'sidebar .container',
+  sidebarRegion: '#sidebar .container',
   dialogRegion: '.dialog_container',
-  notificationsRegion: 'sidebar .notifications_container',
-  helpButtonRegion: 'sidebar .help_button_container'
+  notificationsRegion: '#sidebar .notifications_container',
+  helpButtonRegion: '#sidebar .help_button_container'
 });

--- a/app/assets/stylesheets/pageflow/print_view.css.scss
+++ b/app/assets/stylesheets/pageflow/print_view.css.scss
@@ -4,7 +4,6 @@ body {
     overflow: visible !important;
   }
   background-color: white !important;
-  height: !important;
   overflow: visible !important;
 
   .slideshow {
@@ -22,7 +21,7 @@ body {
     padding-left: 17px;
   }
 
-  sidebar {
+  #sidebar {
     display: none;
   }
 
@@ -98,10 +97,8 @@ body {
       width: 100%;
     }
 
-
     .content_and_background {
-      width:100%;
-      min-height: auto;
+      width: 100%;
       position: initial;
     }
 
@@ -112,9 +109,8 @@ body {
     }
 
     h1, h2, h3, p {
-    max-width: initial;
+      max-width: initial;
     }
-
 
     .backgroundArea {
       width: initial;
@@ -122,22 +118,22 @@ body {
       position: absolute;
       background-color: white;
     }
-    .scroller, .content .scroller {
+    .scroller, .content .scroller  {
       opacity: 1 !important;
       visibility: visible !important;
       height: auto;
       position: relative;
     }
     .scroller > div {
-      transform: translate3d(0,0,0) !important;
-      -ms-transform: translate3d(0,0,0) !important; /* IE 9 */
-      -webkit-transform: translate3d(0,0,0) !important; /* Safari and Chrome */
-      transform: translate(0,0) !important;
-      -ms-transform: translate(0,0) !important; /* IE 9 */
-      -webkit-transform: translate(0,0) !important; /* Safari and Chrome */
+      transform: translate3d(0, 0, 0) !important;
+      -ms-transform: translate3d(0, 0, 0) !important; /* IE 9 */
+      -webkit-transform: translate3d(0, 0, 0) !important; /* Safari and Chrome */
+      transform: translate(0, 0) !important;
+      -ms-transform: translate(0, 0) !important; /* IE 9 */
+      -webkit-transform: translate(0, 0) !important; /* Safari and Chrome */
       top: 0 !important;
     }
-    .scroller  > div {
+    .scroller > div {
       position: relative;
     }
     .scroller.fade-out, .scroller.fade-in {
@@ -159,7 +155,7 @@ body {
     background-color: white !important;
   }
 
-  section.page  {
+  section.page {
     display: block;
     background-color: white !important;
   }
@@ -168,7 +164,7 @@ body {
     background-image: none !important;
   }
 
-  &.js .controls, .add_info_box  {
+  &.js .controls, .add_info_box {
     position: relative !important;
     bottom: initial;
     top: 0 !important;
@@ -176,10 +172,9 @@ body {
 
   &.js .controls .add_info_box:before {
     background-color: transparent;
-  };
+  }
 
   .video-js {
     display: none !important;
   }
-
 }

--- a/app/views/pageflow/entries/edit.html.erb
+++ b/app/views/pageflow/entries/edit.html.erb
@@ -12,13 +12,13 @@
   <div id="editor_indicators"></div>
 </main>
 
-<sidebar class="ui-layout-east editor">
+<aside id="sidebar" class="ui-layout-east editor">
   <div class="scrolling">
     <div class="notifications_container"></div>
     <div class="container"></div>
   </div>
   <div class="help_button_container"></div>
-</sidebar>
+</aside>
 
 <div class="dialog_container">
 </div>

--- a/spec/support/dominos/editor/chapter_properties.rb
+++ b/spec/support/dominos/editor/chapter_properties.rb
@@ -1,7 +1,7 @@
 module Dom
   module Editor
     class ChapterProperties < Domino
-      selector 'sidebar.editor .edit_chapter'
+      selector '#sidebar.editor .edit_chapter'
 
       def destroy_button
         node.find('.destroy')

--- a/spec/support/dominos/editor/entry_outline.rb
+++ b/spec/support/dominos/editor/entry_outline.rb
@@ -1,7 +1,7 @@
 module Dom
   module Editor
     class EntryOutline < Domino
-      selector 'sidebar .chapters.outline'
+      selector '#sidebar .chapters.outline'
 
       def self.await!
         find!

--- a/spec/support/dominos/editor/page_properties.rb
+++ b/spec/support/dominos/editor/page_properties.rb
@@ -1,7 +1,7 @@
 module Dom
   module Editor
     class PageProperties < Domino
-      selector 'sidebar.editor .edit_page'
+      selector '#sidebar.editor .edit_page'
 
       def destroy_button
         node.find('.destroy')

--- a/spec/support/dominos/editor/sidebar.rb
+++ b/spec/support/dominos/editor/sidebar.rb
@@ -1,7 +1,7 @@
 module Dom
   module Editor
     class Sidebar < Domino
-      selector 'sidebar.editor'
+      selector '#sidebar.editor'
 
       def has_chapter_item?
         node.has_selector?('ul.chapters > li:not(.creating)')


### PR DESCRIPTION
Replaces the tag ```<sidebar>``` with ```<aside id="sidebar">``` according to HTML5 standards.
This commit also cleans up some code in the print stylesheet.