### PR TITLE
Admin improvements

### DIFF
--- a/admins/pageflow/accounts.rb
+++ b/admins/pageflow/accounts.rb
@@ -3,13 +3,23 @@ module Pageflow
     menu :priority => 3
 
     config.batch_actions = false
-    config.clear_sidebar_sections!
 
     index do
       column :name do |account|
         link_to account.name, admin_account_path(account)
       end
+      column I18n.t('pageflow.admin.accounts.entries_count') do |account|
+        account.entries_count
+      end
+      column I18n.t('pageflow.admin.accounts.users_count') do |account|
+        account.users_count
+      end
+      column I18n.t('pageflow.admin.accounts.default_theming') do |account|
+        account.default_theming.theme_name
+      end
     end
+
+    filter :name
 
     form :partial => 'form'
 

--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -3,7 +3,6 @@ module Pageflow
     menu :priority => 1
 
     config.batch_actions = false
-    config.clear_sidebar_sections!
 
     index do
       column :title, :sortable => 'title' do |entry|
@@ -19,6 +18,7 @@ module Pageflow
       end
       column :created_at
       column :updated_at
+      column I18n.t('pageflow.admin.entries.published_at'), :first_published_at
       column :class => 'buttons' do |entry|
         if authorized?(:edit, Entry)
           span(link_to(I18n.t('pageflow.admin.entries.editor'), pageflow.edit_entry_path(entry), :class => 'editor button'))
@@ -37,6 +37,11 @@ module Pageflow
                           :active_id => params[:folder_id],
                           :grouped_by_accounts => authorized?(:read, Account))
     end
+
+    filter :title
+    filter :created_at
+    filter :updated_at
+    filter :first_published_at, label: I18n.t('pageflow.admin.entries.first_published_at')
 
     form do |f|
       f.inputs do

--- a/app/assets/stylesheets/pageflow/admin.css.scss
+++ b/app/assets/stylesheets/pageflow/admin.css.scss
@@ -1,5 +1,6 @@
 @import "pageflow/mixins";
 
+@import "pageflow/admin/accounts";
 @import "pageflow/admin/columns";
 @import "pageflow/admin/entries";
 @import "pageflow/admin/quotas";

--- a/app/assets/stylesheets/pageflow/admin/accounts.css.scss
+++ b/app/assets/stylesheets/pageflow/admin/accounts.css.scss
@@ -1,0 +1,3 @@
+.admin_accounts {
+  @import './entries/user_badge_list';
+}

--- a/app/jobs/pageflow/reset_counter_caches.rb
+++ b/app/jobs/pageflow/reset_counter_caches.rb
@@ -1,0 +1,13 @@
+module Pageflow
+  class ResetCounterCachesJob
+    @queue = :default
+
+    extend StateMachineJob
+
+    def self.perform_with_result(file, options = {})
+      Account.find_each { |account| Account.reset_counters(account.id, :entries, :users) }
+      :ok
+    end
+
+  end
+end

--- a/app/models/pageflow/entry.rb
+++ b/app/models/pageflow/entry.rb
@@ -8,7 +8,7 @@ module Pageflow
     extend FriendlyId
     friendly_id :slug_candidates, :use => [:finders, :slugged]
 
-    belongs_to :account
+    belongs_to :account, :counter_cache => true
     belongs_to :folder
     belongs_to :theming
 

--- a/app/views/components/pageflow/admin/entries_tab.rb
+++ b/app/views/components/pageflow/admin/entries_tab.rb
@@ -3,11 +3,20 @@ module Pageflow
     class EntriesTab < ViewComponent
       def build(theming)
         account = theming.account
