### PR TITLE
Explicitly set available locales in config

### DIFF
--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -196,7 +196,7 @@ module Pageflow
     attr_reader :admin_form_inputs
 
     # Array of locales which can be chosen as interface language by a
-    # user. Defaults to `I18n.available_locales`.
+    # user. Defaults to `[:en, :de]`.
     # @since 0.7
     attr_accessor :available_locales
 
@@ -248,7 +248,7 @@ module Pageflow
       @admin_resource_tabs = Pageflow::Admin::Tabs.new
       @admin_form_inputs = Pageflow::Admin::FormInputs.new
 
-      @available_locales = Engine.config.i18n.available_locales
+      @available_locales = [:en, :de]
       @available_public_locales = PublicI18n.available_locales
 
       @public_https_mode = :prevent

--- a/spec/pageflow/configuration_spec.rb
+++ b/spec/pageflow/configuration_spec.rb
@@ -87,10 +87,10 @@ module Pageflow
     end
 
     describe '#available_locales' do
-      it 'defaults to I18n.available_locales' do
+      it 'defaults to [:en, :de]' do
         configuration = Configuration.new
 
-        expect(configuration.available_locales).to eq(Engine.config.i18n.available_locales)
+        expect(configuration.available_locales).to eq([:en, :de])
       end
 
       it 'can be overwritten' do


### PR DESCRIPTION
`I18n.available_locales` now also includes locales only supported for
entries.