### PR TITLE
Emphasized Pages and Scoll Indicator Modes Theme Options

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/theming.js
+++ b/app/assets/javascripts/pageflow/editor/models/theming.js
@@ -7,5 +7,13 @@ pageflow.Theming = Backbone.Model.extend({
 
   hasHomeButton: function() {
     return this.get('home_button');
+  },
+
+  supportsEmphasizedPages: function() {
+    return this.get('emphasized_pages');
+  },
+
+  supportsScrollIndicatorModes: function() {
+    return this.get('scroll_indicator_modes');
   }
 });

--- a/app/assets/javascripts/pageflow/editor/views/configuration_editors/groups/options.js
+++ b/app/assets/javascripts/pageflow/editor/views/configuration_editors/groups/options.js
@@ -1,7 +1,7 @@
 pageflow.ConfigurationEditorTabView.groups.define('options', function(options) {
   this.input('display_in_navigation', pageflow.CheckBoxInputView);
 
-  if (pageflow.features.isEnabled('emphasize_pages_in_navigation')) {
+  if (pageflow.theming.supportsEmphasizedPages()) {
     this.input('emphasize_in_navigation', pageflow.CheckBoxInputView);
   }
 
@@ -25,7 +25,7 @@ pageflow.ConfigurationEditorTabView.groups.define('options', function(options) {
     }
   }
 
-  if (pageflow.features.isEnabled('scroll_indicator_modes')) {
+  if (pageflow.theming.supportsScrollIndicatorModes()) {
     this.input('scroll_indicator_mode', pageflow.SelectInputView, {
       values: pageflow.Page.scrollIndicatorModes
     });

--- a/app/views/pageflow/editor/themings/_theming.json.jbuilder
+++ b/app/views/pageflow/editor/themings/_theming.json.jbuilder
@@ -2,3 +2,5 @@ json.pretty_url pretty_theming_url(theming)
 json.home_button theming.theme.has_home_button?
 json.page_change_by_scrolling theming.theme.page_change_by_scrolling?
 json.hide_text_on_swipe theming.theme.hide_text_on_swipe?
+json.emphasized_pages theming.theme.supports_emphasized_pages?
+json.scroll_indicator_modes theming.theme.supports_scroll_indicator_modes?

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,8 +1,6 @@
 Pageflow.configure do |config|
   config.features.register('atmo')
   config.features.register('auto_change_page')
-  config.features.register('scroll_indicator_modes')
   config.features.register('delayed_text_fade_in')
   config.features.register('chapter_hierachy')
-  config.features.register('emphasize_pages_in_navigation')
 end

--- a/config/locales/new/emphasize_pages_in_navigation.yml
+++ b/config/locales/new/emphasize_pages_in_navigation.yml
@@ -1,18 +1,10 @@
 en:
-  pageflow:
-    emphasize_pages_in_navigation:
-      feature_name: "Emphasize pages in navgiationbar"
-
   activerecord:
     attributes:
       "pageflow/page":
         emphasize_in_navigation: "Emphasize in navigationbar"
 
 de:
-  pageflow:
-    emphasize_pages_in_navigation:
-      feature_name: "Seiten in Navigationsleiste hervorheben"
-
   activerecord:
     attributes:
       "pageflow/page":

--- a/config/locales/new/scroll_indicator_modes.yml
+++ b/config/locales/new/scroll_indicator_modes.yml
@@ -1,8 +1,4 @@
 en:
-  pageflow:
-    scroll_indicator_modes:
-      feature_name: "Configurable scroll indicators"
-
   activerecord:
     attributes:
       "pageflow/page":
@@ -19,10 +15,6 @@ en:
           horizontal: "Horizontal"
           vertical: "Vertical"
 de:
-  pageflow:
-    scroll_indicator_modes:
-      feature_name: "Konfigurierbare Scroll Indikatoren"
-
   activerecord:
     attributes:
       "pageflow/page":

--- a/lib/pageflow/theme.rb
+++ b/lib/pageflow/theme.rb
@@ -20,6 +20,14 @@ module Pageflow
       !!@options[:scroll_back_indicator]
     end
 
+    def supports_scroll_indicator_modes?
+      !!@options[:scroll_indicator_modes]
+    end
+
+    def supports_emphasized_pages?
+      !!@options[:emphasized_pages]
+    end
+
     def page_change_by_scrolling?
       !@options[:no_page_change_by_scrolling]
     end

--- a/lib/pageflow/themes.rb
+++ b/lib/pageflow/themes.rb
@@ -6,6 +6,32 @@ module Pageflow
       @themes = HashWithIndifferentAccess.new
     end
 
+    # Register a theme and supply theme options.
+    #
+    # @param name [Symbol]
+    #   Used in conventional directory names.
+    #
+    # @option options :no_home_button [Boolean]
+    #   Pass true if theme does not display home buttons in navigation
+    #   bars.
+    #
+    # @option options :scroll_back_indicator [Boolean]
+    #   Pass true if theme has styles for an indicator pointing to the
+    #   previous page.
+    #
+    # @option options :scroll_indicator_modes [Boolean]
+    #   Pass true if theme supports horizontal scroll indicators.
+    #
+    # @option options :emphasized_pages [Boolean]
+    #   Pass true if theme has styles for emphasized pages in navigation bars.
+    #
+    # @option options :no_page_change_by_scrolling [Boolean]
+    #   Pass true if changing the page by using the mouse wheel shall
+    #   be deactivated.
+    #
+    # @option options :no_hide_text_on_swipe [Boolean]
+    #   Pass true if hiding the text by swiping to left shall be
+    #   deactived on mobile devices.
     def register(name, options = {})
       @themes[name] = Theme.new(name, options)
     end


### PR DESCRIPTION
Both do not make sense as features since they need to be supported by the theme to work. If the theme supports them though, there is really no reason not to enable them.