### PR TITLE
Prevent incorrectly called page type hook on manual start

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/page_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/page_widget.js
@@ -169,7 +169,7 @@
         that._triggerPageTypeHook(name);
       });
 
-      this.element.one('deactivate', function() {
+      this.element.one('pagedeactivate', function() {
         handle.cancel();
       });
     },


### PR DESCRIPTION
If manual start is enabled, the activated hook of the first page is
not supposed to be triggered if another page has already been
navigated to via the url fragment.

The page widget listens for its `deactivate` event to cancel delayed
page type hooks. The event name was wrong though, causing the page
hook to fire anyway.