### PR TITLE
Improve native scrolling prevention

### DIFF
--- a/app/assets/javascripts/pageflow/base.js
+++ b/app/assets/javascripts/pageflow/base.js
@@ -52,6 +52,7 @@
 //= require ./chapter_filter
 //= require ./fullscreen
 //= require ./multimedia_alert
+//= require ./native_scrolling
 
 //= require ./settings
 

--- a/app/assets/javascripts/pageflow/native_scrolling.js
+++ b/app/assets/javascripts/pageflow/native_scrolling.js
@@ -1,0 +1,14 @@
+pageflow.nativeScrolling = {
+  preventScrollBouncing: function(slideshow) {
+    slideshow.on('touchmove', function (e) {
+      e.preventDefault();
+    });
+  },
+
+  preventScrollingOnEmbed: function(slideshow) {
+    slideshow.on('wheel mousewheel DOMMouseScroll', function(e) {
+      e.stopPropagation();
+      e.preventDefault();
+    });
+  }
+};

--- a/app/assets/javascripts/pageflow/ready.js
+++ b/app/assets/javascripts/pageflow/ready.js
@@ -1,11 +1,13 @@
 pageflow.ready = new $.Deferred(function(readyDeferred) {
   window.onload = function() {
     pageflow.browser.detectFeatures().then(function() {
+      var slideshow = $('[data-role=slideshow]');
+
       $('body').one('pagepreloaded', function() {
         readyDeferred.resolve();
       });
 
-      $('[data-role=slideshow]').each(function() {
+      slideshow.each(function() {
         pageflow.entryData = new pageflow.SeedEntryData(
           pageflow.seed
         );
@@ -30,6 +32,7 @@ pageflow.ready = new $.Deferred(function(readyDeferred) {
       });
 
       pageflow.links.setup();
+      pageflow.nativeScrolling.preventScrollingOnEmbed(slideshow);
     });
   };
 }).promise();

--- a/app/assets/javascripts/pageflow/slideshow.js
+++ b/app/assets/javascripts/pageflow/slideshow.js
@@ -191,8 +191,7 @@ pageflow.Slideshow = function($el, configurations) {
 
   $(window).on('resize', this.triggerResizeHooks);
 
-  // prevent page from bouncing in modern browsers
-  $(document).on('touchmove', function (e) { e.preventDefault(); });
+  pageflow.nativeScrolling.preventScrollBouncing($el);
 
   $el.addClass('slideshow');
 


### PR DESCRIPTION
When embedding Pageflow in an iframe, the wheel should not scroll the
outer page.

Prevent scroll bounce only on slideshow to enable touch scrolling in
the editor sidebar.