### PR TITLE
Use special page transitions for storyline change

### DIFF
--- a/app/assets/javascripts/pageflow/page_transitions.js
+++ b/app/assets/javascripts/pageflow/page_transitions.js
@@ -25,3 +25,5 @@ pageflow.pageTransitions.register('cut', {duration: 1100});
 pageflow.pageTransitions.register('scroll', {duration: 1100});
 pageflow.pageTransitions.register('scroll_right', {duration: 1100});
 pageflow.pageTransitions.register('scroll_left', {duration: 1100});
+pageflow.pageTransitions.register('scroll_over_from_right', {duration: 1100});
+pageflow.pageTransitions.register('scroll_over_from_left', {duration: 1100});

--- a/app/assets/javascripts/pageflow/slideshow.js
+++ b/app/assets/javascripts/pageflow/slideshow.js
@@ -75,7 +75,8 @@ pageflow.Slideshow = function($el, configurations) {
   };
 
   this.goToParentPage = function() {
-    this.goToByPermaId(pageflow.entryData.getParentPagePermaIdByPagePermaId(currentPagePermaId()));
+    this.goToByPermaId(pageflow.entryData.getParentPagePermaIdByPagePermaId(currentPagePermaId()),
+                       {transition: 'scroll_over_from_right'});
   };
 
   this.goToById = function(id, options) {

--- a/app/assets/javascripts/pageflow/slideshow/dom_order_scroll_navigator.js
+++ b/app/assets/javascripts/pageflow/slideshow/dom_order_scroll_navigator.js
@@ -8,7 +8,7 @@ pageflow.DomOrderScrollNavigator = function(slideshow, entryData) {
     var previousPage = this.getPreviousPage(currentPage, pages);
 
     if (previousPage.is(getParentPage(currentPage, pages))) {
-      forcedTransition = 'scroll_right';
+      forcedTransition = 'scroll_over_from_right';
     }
 
     slideshow.goTo(previousPage, {
@@ -22,7 +22,7 @@ pageflow.DomOrderScrollNavigator = function(slideshow, entryData) {
     var nextPage = this.getNextPage(currentPage, pages);
 
     if (nextPage.is(getParentPage(currentPage, pages))) {
-      forcedTransition = 'scroll_right';
+      forcedTransition = 'scroll_over_from_right';
     }
 
     slideshow.goTo(nextPage, {transition: forcedTransition});

--- a/app/assets/stylesheets/pageflow/page_transitions.css.scss
+++ b/app/assets/stylesheets/pageflow/page_transitions.css.scss
@@ -8,3 +8,6 @@
 
 @import "./page_transitions/scroll_right";
 @import "./page_transitions/scroll_left";
+
+@import "./page_transitions/scroll_over_from_right";
+@import "./page_transitions/scroll_over_from_left";

--- a/app/assets/stylesheets/pageflow/page_transitions/scroll_over_from_left.scss
+++ b/app/assets/stylesheets/pageflow/page_transitions/scroll_over_from_left.scss
@@ -1,0 +1,12 @@
+section.scroll_over_from_left {
+  &.animate-in-forwards, &.animate-out-backwards {
+    z-index: 2;
+  }
+
+  &.animate-in-forwards {
+    @include animation(scroll-in-left forwards 1s 1);
+  }
+  &.animate-out-backwards {
+    @include animation(scroll-out-left forwards 1s 1);
+  }
+}

--- a/app/assets/stylesheets/pageflow/page_transitions/scroll_over_from_right.scss
+++ b/app/assets/stylesheets/pageflow/page_transitions/scroll_over_from_right.scss
@@ -1,0 +1,12 @@
+section.scroll_over_from_right {
+  &.animate-in-forwards, &.animate-out-backwards {
+    z-index: 2;
+  }
+
+  &.animate-in-forwards {
+    @include animation(scroll-in-right forwards 1s 1);
+  }
+  &.animate-out-backwards {
+    @include animation(scroll-out-right forwards 1s 1);
+  }
+}

--- a/config/locales/new/scroll_over.de.yml
+++ b/config/locales/new/scroll_over.de.yml
@@ -1,0 +1,5 @@
+de:
+  pageflow:
+    page_transitions:
+      scroll_over_from_right: "Überlagern (von rechts)"
+      scroll_over_from_left: "Überlagern (von links)"

--- a/config/locales/new/scroll_over.en.yml
+++ b/config/locales/new/scroll_over.en.yml
@@ -1,0 +1,5 @@
+en:
+  pageflow:
+    page_transitions:
+      scroll_over_from_right: "Scroll over from right"
+      scroll_over_from_left: "Scroll over from left"


### PR DESCRIPTION
The "scroll over" transitions look as if the new page was moved in
from the side. Returning reveals the unmoved original page.