### PR TITLE
Copy feature flags to duplicated entry

### DIFF
--- a/app/models/pageflow/entry_duplicate.rb
+++ b/app/models/pageflow/entry_duplicate.rb
@@ -38,6 +38,7 @@ module Pageflow
         title: new_title,
         account: original_entry.account,
         theming: original_entry.theming,
+        features_configuration: original_entry.features_configuration,
 
         skip_draft_creation: true
       }

--- a/spec/models/pageflow/entry_duplicate_spec.rb
+++ b/spec/models/pageflow/entry_duplicate_spec.rb
@@ -38,6 +38,14 @@ module Pageflow
 
         expect(duplicate.users.first).to eq(user)
       end
+
+      it 'copies enabled features' do
+        entry = create(:entry, features_configuration: {fancy_page_type: true})
+
+        duplicate = EntryDuplicate.of(entry).create!
+
+        expect(duplicate.feature_state('fancy_page_type')).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
Ensure the same features are enabled on the copied entry. Otherwise there may be errors when opening the editor and page types are missing.