### PR TITLE
Add configuration API to add inputs to admin forms 

### DIFF
--- a/.rubocop_hound.yml
+++ b/.rubocop_hound.yml
@@ -416,7 +416,7 @@ Style/SpaceInsideHashLiteralBraces:
   Description: Use spaces inside hash literal braces - or don't.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
   Enabled: true
-  EnforcedStyle: space
+  EnforcedStyle: no_space
   EnforcedStyleForEmptyBraces: no_space
   SupportedStyles:
   - space

--- a/admins/pageflow/accounts.rb
+++ b/admins/pageflow/accounts.rb
@@ -57,27 +57,47 @@ module Pageflow
       end
 
       def permitted_params
-        result = params.permit(:account => [
-                                 :name,
-                                 :default_file_rights,
-                                 :default_theming_attributes => [
-                                   :cname,
-                                   :theme_name,
-                                   :imprint_link_url,
-                                   :imprint_link_label,
-                                   :copyright_link_url,
-                                   :copyright_link_label,
-                                   :home_url,
-                                   :home_button_enabled_by_default
-                                 ]
-                               ])
+        result = params.permit(account: permitted_account_attributes)
 
         if result[:account]
           feature_states = params[:account][:feature_states].try(:permit!)
-          result[:account].merge!(:feature_states => feature_states || {})
+          result[:account].merge!(feature_states: feature_states || {})
         end
 
         result
+      end
+
+      private
+
+      def permitted_account_attributes
+        [
+          :name,
+          :default_file_rights,
+          default_theming_attributes: permitted_theming_attributes
+        ] +
+          permitted_attributes_for(:account)
+      end
+
+      def permitted_theming_attributes
+        [
+          :cname,
+          :theme_name,
+          :imprint_link_url,
+          :imprint_link_label,
+          :copyright_link_url,
+          :copyright_link_label,
+          :home_url,
+          :home_button_enabled_by_default
+        ] +
+          permitted_attributes_for(:theming)
+      end
+
+      def permitted_attributes_for(resource_name)
+        if params[:id]
+          Pageflow.config_for(resource).admin_form_inputs.permitted_attributes_for(resource_name)
+        else
+          []
+        end
       end
     end
   end

--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -51,6 +51,8 @@ module Pageflow
         if authorized?(:manage, Folder)
           f.input :folder, :collection => collection_for_folders(f.object.account), :include_blank => true
         end
+
+        Pageflow.config_for(f.object).admin_form_inputs.build(:entry, f)
       end
       f.actions
     end
@@ -126,16 +128,20 @@ module Pageflow
       end
 
       def permitted_params
-        result = params.permit(:entry => [:title, :account_id, :theming_id, :folder_id])
-        restrict_attributes(params[:id], result[:entry]) if result[:entry]
-        result
+        params.permit(entry: permitted_attributes)
       end
 
       private
 
-      def restrict_attributes(id, attributes)
-        attributes.except!(:account_id, :theming_id) unless authorized?(:read, Account)
-        attributes.except!(:folder_id) unless authorized?(:manage, Folder)
+      def permitted_attributes
+        result = [:title]
+
+        target = params[:id] ? resource : current_user.account
+        result += Pageflow.config_for(target).admin_form_inputs.permitted_attributes_for(:entry)
+
+        result += [:account_id, :theming_id] if authorized?(:read, Account)
+        result << :folder_id if authorized?(:manage, Folder)
+        result
       end
     end
   end

--- a/app/views/admin/accounts/_form.html.erb
+++ b/app/views/admin/accounts/_form.html.erb
@@ -1,7 +1,13 @@
 <%= semantic_form_for [:admin, resource] do |f| %>
+  <% account_config = Pageflow.config_for(f.object) %>
+
   <%= f.inputs do %>
     <%= f.input :name %>
     <%= f.input :default_file_rights %>
+
+    <% account_config.admin_form_inputs.find_all_for(:account).each do |form_input| %>
+      <%= form_input.build(f) %>
+    <% end %>
   <% end %>
 
   <%= f.semantic_fields_for :default_theming do |theming| %>
@@ -18,7 +24,9 @@
       <%= theming.input :copyright_link_label %>
       <%= theming.input :copyright_link_url %>
 
-      <% account_config = Pageflow.config_for(theming.object.account) %>
+      <% account_config.admin_form_inputs.find_all_for(:theming).each do |form_input| %>
+        <%= form_input.build(theming) %>
+      <% end %>
 
       <% theming.object.widgets.resolve(:include_placeholders => true).each do |widget| %>
         <%= f.semantic_fields_for(widget) do |w| %>

--- a/lib/pageflow/admin/form_input.rb
+++ b/lib/pageflow/admin/form_input.rb
@@ -1,0 +1,18 @@
+module Pageflow
+  module Admin
+    # @api private
+    class FormInput
+      attr_reader :attribute_name
+
+      def initialize(attribute_name, options)
+        @attribute_name = attribute_name
+        @options = options
+      end
+
+      def build(form_builder)
+        options = @options.respond_to?(:call) ? @options.call : @options
+        form_builder.input(attribute_name, options)
+      end
+    end
+  end
+end

