### PR TITLE
Page Attribute Translation Key Prefixes

### DIFF
--- a/app/assets/javascripts/pageflow/editor/api/page_type.js
+++ b/app/assets/javascripts/pageflow/editor/api/page_type.js
@@ -32,6 +32,11 @@ pageflow.PageType = pageflow.Object.extend({
     var constructor = this.configurationEditorView();
     options.pageType = this.seed;
 
-    return new constructor(options);
+    return new constructor(_.extend({
+      attributeTranslationKeyPrefixes: [
+        this.seed.translation_key_prefix + '.page_attributes',
+        'pageflow.common_page_attributes'
+      ]
+    }, options));
   }
 });

--- a/app/assets/javascripts/pageflow/ui.js
+++ b/app/assets/javascripts/pageflow/ui.js
@@ -8,6 +8,7 @@
 //= require ./ui/renderer
 //= require ./ui/object
 
+//= require_tree ./ui/utils
 //= require_tree ./ui/views/mixins
 //= require ./ui/views/inputs/select_input_view
 //= require_tree ./ui/views

--- a/app/assets/javascripts/pageflow/ui/utils/i18n_utils.js
+++ b/app/assets/javascripts/pageflow/ui/utils/i18n_utils.js
@@ -1,0 +1,23 @@
+pageflow.i18nUtils = {
+  findTranslation: function(keys, options) {
+    options = options || {};
+
+    return _.chain(keys).reverse().reduce(function(result, key) {
+      return I18n.t(key, {defaultValue: result});
+    }, options.defaultValue).value();
+  },
+
+  findKeyWithTranslation: function(keys) {
+    var missing = '_not_translated';
+
+    return _(keys).detect(function(key) {
+      return I18n.t(key, {defaultValue: missing}) !== missing;
+    }) || _.first(keys);
+  },
+
+  translationKeysWithSuffix: function(keys, suffix) {
+    return _.chain(keys).map(function(key) {
+      return [key + '_' + suffix, key];
+    }).flatten().value();
+  }
+};

