### PR TITLE
make https mode configurable

### DIFF
--- a/app/controllers/concerns/pageflow/public_https_mode.rb
+++ b/app/controllers/concerns/pageflow/public_https_mode.rb
@@ -1,15 +1,13 @@
 module Pageflow
   module PublicHttpsMode
-
     protected
 
     def check_public_https_mode
       if request.ssl? && Pageflow.config.public_https_mode == :prevent
-        redirect_to("http://#{request.host}#{request.fullpath}", :status => :moved_permanently)
+        redirect_to("http://#{request.host}#{request.fullpath}", status: :moved_permanently)
       elsif !request.ssl? && Pageflow.config.public_https_mode == :enforce
-        redirect_to("https://#{request.host}#{request.fullpath}", :status => :moved_permanently)
+        redirect_to("https://#{request.host}#{request.fullpath}", status: :moved_permanently)
       end
     end
-
   end
 end

--- a/app/controllers/concerns/pageflow/public_https_mode.rb
+++ b/app/controllers/concerns/pageflow/public_https_mode.rb
@@ -1,0 +1,15 @@
+module Pageflow
+  module PublicHttpsMode
+
+    protected
+
+    def check_public_https_mode
+      if request.ssl? && Pageflow.config.public_https_mode == :prevent
+        redirect_to("http://#{request.host}#{request.fullpath}", :status => :moved_permanently)
+      elsif !request.ssl? && Pageflow.config.public_https_mode == :enforce
+        redirect_to("https://#{request.host}#{request.fullpath}", :status => :moved_permanently)
+      end
+    end
+
+  end
+end

--- a/app/controllers/pageflow/application_controller.rb
+++ b/app/controllers/pageflow/application_controller.rb
@@ -54,12 +54,6 @@ module Pageflow
       root_url(:protocol => 'http')
     end
 
-    def prevent_ssl
-      if request.ssl?
-        redirect_to("http://#{request.host}#{request.fullpath}", :status => :moved_permanently)
-      end
-    end
-
     def locale_from_accept_language_header
       http_accept_language.compatible_language_from(I18n.available_locales)
     end

--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -1,11 +1,10 @@
 module Pageflow
   class EntriesController < Pageflow::ApplicationController
-
     include PublicHttpsMode
 
     before_filter :authenticate_user!, :except => [:index, :show, :page]
 
-    before_filter :check_public_https_mode, :only => [:index, :show], :unless => lambda { |controller| controller.request.format.json? }
+    before_filter :check_public_https_mode, only: [:index, :show], unless: lambda { |controller| controller.request.format.json? }
 
     helper_method :render_to_string
 

--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -1,8 +1,11 @@
 module Pageflow
   class EntriesController < Pageflow::ApplicationController
+
+    include PublicHttpsMode
+
     before_filter :authenticate_user!, :except => [:index, :show, :page]
 
-    before_filter :prevent_ssl, :only => [:index, :show], :unless => lambda { |controller| controller.request.format.json? }
+    before_filter :check_public_https_mode, :only => [:index, :show], :unless => lambda { |controller| controller.request.format.json? }
 
     helper_method :render_to_string
 

--- a/app/controllers/pageflow/files_controller.rb
+++ b/app/controllers/pageflow/files_controller.rb
@@ -1,6 +1,9 @@
 module Pageflow
   class FilesController < Pageflow::ApplicationController
-    before_filter :prevent_ssl
+
+    include PublicHttpsMode
+
+    before_filter :check_public_https_mode
 
     def show
       respond_to do |format|

--- a/app/controllers/pageflow/files_controller.rb
+++ b/app/controllers/pageflow/files_controller.rb
@@ -1,6 +1,5 @@
 module Pageflow
   class FilesController < Pageflow::ApplicationController
-
     include PublicHttpsMode
 
     before_filter :check_public_https_mode

--- a/lib/generators/pageflow/initializer/templates/pageflow.rb
+++ b/lib/generators/pageflow/initializer/templates/pageflow.rb
@@ -34,6 +34,16 @@ Pageflow.configure do |config|
   # pageflow_filesystem_root paperclip interpolation.
   config.paperclip_filesystem_root = 'tmp/attachments/production'
 
