### PR TITLE
Make editor background color black

### DIFF
--- a/app/assets/stylesheets/pageflow/editor/base.css.scss
+++ b/app/assets/stylesheets/pageflow/editor/base.css.scss
@@ -122,6 +122,7 @@ main.ui-layout-pane {
   padding: 0;
   overflow: hidden;
   border: 0;
+  background-color: #000;
 }
 
 main > div {


### PR DESCRIPTION
Some page types rely on the fact that the background of the Pageflow
is black, which is true in the published version. Since the editor's
preview background was white, especially pages without configured
background image used to flash on page change.