### PR TITLE
Optimize sidebar for text box compatibility

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/editor_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/editor_view.js
@@ -24,6 +24,9 @@ pageflow.EditorView = Backbone.View.extend({
       togglerTip_closed: I18n.t('pageflow.editor.views.editor_views.show_editor'),
       togglerTip_open: I18n.t('pageflow.editor.views.editor_views.hide_editor'),
       resizerTip: I18n.t('pageflow.editor.views.editor_views.resize_editor'),
+      enableCursorHotkey: false,
+      fxName: 'none',
+
       onresize: function() {
         pageflow.app.trigger('resize');
       }


### PR DESCRIPTION
* Disable hot keys to open/close the sidebar (Ctrl + cursor keys) which conflicted with text movement commands.
* Disable open/close animation which caused text areas to be rendered blank after reopening the sidebar.