### PR TITLE
Add config option for available public locales

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
@@ -25,9 +25,9 @@ pageflow.EditMetaDataView = Backbone.Marionette.Layout.extend({
     configurationEditor.tab('general', function() {
       this.input('title', pageflow.TextInputView);
       this.input('locale', pageflow.SelectInputView, {
-        values: pageflow.config.availableLocales,
-        texts: _.map(pageflow.config.availableLocales, function(locale) {
-          return I18n.t('language', {locale: locale});
+        values: pageflow.config.availablePublicLocales,
+        texts: _.map(pageflow.config.availablePublicLocales, function(locale) {
+          return I18n.t('pageflow.public._language', {locale: locale});
         })
       });
 

--- a/app/views/pageflow/config/_editor_seeds.json.jbuilder
+++ b/app/views/pageflow/config/_editor_seeds.json.jbuilder
@@ -1,3 +1,3 @@
 json.key_format!(camelize: :lower)
-json.(Pageflow.config, :confirm_encoding_jobs, :available_locales)
+json.(Pageflow.config, :confirm_encoding_jobs, :available_locales, :available_public_locales)
 json.file_types(Pageflow.config.file_types, :collection_name, :type_name, :param_key, :i18n_key)

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -196,9 +196,15 @@ module Pageflow
     attr_reader :admin_form_inputs
 
     # Array of locales which can be chosen as interface language by a
-    # user or for an entry. Defaults to `I18n.available_locales`.
+    # user. Defaults to `I18n.available_locales`.
     # @since 0.7
     attr_accessor :available_locales
+
+    # Array of locales which can be chosen as interface language for
+    # an entry. Defaults to the locales supported by the
+    # `pageflow-public-i18n` gem.
+    # @since edge
+    attr_accessor :available_public_locales
 
     # How to handle https requests for URLs which will have assets in the page.
     # If you wish to serve all assets over http and prevent mixed-content warnings,
@@ -243,6 +249,7 @@ module Pageflow
       @admin_form_inputs = Pageflow::Admin::FormInputs.new
 
       @available_locales = Engine.config.i18n.available_locales
+      @available_public_locales = PublicI18n.available_locales
 
       @public_https_mode = :prevent
     end

--- a/lib/pageflow/engine.rb
+++ b/lib/pageflow/engine.rb
@@ -24,6 +24,7 @@ require 'jquery-fileupload-rails'
 require 'wysihtml5x/rails'
 require 'i18n-js'
 require 'http_accept_language'
+require 'pageflow-public-i18n'
 
 module Pageflow
   # Rails integration
@@ -34,7 +35,7 @@ module Pageflow
     config.autoload_paths << File.join(config.root, 'app', 'views', 'components')
 
     config.i18n.load_path += Dir[config.root.join('config', 'locales', '**', '*.yml').to_s]
-    config.i18n.available_locales = [:en, :de]
+    config.i18n.available_locales = [:en, :de] | PublicI18n.available_locales
     config.i18n.default_locale = :en
 
     # Supress deprecation warning. This is the future default value of the option.

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -92,6 +92,9 @@ Gem::Specification.new do |s|
   # Browser language detection
   s.add_dependency 'http_accept_language', '~> 2.0'
 
+  # Shared translations
+  s.add_dependency 'pageflow-public-i18n', '~> 1.0'
+
   # Password encryption
   s.add_dependency 'bcrypt', '~> 3.1.7'
 

--- a/spec/helpers/pageflow/config_helper_spec.rb
+++ b/spec/helpers/pageflow/config_helper_spec.rb
@@ -24,6 +24,14 @@ module Pageflow
 
         expect(result['availableLocales']).to eq(['de', 'fr'])
       end
+
+      it 'includes available public locales' do
+        Pageflow.config.available_public_locales = [:fr]
+
+        result = JSON.parse(helper.editor_config_seeds)
+
+        expect(result['availablePublicLocales']).to eq(['fr'])
+      end
     end
   end
 end

--- a/spec/pageflow/configuration_spec.rb
+++ b/spec/pageflow/configuration_spec.rb
@@ -101,5 +101,21 @@ module Pageflow
         expect(configuration.available_locales).to eq([:fr])
       end
     end
+
+    describe '#available_public_locales' do
+      it 'defaults to Pageflow::PublicI18n.available_locales' do
+        configuration = Configuration.new
+
+        expect(configuration.available_public_locales).to eq(PublicI18n.available_locales)
+      end
+
+      it 'can be overwritten' do
+        configuration = Configuration.new
+
+        configuration.available_public_locales = [:fr]
+
+        expect(configuration.available_public_locales).to eq([:fr])
+      end
+    end
   end
 end


### PR DESCRIPTION
Translations for public pages are now supplied via the `pageflow-public-i18n` gem. Allow selecting one of the supported locales inside the editor.