### PR TITLE
Reload dynamically generated entry stylesheet

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,7 @@ Style/Blocks:
 # The default of 80 characters is a little to narrow.
 Metrics/LineLength:
   Max: 100
+
+# Only place spaces inside blocks written with braces.
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space

--- a/app/assets/javascripts/pageflow/editor/base.js
+++ b/app/assets/javascripts/pageflow/editor/base.js
@@ -15,6 +15,7 @@
 
 //= require_self
 
+//= require_tree ./utils
 //= require_tree ./models/mixins
 //= require ./models/uploaded_file
 //= require ./models/hosted_file
@@ -49,6 +50,7 @@
 //= require ./initializers/setup_hotkeys
 //= require ./initializers/edit_lock
 //= require ./initializers/files_polling
+//= require ./initializers/stylesheet_reloading
 //= require ./initializers/routing
 //= require ./initializers/error_listener
 //= require ./initializers/additional_initializers

--- a/app/assets/javascripts/pageflow/editor/initializers/stylesheet_reloading.js
+++ b/app/assets/javascripts/pageflow/editor/initializers/stylesheet_reloading.js
@@ -4,4 +4,8 @@ pageflow.app.addInitializer(function(options) {
       pageflow.reloadStylesheet('entry');
     }
   });
+
+  pageflow.entry.on('use:file', function() {
+    pageflow.reloadStylesheet('entry');
+  });
 });

--- a/app/assets/javascripts/pageflow/editor/initializers/stylesheet_reloading.js
+++ b/app/assets/javascripts/pageflow/editor/initializers/stylesheet_reloading.js
@@ -1,0 +1,7 @@
+pageflow.app.addInitializer(function(options) {
+  pageflow.entry.on('change:pending_files_count', function(model, value) {
+    if (value < pageflow.entry.previous('pending_files_count')) {
+      pageflow.reloadStylesheet('entry');
+    }
+  });
+});

--- a/app/assets/javascripts/pageflow/editor/models/entry.js
+++ b/app/assets/javascripts/pageflow/editor/models/entry.js
@@ -78,6 +78,8 @@ pageflow.Entry = Backbone.Model.extend({
     fileUsages.createForFile(file, { success: function(usage) {
       file.set('usage_id', usage.get('id'));
       this.getFileCollection(file.fileType()).add(file);
+
+      this.trigger('use:file', file);
     }.bind(this)});
   },
 

--- a/app/assets/javascripts/pageflow/editor/utils/reload_stylesheet.js
+++ b/app/assets/javascripts/pageflow/editor/utils/reload_stylesheet.js
@@ -1,0 +1,9 @@
+pageflow.reloadStylesheet = function(name) {
+  var link = $('head link[data-name=' + name + ']');
+
+  if (!link.data('originalHref')) {
+    link.data('originalHref', link.attr('href'));
+  }
+
+  link.attr('href', link.data('originalHref') + '&reload=' + new Date().getTime());
+};

--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -46,7 +46,9 @@ module Pageflow
                              p: Pageflow::VERSION,
                              format: 'css')
 
-      stylesheet_link_tag(url, media: 'all')
+      stylesheet_link_tag(url,
+                          media: 'all',
+                          data: {name: 'entry'})
     end
 
     def entry_mobile_navigation_pages(entry)


### PR DESCRIPTION
This allows to use image css class in the editor instead of urls in inline styles. The editor display does therefore better match the final result.