### PR TITLE
Prevent accessing password protected entries

### DIFF
--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -24,7 +24,7 @@ module Pageflow
           @entry = PublishedEntry.find(params[:id], entry_request_scope)
           I18n.locale = @entry.locale
 
-          if request.format.html? && @entry.password_protected?
+          if !request.format.css? && @entry.password_protected?
             check_entry_password(@entry)
           end
 

--- a/spec/controllers/pageflow/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/entries_controller_spec.rb
@@ -149,6 +149,17 @@ module Pageflow
     end
 
     describe '#show' do
+      context 'with format */*' do
+        it 'responds with forbidden for entry published with password' do
+          entry = create(:entry, :published_with_password, password: 'abc123abc')
+
+          request.env['HTTP_ACCEPT'] = '*/*'
+          get(:show, id: entry)
+
+          expect(response.status).to eq(401)
+        end
+      end
+
       context 'with format html' do
         it 'responds with success for published entry' do
           entry = create(:entry, :published)


### PR DESCRIPTION
To enable CDN access, generated css of password protected entries is
accessible without password. The check used `format.html?`, which
returned `false`, though, when the Accept header was set to "*/*"
causing the HTML format also to be publicly accessible.

Explicitly check for `format.css?` now.