### PR TITLE
Allow adding Pageflow configure blocks in tests

### DIFF
--- a/spec/features/admin/enabled_a_feature_for_an_account_spec.rb
+++ b/spec/features/admin/enabled_a_feature_for_an_account_spec.rb
@@ -4,6 +4,10 @@ feature 'admim enabling a feature for an account' do
   scenario 'enabled for account' do
     account = create(:account)
 
+    pageflow_configure do |config|
+      config.features.register('test_feature')
+    end
+
     Dom::Admin::Page.sign_in_as(:admin)
     visit(admin_account_path(account))
     Dom::Admin::AccountPage.find!.features_tab.click

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,13 +13,4 @@ RSpec.configure do |config|
 
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"
-
-  # Reset configuration
-  config.before do
-    Pageflow.configure!
-  end
-end
-
-Pageflow.configure do |config|
-  config.features.register('test_feature')
 end

--- a/spec/support/helpers/pageflow_global_config_api_helper.rb
+++ b/spec/support/helpers/pageflow_global_config_api_helper.rb
@@ -1,0 +1,29 @@
+$CUSTOM_PAGEFLOW_CONFIGURE_BLOCK = nil
+
+# This helper allows to register a custom configure block that shall
+# be executed in the context of a test. This is required when testing
+# functionality that calls `Pageflow.config_for`, which builds up a
+# new configuration object. Simply calling `Pageflow.configure` from
+# inside a test does not work since there is no easy way to tear it
+# down after the test.
+module PageflowGlobalConfigApiHelper
+  def pageflow_configure(&block)
+    $CUSTOM_PAGEFLOW_CONFIGURE_BLOCK = block
+    Pageflow.configure!
+  end
+end
+
+Pageflow.configure do |config|
+  if $CUSTOM_PAGEFLOW_CONFIGURE_BLOCK
+    $CUSTOM_PAGEFLOW_CONFIGURE_BLOCK.call(config)
+  end
+end
+
+RSpec.configure do |config|
+  config.include(PageflowGlobalConfigApiHelper)
+
+  config.before do
+    $CUSTOM_PAGEFLOW_CONFIGURE_BLOCK = nil
+    Pageflow.configure!
+  end
+end


### PR DESCRIPTION
This new test helper allows to test controllers that use the `Pageflow.config_for` method. This is necessary since manually made changes to `Pageflow.config` as part of test setup are not visible in these config objects.