### PR TITLE
Disallow links in overview description

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/configuration_editors/groups/options.js
+++ b/app/assets/javascripts/pageflow/editor/views/configuration_editors/groups/options.js
@@ -11,7 +11,7 @@ pageflow.ConfigurationEditorTabView.groups.define('options', function(options) {
     this.input('delayed_text_fade_in', pageflow.SelectInputView, {values: pageflow.Page.delayedTextFadeIn});
   }
 
-  this.input('description', pageflow.TextAreaInputView, {size: 'short'});
+  this.input('description', pageflow.TextAreaInputView, {size: 'short', disableLinks: true});
 
   if (pageflow.features.isEnabled('atmo')) {
     this.input('atmo_audio_file_id', pageflow.FileInputView, {


### PR DESCRIPTION
Links within the overview description cause misalignment of the preview boxes. Thus it is reasonable to disallow setting links there. Note: This bugfix requires PR #404.