### PR TITLE
Correctly detect links to prevent default for in editor

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/editor_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/editor_view.js
@@ -2,9 +2,9 @@ pageflow.EditorView = Backbone.View.extend({
   events: {
     'click a': function(event) {
       // prevent default for all links
-      if (!$(event.target).attr('target') &&
-          !$(event.target).attr('download') &&
-          !$(event.target).attr('href')) {
+      if (!$(event.currentTarget).attr('target') &&
+          !$(event.currentTarget).attr('download') &&
+          !$(event.currentTarget).attr('href')) {
         return false;
       }
     }


### PR DESCRIPTION
Previously we were looking at `event.target` to determine if `href` is empty. But if a `div` inside a link was clicked, the `div` is the target. We have to use `currentTarget` to inspect the link.