-        embedded_index_table account.entries, blank_slate_text: I18n.t('pageflow.admin.entries.no_members') do
-          table_for_collection :class => 'entries', :i18n => Pageflow::Entry do
-            column :title do |entry|
+        embedded_index_table account.entries.order(
+            params[:order] && Entry.column_names.include?(params[:order].gsub('_asc', '').gsub('_desc', '')) ?
+                params[:order].gsub('_asc', ' asc').gsub('_desc', ' desc') : 'title desc'),
+                             blank_slate_text: I18n.t('pageflow.admin.entries.no_members') do
+          table_for_collection :sortable => true, :class => 'entries', :i18n => Pageflow::Entry do
+            column :title, :sortable => :title do |entry|
               link_to(entry.title, admin_entry_path(entry))
             end
+            column I18n.t('pageflow.admin.entries.members'), :class => 'members' do |entry|
+              entry_user_badge_list(entry)
+            end
+            column :created_at
+            column :updated_at
+            column :first_published_at
           end
         end
       end

--- a/app/views/components/pageflow/admin/entries_tab.rb
+++ b/app/views/components/pageflow/admin/entries_tab.rb
@@ -3,16 +3,10 @@ module Pageflow
     class EntriesTab < ViewComponent
       def build(theming)
         account = theming.account
-        if account.entries.any?
-          table_for account.entries, :i18n => Pageflow::Entry do
+        embedded_index_table account.entries, blank_slate_text: I18n.t('pageflow.admin.entries.no_members') do
+          table_for_collection :class => 'entries', :i18n => Pageflow::Entry do
             column :title do |entry|
               link_to(entry.title, admin_entry_path(entry))
-            end
-          end
-          else
-            div :class => "blank_slate_container" do
-            span :class => "blank_slate" do
-              I18n.t('pageflow.admin.accounts.no_entries')
             end
           end
         end

--- a/app/views/components/pageflow/admin/members_tab.rb
+++ b/app/views/components/pageflow/admin/members_tab.rb
@@ -2,8 +2,8 @@ module Pageflow
   module Admin
     class MembersTab < ViewComponent
       def build(entry)
-        if entry.memberships.any?
-          table_for entry.memberships, :class => 'memberships' do
+        embedded_index_table entry.memberships, blank_slate_text: I18n.t('pageflow.admin.entries.no_members') do
+          table_for_collection :class => 'memberships', :i18n => Pageflow::Membership do
             column t('activerecord.attributes.user.full_name'), class: 'name' do |membership|
               if authorized? :manage, User
                 link_to membership.user.full_name, admin_user_path(membership.user), :class => 'view_creator'
@@ -13,14 +13,9 @@ module Pageflow
             end
             column do |membership|
               if authorized?(:destroy, membership)
-                link_to(I18n.t('pageflow.admin.entries.remove'), admin_entry_membership_path(membership.entry, membership), :method => :delete, :data => {:confirm => I18n.t('active_admin.delete_confirmation'), :rel => 'delete_membership'})
+                link_to(I18n.t('pageflow.admin.entries.remove'), admin_entry_membership_path(membership.entry, membership),
+                        :method => :delete, :data => {:confirm => I18n.t('active_admin.delete_confirmation'), :rel => 'delete_membership'})
               end
-            end
-          end
-        else
-          div :class => "blank_slate_container" do
-            span :class => "blank_slate" do
-              I18n.t('pageflow.admin.entries.no_members')
             end
           end
         end

--- a/app/views/components/pageflow/admin/revisions_tab.rb
+++ b/app/views/components/pageflow/admin/revisions_tab.rb
@@ -20,7 +20,7 @@ module Pageflow
                 revision.creator.full_name
               end
             end
-            column :published_until  do |revision|
+            column :published_until do |revision|
               if revision.published_until
                 I18n.l(revision.published_until)
               elsif revision.published?

--- a/app/views/components/pageflow/admin/users_tab.rb
+++ b/app/views/components/pageflow/admin/users_tab.rb
@@ -3,16 +3,10 @@ module Pageflow
     class UsersTab < ViewComponent
       def build(theming)
         account = theming.account
