### PR TITLE
features must be registered with a String

### DIFF
--- a/doc/understanding_plugins_and_features.md
+++ b/doc/understanding_plugins_and_features.md
@@ -35,7 +35,7 @@ a feature:
 
     class MyPlugin < Pageflow::Plugin
       def configure(config)
-        config.features.register(:my_feature) do |feature_config|
+        config.features.register("my_feature") do |feature_config|
           feature_config.page_types.register(MyPageType.new)
         end
       end


### PR DESCRIPTION
This is explicitly checked:
https://github.com/codevise/pageflow/blob/127e61bb2b371ed0c799bd3abb26de77602a31b5/lib/pageflow/features.rb#L30

passing a symbol here will not work.