--- a/app/assets/javascripts/pageflow/ui/views/configuration_editor_tab_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/configuration_editor_tab_view.js
@@ -8,7 +8,8 @@ pageflow.ConfigurationEditorTabView = Backbone.Marionette.View.extend({
   input: function(propertyName, view, options) {
     this.view(view, _.extend({
       placeholderModel: this.options.placeholderModel,
-      propertyName: propertyName
+      propertyName: propertyName,
+      attributeTranslationKeyPrefixes: this.options.attributeTranslationKeyPrefixes
     }, options || {}));
   },
 

--- a/app/assets/javascripts/pageflow/ui/views/configuration_editor_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/configuration_editor_view.js
@@ -16,7 +16,8 @@ pageflow.ConfigurationEditorView = Backbone.Marionette.View.extend({
       var tabView = new pageflow.ConfigurationEditorTabView({
         model: this.model,
         placeholderModel: this.options.placeholderModel,
-        tab: name
+        tab: name,
+        attributeTranslationKeyPrefixes: this.options.attributeTranslationKeyPrefixes
       });
 
       callback.call(tabView);

--- a/app/assets/javascripts/pageflow/ui/views/inputs/select_input_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/inputs/select_input_view.js
@@ -33,7 +33,10 @@ pageflow.SelectInputView = Backbone.Marionette.ItemView.extend({
 
     if (!this.options.texts) {
       if (!this.options.translationKeys) {
-        var translationKeyPrefix = this.options.translationKeyPrefix || 'activerecord.values.' + this.model.i18nKey + '.' + this.options.propertyName;
+        var translationKeyPrefix = this.options.translationKeyPrefix ||
+          pageflow.i18nUtils.findKeyWithTranslation(this.attributeTranslationKeys('values', {
+            fallbackPrefix: 'activerecord.values'
+          }));
 
         this.options.translationKeys = _.map(this.options.values, function(value) {
           return translationKeyPrefix + '.' + value;

--- a/app/assets/javascripts/pageflow/ui/views/mixins/input_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/mixins/input_view.js
@@ -1,9 +1,135 @@
+/**
+ * Mixin for input views handling common concerns like labels,
+ * inline help, visiblity and disabling.
+ *
+ * ## Label and Inline Help Translations
+ *
+ * By default `#labelText` and `#inlineHelpText` are defined through
+ * translations. If no `attributeTranslationKeyPrefixes` are given,
+ * translation keys for labels and inline help are constructed from
+ * the `i18nKey` of the model and the given `propertyName`
+ * option. Suppose the model's `i18nKey` is "page" and the
+ * `propertyName` option is "title". Then the key
+ *
+ *     activerecord.attributes.page.title
+ *
+ * will be used for the label. And the key
+ *
+ *     pageflow.ui.inline_help.page.title
+ *
+ * will be used for the inline help.
+ *
+ * ### Attribute Translation Key Prefixes
+ *
+ * The `attributeTranslationKeyPrefixes` option can be used to supply
+ * an array of scopes in which label and inline help translations
+ * shall be looked up based on the `propertyName` option.
+ *
+ * Suppose the array `['some.attributes', 'fallback.attributes']` is
+ * given as `attributeTranslationKeyPrefixes` option. Then, in the
+ * example above, the first existing translation key is used as label:
+ *
+ *     some.attributes.title.label
+ *     fallback.attributes.title.label
+ *     activerecord.attributes.post.title
+ *
+ * Accordingly, for the inline help:
+ *
+ *     some.attributes.title.inline_help
+ *     fallback.attributes.title.inline_help
+ *     pageflow.ui.inline_help.post.title
+ *
+ * This setup allows to keep all translation keys for an attribute
+ * to share a common prefix:
+ *
+ *    some:
+ *      attributes:
+ *        title:
+ *          label: "Label"
+ *          inline_help: "..."
+ *          inline_help_disabled: "..."
+ *
+ * ### Inline Help for Disabled Inputs
+ *
+ * For each inline help translation key, a separate key with an
+ * `"_disbaled"` suffix can be supplied, which provides a help string
+ * that shall be displayed when the input is disabled. More specific
+ * attribute translation key prefixes take precedence over suffixed
+ * keys:
+ *
+ *     some.attributes.title.inline_help
+ *     some.attributes.title.inline_help_disabled
+ *     fallback.attributes.title.inline_help
+ *     fallback.attributes.title.inline_help_disabled
+ *     pageflow.ui.inline_help.post.title
+ *     pageflow.ui.inline_help.post.title_disabled
+ *
+ * @option propertyName [String]
+ *   Name of the attribute on the model to display and edit.
+ *
+ * @option label [String]
+ *   Label text for the input.
+ *
+ * @option attributeTranslationKeyPrefixes [Array<String>]
+ *   An array of prefixes to lookup translations for labels and
+ *   inline help texts based on attribute names.
+ *
+ * @option disabled [Boolean]
+ *   Render input as disabled.
+ *
+ * @option visibleBinding [String]
+ *   Name of an attribute to control whether the input is visible. If
+ *   the `visible` and `visibleBindingValue` options are not set,
+ *   input will be visible whenever this attribute as a truthy value.
+ *
+ * @option visible [Function|Boolean]
+ *   A Function taking the value of the `visibleBinding` attribute as
+ *   parameter. Input will be visible only if function returns `true`.
+ *
+ * @option visibleBindingValue [Any]
+ *   Input will be visible whenever the value of the `visibleBinding`
+ *   attribute equals the value of this option.
+ */
 pageflow.inputView = {
   ui: {
     labelText: 'label .name',
     inlineHelp: 'label .inline_help'
   },
 
+  /**
+   * Returns an array of translation keys based on the propertyName
+   * options and the given prefixes.
+   *
+   * @param keyName [String]
+   *   Suffix to append to prefixes.
+   *
+   * @option attributeTranslationKeyPrefixes [Array<String>]
+   *   An array of strings to use as prefixes to constructs
+   *   translation keys.
+   *
+   * @option fallbackPrefix [String]
+   *   Optional additional prefix to form a model based translation
+   *   key of the form `prefix.modelI18nKey.propertyName.keyName
+   *
+   * @api edge
+   */
+  attributeTranslationKeys: function(keyName, options) {
+    var result = [];
+
+    if (this.options.attributeTranslationKeyPrefixes) {
+      result = result.concat(_(this.options.attributeTranslationKeyPrefixes).map(function(prefix) {
+        return prefix + '.' + this.options.propertyName + '.' + keyName;
+      }, this));
+    }
+
+    if (options && options.fallbackPrefix) {
+      result.push(options.fallbackPrefix + '.' + this.model.i18nKey + '.' + this.options.propertyName);
+    }
+
+    return result;
+  },
+
+  /** @private */
   onRender: function() {
     this.$el.addClass(this.model.modelName + '_' + this.options.propertyName);
     this.ui.labelText.text(this.labelText());
@@ -23,26 +149,27 @@ pageflow.inputView = {
   },
 
   localizedAttributeName: function() {
-    return I18n.t('activerecord.attributes.' + this.model.i18nKey + '.' + this.options.propertyName);
+    return pageflow.i18nUtils.findTranslation(this.attributeTranslationKeys('label', {fallbackPrefix: 'activerecord.attributes'}));
   },
 
   inlineHelpText: function() {
-    var key = 'pageflow.ui.inline_help.' + this.model.i18nKey + '.' + this.options.propertyName;
-    var text = I18n.t(key, {defaultValue: ''});
+    var keys = this.attributeTranslationKeys('inline_help', {fallbackPrefix: 'pageflow.ui.inline_help'});
 
     if (this.options.disabled) {
-      text = I18n.t(key + '_disabled', {defaultValue: text});
+      keys = pageflow.i18nUtils.translationKeysWithSuffix(keys, 'disabled');
     }
 
-    return text;
+    return pageflow.i18nUtils.findTranslation(keys, {defaultValue: ''});
   },
 
+  /** @private */
   updateDisabled: function() {
     if (this.ui.input) {
       this.updateDisabledAttribute(this.ui.input);
     }
   },
 
+  /** @private */
   updateDisabledAttribute: function(element) {
     if (this.options.disabled) {
       element.attr('disabled', true);
@@ -52,6 +179,7 @@ pageflow.inputView = {
     }
   },
 
+  /** @private */
   setupVisibleBinding: function() {
     var view = this;
 

--- a/app/views/pageflow/page_types/_page_type.json.jbuilder
+++ b/app/views/pageflow/page_types/_page_type.json.jbuilder
@@ -1,4 +1,10 @@
-json.(page_type, :name, :translation_key, :help_entry_translation_key, :description_translation_key, :category_translation_key)
+json.(page_type,
+      :name,
+      :translation_key_prefix,
+      :translation_key,
+      :help_entry_translation_key,
+      :description_translation_key,
+      :category_translation_key)
 
 json.thumbnail_candidates(page_type.thumbnail_candidates) do |candidate|
   json.(candidate, :attribute, :file_collection)

--- a/spec/javascripts/pageflow/ui/utils/i18n_utils_spec.js
+++ b/spec/javascripts/pageflow/ui/utils/i18n_utils_spec.js
@@ -1,0 +1,54 @@
+describe('pageflow.i18nUtils', function() {
+  support.useFakeTranslations({
+    'some.key': 'Some text',
+    'fallback': 'Fallback'
+  });
+
+  describe('.findTranslation', function() {
+    it('returns first present translation', function() {
+      var result = pageflow.i18nUtils.findTranslation(
+        ['not.there', 'some.key', 'fallback']
+      );
+
+      expect(result).to.eq('Some text');
+    });
+
+    it('falls back to defaultValue', function() {
+      var result = pageflow.i18nUtils.findTranslation(
+        ['not.there'],
+        {defaultValue: 'Default'}
+      );
+
+      expect(result).to.eq('Default');
+    });
+  });
+
+  describe('.findKeyWithTranslation', function() {
+    it('returns key withpresent translation', function() {
+      var result = pageflow.i18nUtils.findKeyWithTranslation(
+        ['not.there', 'some.key', 'fallback']
+      );
+
+      expect(result).to.eq('some.key');
+    });
+
+    it('falls back first key if all are missing', function() {
+      var result = pageflow.i18nUtils.findKeyWithTranslation(
+        ['not.there', 'also.not.there']
+      );
+
+      expect(result).to.eq('not.there');
+    });
+  });
+
+  describe('.translationKeysWithSuffix', function() {
+    it('returns array with additional suffixed key for each item', function() {
+      var result = pageflow.i18nUtils.translationKeysWithSuffix(
+        ['some.key', 'fallback'],
+        'disabled'
+      );
+
+      expect(result).to.deep.eq(['some.key_disabled', 'some.key', 'fallback_disabled', 'fallback']);
+    });
+  });
+});

--- a/spec/javascripts/pageflow/ui/views/inputs/select_input_view_spec.js
+++ b/spec/javascripts/pageflow/ui/views/inputs/select_input_view_spec.js
@@ -1,0 +1,154 @@
+describe('pageflow.SelectInputView', function() {
+  var Model = Backbone.Model.extend({
+    i18nKey: 'page'
+  });
+
+  describe('without texts option', function() {
+    support.useFakeTranslations({
+      'activerecord.values.page.modes.one': 'One',
+      'activerecord.values.page.modes.two': 'Two'
+    });
+
+    it('uses activerecord values translations for item', function() {
+      var selectInputView = new pageflow.SelectInputView({
+        model: new Model(),
+        propertyName: 'modes',
+        values: ['one', 'two']
+      });
+
+      var texts = optionTexts(selectInputView);
+
+      expect(texts).to.deep.eq(['One', 'Two']);
+    });
+  });
+
+  describe('with texts option', function() {
+    it('uses texts for items', function() {
+      var selectInputView = new pageflow.SelectInputView({
+        model: new Model(),
+        propertyName: 'size',
+        values: [1, 2],
+        texts: ['One', 'Two']
+      });
+
+      var texts = optionTexts(selectInputView);
+
+      expect(texts).to.deep.eq(['One', 'Two']);
+    });
+  });
+
+  describe('with translationKeys option', function() {
+    support.useFakeTranslations({
+      'items.one': 'One',
+      'items.two': 'Two'
+    });
+
+    it('uses translations for items', function() {
+      var selectInputView = new pageflow.SelectInputView({
+        model: new Model(),
+        propertyName: 'size',
+        values: [1, 2],
+        translationKeys: ['items.one', 'items.two']
+      });
+
+      var texts = optionTexts(selectInputView);
+
+      expect(texts).to.deep.eq(['One', 'Two']);
+    });
+  });
+
+  describe('with translationKeyPrefix option', function() {
+    support.useFakeTranslations({
+      'items.one': 'One',
+      'items.two': 'Two'
+    });
+
+    it('uses translation keys from values for items', function() {
+      var selectInputView = new pageflow.SelectInputView({
+        model: new Model(),
+        propertyName: 'modes',
+        values: ['one', 'two'],
+        translationKeyPrefix: 'items'
+      });
+
+      var texts = optionTexts(selectInputView);
+
+      expect(texts).to.deep.eq(['One', 'Two']);
+    });
+  });
+
+  describe('with attributeTranslationKeyPrefixes option', function() {
+    support.useFakeTranslations({
+      'some.attributes.modes.values.one': 'One',
+      'some.attributes.modes.values.two': 'Two',
+      'fallback.attributes.modes.values.one': 'Fallback One',
+      'fallback.attributes.modes.values.two': 'Fallback Two',
+
+      'fallback.attributes.fallback.values.one': 'Fallback One',
+      'fallback.attributes.fallback.values.two': 'Fallback Two',
+
+      'activerecord.values.page.legacy.one': 'AR One',
+      'activerecord.values.page.legacy.two': 'AR Two'
+    });
+
+    it('uses attribute values translation keys', function() {
+      var selectInputView = new pageflow.SelectInputView({
+        model: new Model(),
+        propertyName: 'modes',
+        values: ['one', 'two'],
+        attributeTranslationKeyPrefixes: ['some.attributes']
+      });
+
+      var texts = optionTexts(selectInputView);
+
+      expect(texts).to.deep.eq(['One', 'Two']);
+    });
+
+    it('prefers first attribute translation key prefix', function() {
+      var selectInputView = new pageflow.SelectInputView({
+        model: new Model(),
+        propertyName: 'modes',
+        values: ['one', 'two'],
+        attributeTranslationKeyPrefixes: ['some.attributes', 'fallback.attributes']
+      });
+
+      var texts = optionTexts(selectInputView);
+
+      expect(texts).to.deep.eq(['One', 'Two']);
+    });
+
+    it('falls back to second attribute translation key prefix', function() {
+      var selectInputView = new pageflow.SelectInputView({
+        model: new Model(),
+        propertyName: 'fallback',
+        values: ['one', 'two'],
+        attributeTranslationKeyPrefixes: ['some.attributes', 'fallback.attributes']
+      });
+
+      var texts = optionTexts(selectInputView);
+
+      expect(texts).to.deep.eq(['Fallback One', 'Fallback Two']);
+    });
+
+    it('falls back active record values translations', function() {
+      var selectInputView = new pageflow.SelectInputView({
+        model: new Model(),
+        propertyName: 'legacy',
+        values: ['one', 'two'],
+        attributeTranslationKeyPrefixes: ['some.attributes', 'fallback.attributes']
+      });
+
+      var texts = optionTexts(selectInputView);
+
+      expect(texts).to.deep.eq(['AR One', 'AR Two']);
+    });
+  });
+
+  function optionTexts(view) {
+    view.render();
+
+    return jQuery(view.el).find('option').map(function() {
+      return jQuery(this).text();
+    }).get();
+  }
+});

--- a/spec/javascripts/pageflow/ui/views/mixins/input_view_spec.js
+++ b/spec/javascripts/pageflow/ui/views/mixins/input_view_spec.js
@@ -1,0 +1,233 @@
+describe('pageflow.inputView', function() {
+  describe('attributeTranslationKeys', function() {
+    describe('without attributeTranslationKeyPrefixes', function() {
+      it('constructs fallback key from fallback prefix, model i18nKey and propertyName', function() {
+        var view = createInputView({
+          model: {i18nKey: 'page'},
+          propertyName: 'title'
+        });
+
+        var result = view.attributeTranslationKeys('label', {fallbackPrefix: 'activerecord.attributes'});
+
+        expect(result).to.deep.eq(['activerecord.attributes.page.title']);
+      });
+    });
+
+    describe('with attributeTranslationKeyPrefixes', function() {
+      it('constructs additional candidates from prefix, propertyName and given key', function() {
+        var view = createInputView({
+          attributeTranslationKeyPrefixes: [
+            'pageflow.rainbows.page_attributes',
+            'pageflow.common_page_attributes'
+          ],
+          model: {i18nKey: 'page'},
+          propertyName: 'title'
+        });
+
+        var result = view.attributeTranslationKeys('label', {fallbackPrefix: 'activerecord.attributes'});
+
+        expect(result).to.deep.eq([
+          'pageflow.rainbows.page_attributes.title.label',
+          'pageflow.common_page_attributes.title.label',
+          'activerecord.attributes.page.title'
+        ]);
+      });
+    });
+  });
+
+  describe('#labelText', function() {
+    describe('with label option', function() {
+      it('returns label option', function() {
+        var view = createInputView({label: 'Some Label'});
+
+        var result = view.labelText();
+
+        expect(result).to.eq('Some Label');
+      });
+    });
+
+    describe('with attributeTranslationKeyPrefixes option', function() {
+      describe('with present prefixed attribute translation', function() {
+        support.useFakeTranslations({
+          'pageflow.rainbows.page_attributes.title.label': 'Rainbow Text',
+          'activerecord.attributes.page.title': 'AR Text'
+        });
+
+        it('uses prefixed attribute translation', function() {
+          var view = createInputView({
+            attributeTranslationKeyPrefixes: [
+              'pageflow.rainbows.page_attributes'
+            ],
+            model: {i18nKey: 'page'},
+            propertyName: 'title'
+          });
+
+          var result = view.labelText();
+
+          expect(result).to.eq('Rainbow Text');
+        });
+      });
+
+      describe('with missing prefixed attribute translation', function() {
+        support.useFakeTranslations({
+          'activerecord.attributes.page.title': 'AR Text'
+        });
+
+        it('falls back to active record attribute translation', function() {
+          var view = createInputView({
+            attributeTranslationKeyPrefixes: [
+              'pageflow.rainbows.page_attributes'
+            ],
+            model: {i18nKey: 'page'},
+            propertyName: 'title'
+          });
+
+          var result = view.labelText();
+
+          expect(result).to.eq('AR Text');
+        });
+      });
+    });
+
+    describe('without attributeTranslationKeyPrefixes', function() {
+      support.useFakeTranslations({
+        'activerecord.attributes.page.title': 'AR Text'
+      });
+
+      it('uses active record attribute translation', function() {
+        var view = createInputView({
+          model: {i18nKey: 'page'},
+          propertyName: 'title'
+        });
+
+        var result = view.labelText();
+
+        expect(result).to.eq('AR Text');
+      });
+    });
+  });
+
+  describe('#inlineHelpText', function() {
+    describe('with attributeTranslationKeyPrefixes option', function() {
+      describe('with present prefixed attribute translation', function() {
+        support.useFakeTranslations({
+          'pageflow.rainbows.page_attributes.title.inline_help': 'Rainbow Help',
+          'pageflow.rainbows.page_attributes.title.inline_help_disabled': 'Rainbow Help Disabled',
+          'pageflow.ui.inline_help.page.title': 'Model/Attribute Help'
+        });
+
+        it('uses prefixed inline help translation', function() {
+          var view = createInputView({
+            attributeTranslationKeyPrefixes: [
+              'pageflow.rainbows.page_attributes'
+            ],
+            model: {i18nKey: 'page'},
+            propertyName: 'title'
+          });
+
+          var result = view.inlineHelpText();
+
+          expect(result).to.eq('Rainbow Help');
+        });
+
+        it('prefers prefixed inline help translation for disabled input', function() {
+          var view = createInputView({
+            attributeTranslationKeyPrefixes: [
+              'pageflow.rainbows.page_attributes'
+            ],
+            model: {i18nKey: 'page'},
+            propertyName: 'title',
+            disabled: true
+          });
+
+          var result = view.inlineHelpText();
+
+          expect(result).to.eq('Rainbow Help Disabled');
+        });
+      });
+
+      describe('with multiple prefixed attribute translations', function() {
+        support.useFakeTranslations({
+          'pageflow.rainbows.page_attributes.title.inline_help': 'Rainbow Help',
+          'pageflow.common_page_attributes.title.inline_help': 'Common Help',
+          'pageflow.common_page_attributes.title.inline_help_disabled': 'Common Help Disabled',
+          'pageflow.ui.inline_help.page.title': 'Model/Attribute Help'
+        });
+
+        it('prefers more specific inline help over disabled inline help', function() {
+          var view = createInputView({
+            attributeTranslationKeyPrefixes: [
+              'pageflow.rainbows.page_attributes',
+              'pageflow.common_page_attributes'
+            ],
+            model: {i18nKey: 'page'},
+            propertyName: 'title',
+            disabled: true
+          });
+
+          var result = view.inlineHelpText();
+
+          expect(result).to.eq('Rainbow Help');
+        });
+      });
+
+      describe('with missing prefixed attribute translation', function() {
+        support.useFakeTranslations({
+          'pageflow.ui.inline_help.page.title': 'Model/Attribute Help'
+        });
+
+        it('falls back to model/attribute based inline help translation', function() {
+          var view = createInputView({
+            attributeTranslationKeyPrefixes: [
+              'pageflow.rainbows.page_attributes'
+            ],
+            model: {i18nKey: 'page'},
+            propertyName: 'title'
+          });
+
+          var result = view.inlineHelpText();
+
+          expect(result).to.eq('Model/Attribute Help');
+        });
+      });
+    });
+
+    describe('without attributeTranslationKeyPrefixes', function() {
+      support.useFakeTranslations({
+        'pageflow.ui.inline_help.page.title': 'Model/Attribute Help',
+        'pageflow.ui.inline_help.page.title_disabled': 'Model/Attribute Help Disabled'
+      });
+
+      it('uses model/attribute based inline help translation', function() {
+        var view = createInputView({
+          model: {i18nKey: 'page'},
+          propertyName: 'title'
+        });
+
+        var result = view.inlineHelpText();
+
+        expect(result).to.eq('Model/Attribute Help');
+      });
+
+      it('prefers disabled suffix if disabled', function() {
+        var view = createInputView({
+          model: {i18nKey: 'page'},
+          propertyName: 'title',
+          disabled: true
+        });
+
+        var result = view.inlineHelpText();
+
+        expect(result).to.eq('Model/Attribute Help Disabled');
+      });
+    });
+  });
+
+  function createInputView(options) {
+    var view = {options: options};
+    view.model = options.model;
+    _.extend(view, pageflow.inputView);
+
+    return view;
+  }
+});

--- a/spec/javascripts/support/use_fake_translations.js
+++ b/spec/javascripts/support/use_fake_translations.js
@@ -1,0 +1,24 @@
+support.useFakeTranslations = function(translations) {
+  beforeEach(function() {
+    this._originalTranslations = I18n.translations;
+
+    var nested = _(translations).reduce(function(result, value, key) {
+      var keys = key.split('.');
+      var last = keys.pop();
+
+      var inner = _(keys).reduce(function(r, key) {
+        r[key] = r[key] || {};
+        return r[key];
+      }, result);
+
+      inner[last] = value;
+      return result;
+    }, {});
+
+    I18n.translations = {en: nested};
+  });
+
+  afterEach(function() {
+    I18n.translations = this._originalTranslations;
+  });
+};


### PR DESCRIPTION
Before, translations for page attribute labels and inline help texts were looked up in the `activerecord.attributes` and `pageflow.ui.inline_help` scopes. Translations for select box entries
where looked up in `activerecord.values`.  This caused three problems:

* No two page types could use different texts for the same attribute.

* Active record scopes reveal too much implementation details. Should
  be `pageflow...` scope.

* Translations for an attribute were scattered accross different
  parent scopes.

Introduce new scopes for common and page type specific attribute translations:

    pageflow.common_page_attributes.<attribute>.label
    pageflow.common_page_attributes.<attribute>.inline_help
    pageflow.common_page_attributes.<attribute>.inline_help_disabled
    pageflow.common_page_attributes.<attribute>.values

    <page_type_translation_key_prefix>.page_attributes.<attribute>.label
    <page_type_translation_key_prefix>.page_attributes.<attribute>.inline_help
    <page_type_translation_key_prefix>.page_attributes.<attribute>.inline_help_disabled
    <page_type_translation_key_prefix>.page_attributes.<attribute>.values