### PR TITLE
Implement remembering of scroll position in chapter overview

### DIFF
--- a/app/assets/javascripts/pageflow/editor/initializers/boot.js
+++ b/app/assets/javascripts/pageflow/editor/initializers/boot.js
@@ -3,6 +3,11 @@ pageflow.app.addInitializer(function(options) {
     el: $('body')
   }).render();
 
+  new pageflow.ScrollingView({
+    el: $('sidebar .scrolling'),
+    region: pageflow.app.sidebarRegion
+  }).render();
+
   pageflow.app.previewRegion.show(new pageflow.EntryPreviewView({
     model: pageflow.entry
   }));

--- a/app/assets/javascripts/pageflow/editor/views/scrolling_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/scrolling_view.js
@@ -1,0 +1,24 @@
+pageflow.ScrollingView = Backbone.Marionette.View.extend({
+
+  events: {
+    scroll: function() {
+      if (this._isChapterView()) {
+        this.scrollpos = this.$el.scrollTop();
+      }
+    }
+  },
+
+  initialize: function() {
+    this.scrollpos = 0;
+
+    this.listenTo(this.options.region, 'show', function() {
+      if (this._isChapterView()) {
+        this.$el.scrollTop(this.scrollpos);
+      }
+    });
+  },
+
+  _isChapterView: function() {
+    return !Backbone.history.getFragment();
+  }
+});


### PR DESCRIPTION
The scrollbar's position is now being remembered in the chapters overview. Issue #378 solved.