### PR TITLE
Record when an entry has first been published 

### DIFF
--- a/app/models/pageflow/entry.rb
+++ b/app/models/pageflow/entry.rb
@@ -54,6 +54,7 @@ module Pageflow
 
     def publish(options = {})
       ActiveRecord::Base.transaction do
+        self.first_published_at ||= Time.now
         update_password!(options.slice(:password, :password_protected))
 
         revisions.depublish_all

--- a/db/migrate/20151022080518_add_first_published_at_to_entries.rb
+++ b/db/migrate/20151022080518_add_first_published_at_to_entries.rb
@@ -1,0 +1,14 @@
+class AddFirstPublishedAtToEntries < ActiveRecord::Migration
+  def change
+    add_column :pageflow_entries, :first_published_at, :datetime
+
+    execute(<<-SQL)
+      UPDATE pageflow_entries SET first_published_at = (
+        SELECT MIN(published_at)
+        FROM pageflow_revisions
+        WHERE pageflow_revisions.entry_id = pageflow_entries.id
+        LIMIT 1
+      );
+    SQL
+  end
+end

--- a/spec/models/pageflow/entry_spec.rb
+++ b/spec/models/pageflow/entry_spec.rb
@@ -99,6 +99,24 @@ module Pageflow
         expect(revision).to be_frozen
       end
 
+      it 'sets first_published_at on first publication' do
+        creator = create(:user)
+        entry = create(:entry)
+
+        entry.publish(creator: creator)
+
+        expect(entry.first_published_at).to be_present
+      end
+
+      it 'does not set first_published_at if it is already present' do
+        creator = create(:user)
+        entry = create(:entry, first_published_at: 1.day.ago)
+
+        entry.publish(creator: creator)
+
+        expect(entry.first_published_at).to eq(1.day.ago)
+      end
+
       context 'with :published_until option' do
         it 'publishes entry directly' do
           creator = create(:user)

--- a/spec/models/pageflow/entry_spec.rb
+++ b/spec/models/pageflow/entry_spec.rb
@@ -33,8 +33,8 @@ module Pageflow
 
     context 'validation' do
       it 'ensures folder belongs to same account' do
-        folder = build(:folder, :account => build_stubbed(:account))
-        entry = build(:entry, :account => build_stubbed(:account))
+        folder = build(:folder, account: build_stubbed(:account))
+        entry = build(:entry, account: build_stubbed(:account))
 
         entry.folder = folder
 
@@ -48,7 +48,7 @@ module Pageflow
         entry = create(:entry)
 
         expect {
-          entry.publish(:creator => creator)
+          entry.publish(creator: creator)
         }.to change { entry.revisions.count }
       end
 
@@ -56,7 +56,7 @@ module Pageflow
         creator = create(:user)
         entry = create(:entry)
 
-        entry.publish(:creator => creator)
+        entry.publish(creator: creator)
 
         expect(entry).to be_published
       end
@@ -66,7 +66,7 @@ module Pageflow
         entry = create(:entry, :published)
 
         revision = entry.published_revision
-        entry.publish(:creator => creator)
+        entry.publish(creator: creator)
 
         expect(entry.published_revision).not_to eq(revision)
       end
@@ -74,9 +74,9 @@ module Pageflow
       it 'depublishes eariler revisions' do
         creator = create(:user)
         entry = create(:entry)
-        earlier_revision = create(:revision, :published, :entry => entry, :published_at => 1.week.ago)
+        earlier_revision = create(:revision, :published, entry: entry, published_at: 1.week.ago)
 
-        entry.publish(:creator => creator)
+        entry.publish(creator: creator)
 
         expect(earlier_revision.reload).not_to be_published
       end
@@ -85,7 +85,7 @@ module Pageflow
         creator = create(:user)
         entry = create(:entry)
 
-        revision = entry.publish(:creator => creator)
+        revision = entry.publish(creator: creator)
 
         expect(revision.creator).to be(creator)
       end
@@ -94,7 +94,7 @@ module Pageflow
         creator = create(:user)
         entry = create(:entry)
 
-        revision = entry.publish(:creator => creator)
+        revision = entry.publish(creator: creator)
 
         expect(revision).to be_frozen
       end
@@ -104,7 +104,7 @@ module Pageflow
           creator = create(:user)
           entry = create(:entry)
 
-          entry.publish(:published_until => 1.month.from_now, :creator => creator)
+          entry.publish(published_until: 1.month.from_now, creator: creator)
 
           expect(entry).to be_published
         end
@@ -113,7 +113,7 @@ module Pageflow
           creator = create(:user)
           entry = create(:entry)
 
