### PR TITLE
Add commented editor_route_constraint option

### DIFF
--- a/lib/generators/pageflow/initializer/templates/pageflow.rb
+++ b/lib/generators/pageflow/initializer/templates/pageflow.rb
@@ -5,6 +5,10 @@ Pageflow.configure do |config|
   # The email address to use as from header in invitation mails to new
   # users.
   config.mailer_sender = 'change-me-at-config-initializers-pageflow@example.com'
+  
+  # Activate a constraint for the editor routes defined by Pageflow.
+  # This is useful when you have accounts with CNAMEs.
+  # config.editor_route_constraint = HostConstraint.new
 
   # Page types available in the editor. Add futher page types from
   # page type engines below.


### PR DESCRIPTION
This is useful to have generated in the initialiser. When people need the default option presented in the Wiki, they can just uncomment this line.