### PR TITLE
Use entry locale for scroll indicators in editor

### DIFF
--- a/app/views/pageflow/entries/edit.html.erb
+++ b/app/views/pageflow/entries/edit.html.erb
@@ -41,9 +41,9 @@
 
 <% I18n.with_locale(@entry.locale) do %>
   <%= page_type_templates %>
+  <%= render('pageflow/editor/entries/indicators_seed', theme: @entry.theming.theme) %>
 <% end %>
 
 <%= render('pageflow/editor/entries/help_entries_seed', config: @entry_config) %>
-<%= render('pageflow/editor/entries/indicators_seed', theme: @entry.theming.theme) %>
 
 <%= render('pageflow/editor/entries/analytics', entry: @entry) %>


### PR DESCRIPTION
Ensure translations from the selected locale are used for the scroll indicators inside the editor.