### PR TITLE
Use correct key in navigation share box

### DIFF
--- a/app/views/pageflow/entries/navigation/_bar_top.html.erb
+++ b/app/views/pageflow/entries/navigation/_bar_top.html.erb
@@ -24,8 +24,8 @@
       <%= render 'pageflow/entries/share_menu/twitter_link', entry: entry %>
       <%= render 'pageflow/entries/share_menu/google_link', entry: entry %>
       <div class="sub_share">
-        <a tabindex="2" target="_blank"><%= I18n.t('pageflow.public.sharing.this_entry') %></a>
-        <a tabindex="2" target="_blank"><%= I18n.t('pageflow.public.sharing.this_page') %></a>
+        <a tabindex="2" target="_blank"><%= I18n.t('pageflow.public.share_this_entry') %></a>
+        <a tabindex="2" target="_blank"><%= I18n.t('pageflow.public.share_this_page') %></a>
       </div>
     </div>
     <a title="<%= t('pageflow.public.share') %>">


### PR DESCRIPTION
Wring keys were used for sub share navigation