--- a/lib/pageflow/admin/form_inputs.rb
+++ b/lib/pageflow/admin/form_inputs.rb
@@ -1,0 +1,41 @@
+module Pageflow
+  module Admin
+    # A registry of additional inputs for admin forms.
+    #
+    # @since edge
+    class FormInputs
+      def initialize
+        @resources = {}
+      end
+
+      # Register a proc which adds additional inputs to admin forms.
+      #
+      # @param resource_name [Symbol] A resource name like `:entry`,
+      #   `:account` or `:theming`
+      # @param attribute_name [Symbol] The name of the additional
+      #   attribute
+      # @param options [Hash] Formtastic options
+      def register(resource_name, attribute_name, options = {})
+        @resources[resource_name] ||= []
+        @resources[resource_name] << FormInput.new(attribute_name, options)
+      end
+
+      # @api private
+      def build(resource_name, form_builder)
+        find_all_for(resource_name).each do |form_input|
+          form_input.build(form_builder)
+        end
+      end
+
+      # @api private
+      def permitted_attributes_for(resource_name)
+        find_all_for(resource_name).map(&:attribute_name)
+      end
+
+      # @api private
+      def find_all_for(resource_name)
+        @resources.fetch(resource_name, [])
+      end
+    end
+  end
+end

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -180,8 +180,20 @@ module Pageflow
     #
     #     config.admin_resource_tabs.register(:entry, Admin::CustomTab)
     #
-    # @return [Admin::TabsRegistry]
+    # @return [Admin::Tabs]
     attr_reader :admin_resource_tabs
+
+    # Add custom form fields to admin forms.
+    #
+    # @example
+    #
+    #     config.admin_form_inputs.register(:entry) do |form|
+    #       form.input(:custom_field)
+    #     end
+    #
+    # @since edge
+    # @return [Admin::FormInputs]
+    attr_reader :admin_form_inputs
 
     # Array of locales which can be chosen as interface language by a
     # user or for an entry. Defaults to `I18n.available_locales`.
@@ -228,6 +240,7 @@ module Pageflow
       @confirm_encoding_jobs = false
 
       @admin_resource_tabs = Pageflow::Admin::Tabs.new
+      @admin_form_inputs = Pageflow::Admin::FormInputs.new
 
       @available_locales = Engine.config.i18n.available_locales
 
@@ -274,6 +287,7 @@ module Pageflow
       delegate :page_types, to: :config
       delegate :widget_types, to: :config
       delegate :help_entries, to: :config
+      delegate :admin_form_inputs, to: :config
     end
   end
 end

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -62,6 +62,21 @@ describe Admin::EntriesController do
     end
   end
 
+  describe '#new' do
+    it 'displays additional registered form inputs' do
+      user = create(:user, :account_manager)
+
+      pageflow_configure do |config|
+        config.admin_form_inputs.register(:entry, :custom_field)
+      end
+
+      sign_in(user)
+      get :new
+
+      expect(response.body).to have_selector('[name="entry[custom_field]"]')
+    end
+  end
+
   describe '#create' do
     it 'does not allow account manager to create entries for other account' do
       account = create(:account)
@@ -122,6 +137,79 @@ describe Admin::EntriesController do
       post :create, :entry => attributes_for(:entry, :account_id => account)
 
       expect(Pageflow::Entry.last.theming).to eq(account.default_theming)
+    end
+
+    it 'allows account manager to define custom field registered as form input' do
+      user = create(:user, :account_manager)
+
+      pageflow_configure do |config|
+        config.admin_form_inputs.register(:entry, :custom_field)
+      end
+
+      sign_in(user)
+      post(:create, entry: {custom_field: 'some value'})
+
+      expect(Pageflow::Entry.last.custom_field).to eq('some value')
+    end
+
+    it 'does not allows account manager to define custom field not registered as form input' do
+      user = create(:user, :account_manager)
+
+      sign_in(user)
+      post(:create, entry: {custom_field: 'some value'})
+
+      expect(Pageflow::Entry.last.custom_field).to eq(nil)
+    end
+  end
+
+  describe '#edit' do
+    it 'displays additional registered form inputs' do
+      user = create(:user, :editor)
+      entry = create(:entry, with_member: user)
+
+      pageflow_configure do |config|
+        config.admin_form_inputs.register(:entry, :custom_field)
+      end
+
+      sign_in(user)
+      get :edit, id: entry
+
+      expect(response.body).to have_selector('[name="entry[custom_field]"]')
+    end
+
+    it 'displays additional form inputs registered inside enabled feature' do
+      user = create(:user, :editor)
+      entry = create(:entry,
+                     with_member: user,
+                     feature_states: {custom_entry_field: true})
+
+      pageflow_configure do |config|
+        config.features.register('custom_entry_field') do |feature_config|
+          feature_config.admin_form_inputs.register(:entry, :custom_field)
+        end
+      end
+
+      sign_in(user)
+      get :edit, id: entry
+
+      expect(response.body).to have_selector('[name="entry[custom_field]"]')
+    end
+
+    it 'does not display additional form inputs registered inside disabled feature' do
+      user = create(:user, :editor)
+      entry = create(:entry,
+                     with_member: user)
+
+      pageflow_configure do |config|
+        config.features.register('custom_entry_field') do |feature_config|
+          feature_config.admin_form_inputs.register(:entry, :custom_field)
+        end
+      end
+
+      sign_in(user)
+      get :edit, id: entry
+
+      expect(response.body).not_to have_selector('[name="entry[custom_field]"]')
     end
   end
 
