### PR TITLE
Add image CSS classes to lazy load thumbnails

### DIFF
--- a/app/views/pageflow/file_types/_thumbnails.css.erb
+++ b/app/views/pageflow/file_types/_thumbnails.css.erb
@@ -1,5 +1,7 @@
 <% revision.files(file_type.model).each do |file| %>
   <% styles.each do |style| %>
+    .load_all_images .lazy_<%= file_thumbnail_css_class(file, style) %>,
+    .load_image.lazy_<%= file_thumbnail_css_class(file, style) %>,
     .<%= file_thumbnail_css_class(file, style) %> {
       background-image: url('<%= file.thumbnail_url(style) %>');
     }

--- a/spec/helpers/pageflow/file_thumbnails_helper_spec.rb
+++ b/spec/helpers/pageflow/file_thumbnails_helper_spec.rb
@@ -21,6 +21,15 @@ module Pageflow
         expect(result).to include(".pageflow_image_file_link_thumbnail_large_#{image_file.id}")
       end
 
+      it 'renders lazy loaded variants' do
+        entry = create(:entry)
+        image_file = create(:image_file, used_in: entry.draft)
+
+        result = helper.file_thumbnails_css(entry.draft)
+
+        expect(result).to include(".load_image.lazy_pageflow_image_file_link_thumbnail_#{image_file.id}")
+      end
+
       it 'renders link thumbnail rule for video files of revision' do
         entry = create(:entry)
         video_file = create(:video_file, used_in: entry.draft)


### PR DESCRIPTION
Allow prefixing a thumbnail css class with `lazy_` to only load images when either the `load_all_images` class is set on body (for non js) or `load_image` is set on the element itself.