-          entry.publish(:published_until => 1.month.from_now, :creator => creator)
+          entry.publish(published_until: 1.month.from_now, creator: creator)
 
           Timecop.freeze(1.month.from_now) do
             expect(entry).not_to be_published
@@ -126,9 +126,9 @@ module Pageflow
           creator = create(:user)
           entry = create(:entry)
 
-          entry.publish(:creator => creator,
-                        :password_protected => true,
-                        :password => 'abc123abc')
+          entry.publish(creator: creator,
+                        password_protected: true,
+                        password: 'abc123abc')
 
           expect(entry).to be_published_with_password('abc123abc')
         end
@@ -139,9 +139,9 @@ module Pageflow
           creator = create(:user)
           entry = create(:entry)
 
-          entry.publish(:creator => creator,
-                        :password_protected => false,
-                        :password => 'abc123abc')
+          entry.publish(creator: creator,
+                        password_protected: false,
+                        password: 'abc123abc')
 
           expect(entry).to be_published_without_password
         end
@@ -150,13 +150,13 @@ module Pageflow
           creator = create(:user)
           entry = create(:entry)
 
-          entry.publish(:creator => creator,
-                        :password_protected => false,
-                        :password => 'abc123abc')
+          entry.publish(creator: creator,
+                        password_protected: false,
+                        password: 'abc123abc')
 
           expect {
-            entry.publish(:creator => creator,
-                          :password_protected => true)
+            entry.publish(creator: creator,
+                          password_protected: true)
           }.to raise_error(Entry::PasswordMissingError)
         end
 
@@ -164,15 +164,15 @@ module Pageflow
           creator = create(:user)
           entry = create(:entry)
 
-          entry.publish(:creator => creator,
-                        :password_protected => true,
-                        :password => 'abc123abc')
-          entry.publish(:creator => creator,
-                        :password_protected => false)
+          entry.publish(creator: creator,
+                        password_protected: true,
+                        password: 'abc123abc')
+          entry.publish(creator: creator,
+                        password_protected: false)
 
           expect {
-            entry.publish(:creator => creator,
-                          :password_protected => true)
+            entry.publish(creator: creator,
+                          password_protected: true)
           }.to raise_error(Entry::PasswordMissingError)
         end
       end
@@ -182,11 +182,11 @@ module Pageflow
           creator = create(:user)
           entry = create(:entry)
 
-          entry.publish(:creator => creator,
-                        :password_protected => true,
-                        :password => 'abc123abc')
-          entry.publish(:creator => creator,
-                        :password_protected => true)
+          entry.publish(creator: creator,
+                        password_protected: true,
+                        password: 'abc123abc')
+          entry.publish(creator: creator,
+                        password_protected: true)
 
           expect(entry).to be_published_with_password('abc123abc')
         end
@@ -196,8 +196,8 @@ module Pageflow
           entry = create(:entry)
 
           expect {
-            entry.publish(:creator => creator,
-                          :password_protected => true)
+            entry.publish(creator: creator,
+                          password_protected: true)
           }.to raise_error(Entry::PasswordMissingError)
         end
 
@@ -205,11 +205,11 @@ module Pageflow
           creator = create(:user)
           entry = create(:entry)
 
-          entry.publish(:creator => creator)
+          entry.publish(creator: creator)
 
           expect {
-            entry.publish(:creator => creator,
-                          :password_protected => true)
+            entry.publish(creator: creator,
+                          password_protected: true)
           }.to raise_error(Entry::PasswordMissingError)
         end
       end
@@ -219,20 +219,20 @@ module Pageflow
       it 'creates a revision' do
         creator = create(:user)
         entry = create(:entry)
-        earlier_revision = create(:revision, :published, :entry => entry)
+        earlier_revision = create(:revision, :published, entry: entry)
 
         expect {
-          entry.restore(:revision => earlier_revision, :creator => creator)
+          entry.restore(revision: earlier_revision, creator: creator)
         }.to change { entry.revisions.count }
       end
 
       it 'freezes previous draft' do
         creator = create(:user)
         entry = create(:entry)
-        earlier_revision = create(:revision, :published, :entry => entry)
+        earlier_revision = create(:revision, :published, entry: entry)
 
         draft_before_restore = entry.draft
-        entry.restore(:revision => earlier_revision, :creator => creator)
+        entry.restore(revision: earlier_revision, creator: creator)
 
         expect(draft_before_restore.reload).to be_frozen
       end
@@ -240,10 +240,10 @@ module Pageflow
       it 'turns previous draft into snapshot of type before_restore' do
         creator = create(:user)
         entry = create(:entry)
-        earlier_revision = create(:revision, :published, :entry => entry)
+        earlier_revision = create(:revision, :published, entry: entry)
 
         draft_before_restore = entry.draft