+  # How to handle https requests for URLs which will have assets in the page.
+  # If you wish to serve all assets over http and prevent mixed-content warnings,
+  # you can force a redirect to http. The inverse is also true: you can force
+  # a redirect to https for all http requests.
+  #
+  #     config.public_https_mode = :prevent (default) # => redirects https to http
+  #     config.public_https_mode = :enforce # => redirects http to https
+  #     config.public_https_mode = :ignore # => does nothing
+  config.public_https_mode = :ignore
+
   # Rewrite the below section to use your favorite configuration
   # method: ENV variables, secrets.yml, custom yml files. If you use
   # environment variables consider the dotenv gem to configure your

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -188,6 +188,19 @@ module Pageflow
     # @since 0.7
     attr_accessor :available_locales
 
+    # How to handle https requests for URLs which will have assets in the page.
+    # If you wish to serve all assets over http and prevent mixed-content warnings,
+    # you can force a redirect to http. The inverse is also true: you can force
+    # a redirect to https for all http requests.
+    #
+    # @example
+    #
+    #     config.public_https_mode = :prevent (default) # => redirects https to http
+    #     config.public_https_mode = :enforce # => redirects http to https
+    #     config.public_https_mode = :ignore # => does nothing
+    # @since edge
+    attr_accessor :public_https_mode
+
     def initialize
       @paperclip_filesystem_default_options = {validate_media_type: false}
       @paperclip_s3_default_options = {validate_media_type: false}
@@ -217,6 +230,8 @@ module Pageflow
       @admin_resource_tabs = Pageflow::Admin::Tabs.new
 
       @available_locales = Engine.config.i18n.available_locales
+
+      @public_https_mode = :prevent
     end
 
     # Activate a plugin.

--- a/spec/controllers/pageflow/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/entries_controller_spec.rb
@@ -273,7 +273,7 @@ module Pageflow
           it 'redirects to https when https is enforced' do
             Pageflow.config.public_https_mode = :enforce
 
-            get(:show, :id => entry)
+            get(:show, id: entry)
 
             expect(response).to redirect_to("https://test.host/entries/#{entry.to_param}")
           end
@@ -282,7 +282,7 @@ module Pageflow
             Pageflow.config.public_https_mode = :prevent
             request.env['HTTPS'] = 'on'
 
-            get(:show, :id => entry)
+            get(:show, id: entry)
 
             expect(response).to redirect_to("http://test.host/entries/#{entry.to_param}")
           end
@@ -291,7 +291,7 @@ module Pageflow
             Pageflow.config.public_https_mode = :ignore
             request.env['HTTPS'] = 'on'
 
-            get(:show, :id => entry)
+            get(:show, id: entry)
 
             expect(response.status).to eq(200)
           end
@@ -299,7 +299,7 @@ module Pageflow
           it 'stays on http when https mode is ignored' do
             Pageflow.config.public_https_mode = :ignore
 
-            get(:show, :id => entry)
+            get(:show, id: entry)
 
             expect(response.status).to eq(200)
           end

--- a/spec/controllers/pageflow/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/entries_controller_spec.rb
@@ -266,6 +266,44 @@ module Pageflow
               .with_content_including('Shared page')
           end
         end
+
+        context 'https mode' do
+          let(:entry) { create(:entry, :published) }
+
+          it 'redirects to https when https is enforced' do
+            Pageflow.config.public_https_mode = :enforce
+
+            get(:show, :id => entry)
+
+            expect(response).to redirect_to("https://test.host/entries/#{entry.to_param}")
+          end
+
+          it 'redirects to http when https is prevented' do
+            Pageflow.config.public_https_mode = :prevent
+            request.env['HTTPS'] = 'on'
+
+            get(:show, :id => entry)
+
+            expect(response).to redirect_to("http://test.host/entries/#{entry.to_param}")
+          end
+
+          it 'stays on https when https mode is ignored' do
+            Pageflow.config.public_https_mode = :ignore
+            request.env['HTTPS'] = 'on'
+
+            get(:show, :id => entry)
+
+            expect(response.status).to eq(200)
+          end
+
+          it 'stays on http when https mode is ignored' do
+            Pageflow.config.public_https_mode = :ignore
+
+            get(:show, :id => entry)
+
+            expect(response.status).to eq(200)
+          end
+        end
       end
 
       context 'with format css' do

