### PR TITLE
Ensure MultiJson uses yajl json adapter.

### DIFF
--- a/lib/pageflow/engine.rb
+++ b/lib/pageflow/engine.rb
@@ -1,3 +1,4 @@
+require 'yajl'
 require 'state_machine'
 require 'state_machine_job'
 require 'paperclip'


### PR DESCRIPTION
This is much faster then with the json gem. The gem was a dependency all along, but since it was not required is was never picked up by MultiJson.