-        revision = entry.restore(:revision => earlier_revision, :creator => creator)
+        entry.restore(revision: earlier_revision, creator: creator)
 
         expect(draft_before_restore.reload.snapshot_type).to eq('before_restore')
       end
@@ -252,9 +252,9 @@ module Pageflow
         it 'turns copy of passed revision into new draft' do
           creator = create(:user)
           entry = create(:entry)
-          earlier_revision = create(:revision, :published, :title => 'the way it was', :entry => entry)
+          earlier_revision = create(:revision, :published, title: 'the way it was', entry: entry)
 
-          entry.restore(:revision => earlier_revision, :creator => creator)
+          entry.restore(revision: earlier_revision, creator: creator)
 
           expect(entry.draft(true).title).to eq('the way it was')
         end
@@ -264,11 +264,11 @@ module Pageflow
           entry = create(:entry)
           earlier_revision = create(:revision,
                                     :published,
-                                    :title => 'the way it was',
-                                    :entry => entry,
-                                    :password_protected => true)
+                                    title: 'the way it was',
+                                    entry: entry,
+                                    password_protected: true)
 
-          entry.restore(:revision => earlier_revision, :creator => creator)
+          entry.restore(revision: earlier_revision, creator: creator)
 
           expect(entry.draft(true)).not_to be_password_protected
         end
@@ -278,9 +278,9 @@ module Pageflow
         it 'turns copy of passed revision into new draft' do
           creator = create(:user)
           entry = create(:entry)
-          earlier_revision = create(:revision, :frozen, :title => 'the way it was', :entry => entry)
+          earlier_revision = create(:revision, :frozen, title: 'the way it was', entry: entry)
 
-          entry.restore(:revision => earlier_revision, :creator => creator)
+          entry.restore(revision: earlier_revision, creator: creator)
 
           expect(entry.draft(true).title).to eq('the way it was')
         end
@@ -289,10 +289,10 @@ module Pageflow
       it 'saves creator in previous draft' do
         creator = create(:user)
         entry = create(:entry)
-        earlier_revision = create(:revision, :published, :entry => entry)
+        earlier_revision = create(:revision, :published, entry: entry)
 
         draft_before_restore = entry.draft
-        revision = entry.restore(:revision => earlier_revision, :creator => creator)
+        entry.restore(revision: earlier_revision, creator: creator)
 
         expect(draft_before_restore.reload.creator).to eq(creator)
       end
@@ -300,9 +300,9 @@ module Pageflow
       it 'saves which revision was restored from' do
         creator = create(:user)
         entry = create(:entry)
-        earlier_revision = create(:revision, :published, :entry => entry)
+        earlier_revision = create(:revision, :published, entry: entry)
 
-        revision = entry.restore(:revision => earlier_revision, :creator => creator)
+        entry.restore(revision: earlier_revision, creator: creator)
 
         expect(entry.draft(true).restored_from).to eq(earlier_revision)
       end
@@ -314,7 +314,7 @@ module Pageflow
         entry = create(:entry)
 
         expect {
-          entry.snapshot(:creator => creator)
+          entry.snapshot(creator: creator)
         }.to change { entry.revisions.count }
       end
 
@@ -322,7 +322,7 @@ module Pageflow
         creator = create(:user)
         entry = create(:entry)
 
-        revision = entry.snapshot(:creator => creator)
+        revision = entry.snapshot(creator: creator)
 
         expect(revision.creator).to be(creator)
       end
@@ -331,7 +331,7 @@ module Pageflow
         creator = create(:user)
         entry = create(:entry)
 
-        revision = entry.snapshot(:creator => creator)
+        revision = entry.snapshot(creator: creator)
 
         expect(revision).to be_frozen
       end
@@ -340,7 +340,7 @@ module Pageflow
         creator = create(:user)
         entry = create(:entry)
 
-        revision = entry.snapshot(:creator => creator)
+        revision = entry.snapshot(creator: creator)
 
         expect(revision.snapshot_type).to eq('auto')
       end
@@ -349,7 +349,7 @@ module Pageflow
         creator = create(:user)
         entry = create(:entry)
 
-        revision = entry.snapshot(:creator => creator, :type => 'user')
+        revision = entry.snapshot(creator: creator, type: 'user')
 
         expect(revision.snapshot_type).to eq('user')
       end
@@ -360,9 +360,7 @@ module Pageflow
     it 'creates a new entry' do
       entry = create(:entry)
 
-      expect {
-        entry.duplicate
-      }.to change { Entry.count }
+      expect { entry.duplicate }.to change { Entry.count }
     end
   end
 end


### PR DESCRIPTION
Allows to easily sort entries by publication date without having them move to the top on re-publication.