--- a/spec/controllers/pageflow/files_controller_spec.rb
+++ b/spec/controllers/pageflow/files_controller_spec.rb
@@ -64,6 +64,45 @@ module Pageflow
           expect(response.status).to eq(404)
         end
       end
+
+      context 'https mode' do
+        let(:entry) { create(:entry, :published) }
+        let(:video_file) { create(:video_file, :entry => entry, :used_in => entry.published_revision) }
+
+        it 'redirects to https when https is enforced' do
+          Pageflow.config.public_https_mode = :enforce
+
+          get(:show, :entry_id => entry.id, :collection_name => 'video_files', :id => video_file.id)
+
+          expect(response).to redirect_to("https://test.host/#{entry.id}/videos/#{video_file.id}")
+        end
+
+        it 'redirects to http when https is prevented' do
+          Pageflow.config.public_https_mode = :prevent
+          request.env['HTTPS'] = 'on'
+
+          get(:show, :entry_id => entry.id, :collection_name => 'video_files', :id => video_file.id)
+
+          expect(response).to redirect_to("http://test.host/#{entry.id}/videos/#{video_file.id}")
+        end
+
+        it 'stays on https when https mode is ignored' do
+          Pageflow.config.public_https_mode = :ignore
+          request.env['HTTPS'] = 'on'
+
+          get(:show, :entry_id => entry.id, :collection_name => 'video_files', :id => video_file.id)
+
+          expect(response.status).to eq(200)
+        end
+
+        it 'stays on http when https mode is ignored' do
+          Pageflow.config.public_https_mode = :ignore
+
+          get(:show, :entry_id => entry.id, :collection_name => 'video_files', :id => video_file.id)
+
+          expect(response.status).to eq(200)
+        end
+      end
     end
   end
 end

--- a/spec/controllers/pageflow/files_controller_spec.rb
+++ b/spec/controllers/pageflow/files_controller_spec.rb
@@ -67,12 +67,12 @@ module Pageflow
 
       context 'https mode' do
         let(:entry) { create(:entry, :published) }
-        let(:video_file) { create(:video_file, :entry => entry, :used_in => entry.published_revision) }
+        let(:video_file) { create(:video_file, entry: entry, used_in: entry.published_revision) }
 
         it 'redirects to https when https is enforced' do
           Pageflow.config.public_https_mode = :enforce
 
-          get(:show, :entry_id => entry.id, :collection_name => 'video_files', :id => video_file.id)
+          get(:show, entry_id: entry.id, collection_name: 'video_files', id: video_file.id)
 
           expect(response).to redirect_to("https://test.host/#{entry.id}/videos/#{video_file.id}")
         end
@@ -81,7 +81,7 @@ module Pageflow
           Pageflow.config.public_https_mode = :prevent
           request.env['HTTPS'] = 'on'
 
-          get(:show, :entry_id => entry.id, :collection_name => 'video_files', :id => video_file.id)
+          get(:show, entry_id: entry.id, collection_name: 'video_files', id: video_file.id)
 
           expect(response).to redirect_to("http://test.host/#{entry.id}/videos/#{video_file.id}")
         end
@@ -90,7 +90,7 @@ module Pageflow
           Pageflow.config.public_https_mode = :ignore
           request.env['HTTPS'] = 'on'
 
-          get(:show, :entry_id => entry.id, :collection_name => 'video_files', :id => video_file.id)
+          get(:show, entry_id: entry.id, collection_name: 'video_files', id: video_file.id)
 
           expect(response.status).to eq(200)
         end
@@ -98,7 +98,7 @@ module Pageflow
         it 'stays on http when https mode is ignored' do
           Pageflow.config.public_https_mode = :ignore
 
-          get(:show, :entry_id => entry.id, :collection_name => 'video_files', :id => video_file.id)
+          get(:show, entry_id: entry.id, collection_name: 'video_files', id: video_file.id)
 
           expect(response.status).to eq(200)
         end


### PR DESCRIPTION
Pageflow has always been serving assets over a CDN without https
endpoint. The prevent_ssl filter made sure to redirect to a non-https
method when assets are involved. This change makes that setting
configurable. You can now ignore, enforce or prevent https.

The default is to prevent https, like how Pageflow < 1.0 behaved.
However in new initializers the generated value is :ignore. This should
make the setting compatible with most applications out of the box.

fixes codevise/pageflow#388