### PR TITLE
Fix wrong text alignment in right position mode

### DIFF
--- a/app/assets/stylesheets/pageflow/page.css.scss
+++ b/app/assets/stylesheets/pageflow/page.css.scss
@@ -82,10 +82,7 @@
 
   h1, h2 span.subtitle, h2 span.tagline, h3, p {
     max-width: 500px;
-    width: 60%;
-    @include mobile {
-      width: 100%;
-    }
+    width: 100%;
   }
 
   h2 .title {


### PR DESCRIPTION
If text position is set to right and the user's screen is too small, subheadings align incorrectly.

![bildschirmfoto 2016-01-25 um 14 51 01](https://cloud.githubusercontent.com/assets/13730111/12678066/30971334-c69d-11e5-9296-88ead17e275a.png)
