### PR TITLE
Use history PushStateAdapter on iOS 8 and above

### DIFF
--- a/app/assets/javascripts/pageflow/browser/hashchange_support.js
+++ b/app/assets/javascripts/pageflow/browser/hashchange_support.js
@@ -1,8 +1,0 @@
-pageflow.browser.feature('hashchange support', function() {
-  var iOS = parseFloat(
-  ('' + (/CPU.*OS ([0-9_]{1,5})|(CPU like).*AppleWebKit.*Mobile/i.exec(navigator.userAgent) || [0,''])[1])
-  .replace('undefined', '3_2').replace('_', '.').replace('_', '')
-) || false;
-
-  return !(iOS >=8);
-});

--- a/app/assets/javascripts/pageflow/history.js
+++ b/app/assets/javascripts/pageflow/history.js
@@ -46,7 +46,7 @@ pageflow.History.create = function(slideshow, options) {
 
   var adapter;
 
-  if (options.simulate || !pageflow.browser.has('hashchange support')) {
+  if (options.simulate) {
     adapter = new pageflow.History.SimulatedAdapter();
   }
   else if (pageflow.browser.has('pushstate support')) {


### PR DESCRIPTION
Setting the `location.hash` on page change caused the browser
navigation bar to appear on landscape Mobile Safari. Therefore
`hashchange support` was disabled for such devices, causing deep
linking to break.

When introducing the push state adapter this choice was not
re-evaluated, keeping history deactivated. Manipulating history via the
push state API does not appear to trigger navigation bar display
though. Therefore the iOS 8 special case can be removed.