@@ -212,6 +300,30 @@ describe Admin::EntriesController do
       patch :update, :id => entry, :entry => {:folder_id => folder}
 
       expect(entry.reload.folder).to eq(folder)
+    end
+
+    it 'allows editor to change custom field registered as form input' do
+      user = create(:user, :editor)
+      entry = create(:entry, with_member: user, account: user.account)
+
+      pageflow_configure do |config|
+        config.admin_form_inputs.register(:entry, :custom_field)
+      end
+
+      sign_in(user)
+      patch(:update, id: entry, entry: {custom_field: 'some value'})
+
+      expect(entry.reload.custom_field).to eq('some value')
+    end
+
+    it 'does not allows editor to change custom field not registered as form input' do
+      user = create(:user, :editor)
+      entry = create(:entry, with_member: user, account: user.account)
+
+      sign_in(user)
+      patch(:update, id: entry, entry: {custom_field: 'some value'})
+
+      expect(entry.reload.custom_field).to eq(nil)
     end
   end
 

--- a/spec/pageflow/admin/form_inputs_spec.rb
+++ b/spec/pageflow/admin/form_inputs_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+module Pageflow
+  module Admin
+    describe FormInputs do
+      describe '#build' do
+        it 'calls input for registered form inputs' do
+          form_inputs = FormInputs.new
+          form_builder = double('form builder').as_null_object
+
+          form_inputs.register(:entry, :title)
+          form_inputs.register(:entry, :text, hint: 'text')
+          form_inputs.build(:entry, form_builder)
+
+          expect(form_builder).to have_received(:input).with(:title, {})
+          expect(form_builder).to have_received(:input).with(:text, hint: 'text')
+        end
+
+        it 'only calls input for given resource' do
+          form_inputs = FormInputs.new
+          form_builder = double('form builder').as_null_object
+
+          form_inputs.register(:entry, :title)
+          form_inputs.build(:account, form_builder)
+
+          expect(form_builder).not_to have_received(:input)
+        end
+
+        it 'supports options as lambda' do
+          form_inputs = FormInputs.new
+          form_builder = double('form builder').as_null_object
+
+          form_inputs.register(:entry, :title, -> { {hint: 'localized hint'} })
+          form_inputs.build(:entry, form_builder)
+
+          expect(form_builder).to have_received(:input).with(:title, hint: 'localized hint')
+        end
+      end
+
+      describe '#permitted_attributes_for' do
+        it 'returns names of inputs for resource' do
+          form_inputs = FormInputs.new
+
+          form_inputs.register(:entry, :title)
+          form_inputs.register(:entry, :text)
+          form_inputs.register(:account, :name)
+          result = form_inputs.permitted_attributes_for(:entry)
+
+          expect(result).to eq([:title, :text])
+        end
+      end
+
+      describe '#find_all_for' do
+        it 'returns form inputs for resource' do
+          form_inputs = FormInputs.new
+
+          form_inputs.register(:entry, :title)
+          form_inputs.register(:entry, :text)
+          form_inputs.register(:account, :name)
+          result = form_inputs.find_all_for(:entry)
+
+          expect(result.map(&:attribute_name)).to eq([:title, :text])
+        end
+      end
+    end
+  end
+end

--- a/spec/support/pageflow/dummy/rails_template.rb
+++ b/spec/support/pageflow/dummy/rails_template.rb
@@ -49,6 +49,7 @@ prepend_to_file('config/initializers/pageflow.rb',
 
 copy_file('create_test_hosted_file.rb', 'db/migrate/00000000000000_create_test_hosted_file.rb')
 copy_file('create_test_revision_component.rb', 'db/migrate/00000000000001_create_test_revision_component.rb')
+copy_file('add_custom_fields.rb', 'db/migrate/99990000000000_add_custom_fields.rb')
 
 # Devise bug fix: rename migrations without file extension
 

--- a/spec/support/pageflow/dummy/templates/add_custom_fields.rb
+++ b/spec/support/pageflow/dummy/templates/add_custom_fields.rb
@@ -1,0 +1,7 @@
+class AddCustomFields < ActiveRecord::Migration
+  def change
+    add_column :pageflow_entries, :custom_field, :string
+    add_column :pageflow_accounts, :custom_field, :string
+    add_column :pageflow_themings, :custom_field, :string
+  end
+end


### PR DESCRIPTION
Via the `Pageflow.config.admin_form_inputs.register` method it is now possible to add further inputs to entry, account and theming forms. This provides a cleaner extension point than overriding from partials or admin methods.