### PR TITLE
Remove HTML entities from social share description

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
@@ -59,7 +59,10 @@ pageflow.EditMetaDataView = Backbone.Marionette.Layout.extend({
         collection: pageflow.imageFiles,
         fileSelectionHandler: 'entryConfiguration'
       });
-      this.input('summary', pageflow.TextAreaInputView);
+      this.input('summary', pageflow.TextAreaInputView, {
+        disableRichtext: true,
+        disableLinks: true
+      });
     });
 
     this.formContainer.show(configurationEditor);

--- a/app/helpers/pageflow/social_share_helper.rb
+++ b/app/helpers/pageflow/social_share_helper.rb
@@ -64,7 +64,7 @@ module Pageflow
     private
 
     def social_share_sanitize(text)
-      strip_tags(text.gsub(/<br ?\/?>/, ' ').squish)
+      HTMLEntities.new.decode(strip_tags(text.gsub(/<br ?\/?>|&nbsp;/, ' ').squish))
     end
   end
 end

--- a/lib/pageflow/engine.rb
+++ b/lib/pageflow/engine.rb
@@ -6,6 +6,7 @@ require 'friendly_id'
 require 'devise'
 require 'cancan'
 require 'jbuilder'
+require 'htmlentities'
 require 'kramdown'
 
 require 'resque_mailer'

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -53,6 +53,9 @@ Gem::Specification.new do |s|
   # Markdown parser
   s.add_dependency 'kramdown', '~> 1.5'
 
+  # Markdown parser
+  s.add_dependency 'htmlentities', '~> 4.3'
+
   # VideoJS for Asset Pipeline, version fixed at 4.1.0
   # Recommendation: Do not change
   s.add_dependency 'videojs_rails', '4.1.0'

--- a/spec/helpers/pageflow/social_share_helper_spec.rb
+++ b/spec/helpers/pageflow/social_share_helper_spec.rb
@@ -15,12 +15,12 @@ module Pageflow
 
       it 'returns html stripped text' do
         entry = create(:entry, :published)
-        entry.published_revision.summary = 'social<br />share <b>description</b>'
+        entry.published_revision.summary = 'social<br />share <b>description</b> &amp;&nbsp;more'
         published_entry = PublishedEntry.new(entry)
 
         result = helper.social_share_entry_description(published_entry)
 
-        expect(result).to eq('social share description')
+        expect(result).to eq('social share description & more')
       end
 
       it 'returns text of first page which has text' do


### PR DESCRIPTION
* Turn \&nbsp; into spaces
* Decode other entities to utf8 character
* Prevent rich text and links in description