-        if account.users.any?
-          table_for account.users, :i18n => User do
+        embedded_index_table account.users, blank_slate_text: I18n.t('pageflow.admin.entries.no_members') do
+          table_for_collection :class => 'users', :i18n => User do
             column :full_name do |user|
               link_to user.full_name, admin_user_path(user)
-            end
-          end
-        else
-          div :class => "blank_slate_container" do
-            span :class => "blank_slate" do
-              I18n.t('pageflow.admin.accounts.no_members')
             end
           end
         end

--- a/app/views/components/pageflow/admin/users_tab.rb
+++ b/app/views/components/pageflow/admin/users_tab.rb
@@ -3,10 +3,13 @@ module Pageflow
     class UsersTab < ViewComponent
       def build(theming)
         account = theming.account
-        embedded_index_table account.users, blank_slate_text: I18n.t('pageflow.admin.entries.no_members') do
-          table_for_collection :class => 'users', :i18n => User do
-            column :full_name do |user|
-              link_to user.full_name, admin_user_path(user)
+        embedded_index_table account.users.order(
+            params[:order] && User.column_names.include?(params[:order].gsub('_asc', '').gsub('_desc', '')) ?
+                params[:order].gsub('_asc', ' asc').gsub('_desc', ' desc') : 'last_name asc'),
+                             blank_slate_text: I18n.t('pageflow.admin.entries.no_members') do
+          table_for_collection :sortable => true, :class => 'users', :i18n => User do
+            column :formal_name, :sortable => :last_name do |user|
+              link_to user.formal_name, admin_user_path(user)
             end
           end
         end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -695,6 +695,9 @@ de:
       accounts:
         no_entries: Keine Beiträge
         no_members: Keine Benutzer
+        entries_count: Beiträge
+        users_count: Mitglieder
+        default_theming: Theme
       entries:
         add_folder: Ordner hinzufügen
         confirm_depublish: Soll der Beitrag wirklich depubliziert werden?

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -699,6 +699,9 @@ de:
         users_count: Mitglieder
         default_theming: Theme
       entries:
+        published_at: Veröffentlicht am
+        first_published_at: Zuerst veröffentlicht
+        last_published_at: Zuletzt veröffentlicht
         add_folder: Ordner hinzufügen
         confirm_depublish: Soll der Beitrag wirklich depubliziert werden?
         confirm_duplicate: Beitrag wirklich duplizieren?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -693,8 +693,11 @@ en:
   pageflow:
     admin:
       accounts:
-        no_entries: No Stories
+        no_entries: No stories
         no_members: No members
+        entries_count: Stories
+        users_count: Members
+        default_theming: Theme
       entries:
         add_folder: Add folder
         confirm_depublish: Unpublish this story?

--- a/db/migrate/20160131222203_add_cache_counters.rb
+++ b/db/migrate/20160131222203_add_cache_counters.rb
@@ -1,0 +1,11 @@
+class AddCacheCounters < ActiveRecord::Migration
+  def self.up
+    add_column :pageflow_accounts, :users_count, :integer, :default => 0, :null => false
+    add_column :pageflow_accounts, :entries_count, :integer, :default => 0, :null => false
+  end
+
+  def self.down
+    remove_column :pageflow_accounts, :users_count
+    remove_column :pageflow_accounts, :entries_count
+  end
+end

--- a/lib/pageflow/user_mixin.rb
+++ b/lib/pageflow/user_mixin.rb
@@ -9,7 +9,7 @@ module Pageflow
     include Suspendable
 
     included do
-      belongs_to :account, :class_name => 'Pageflow::Account'
+      belongs_to :account, :counter_cache => true, :class_name => 'Pageflow::Account'
 
       has_many :memberships, :dependent => :destroy, :class_name => 'Pageflow::Membership'
       has_many :entries, :through => :memberships, :class_name => 'Pageflow::Entry'


### PR DESCRIPTION
Adds columns and name filter to admin accounts panel. Counter caches are being used for users and entries which belong to an account. Translations must be added manually.