### PR TITLE
Add columns and name filter to admin accounts panel

### DIFF
--- a/admins/pageflow/accounts.rb
+++ b/admins/pageflow/accounts.rb
@@ -3,13 +3,23 @@ module Pageflow
     menu :priority => 3
 
     config.batch_actions = false
-    config.clear_sidebar_sections!
 
     index do
       column :name do |account|
         link_to account.name, admin_account_path(account)
       end
+      column :entries_count do |account|
+        account.entries_count
+      end
+      column :users_count do |account|
+        account.users_count
+      end
+      column :default_theming do |account|
+        account.default_theming.theme_name
+      end
     end
+
+    filter :name
 
     form :partial => 'form'
 
@@ -65,6 +75,10 @@ module Pageflow
         end
 
         result
+      end
+
+      def scoped_collection
+        super.includes(:users, :entries, :themings)
       end
 
       private

--- a/app/models/pageflow/entry.rb
+++ b/app/models/pageflow/entry.rb
@@ -8,7 +8,7 @@ module Pageflow
     extend FriendlyId
     friendly_id :slug_candidates, :use => [:finders, :slugged]
 
-    belongs_to :account
+    belongs_to :account, counter_cache: true
     belongs_to :folder
     belongs_to :theming
 

--- a/db/migrate/20160131222203_add_cache_counters.rb
+++ b/db/migrate/20160131222203_add_cache_counters.rb
@@ -1,0 +1,23 @@
+class AddCacheCounters < ActiveRecord::Migration
+  def self.up
+    add_column :pageflow_accounts, :users_count, :integer, default: 0, null: false
+    add_column :pageflow_accounts, :entries_count, :integer, default: 0, null: false
+
+    execute(<<-SQL)
+      UPDATE pageflow_accounts SET users_count = (
+        SELECT COUNT(*)
+        FROM users
+        WHERE users.account_id = pageflow_accounts.id
+      ), entries_count = (
+        SELECT COUNT(*)
+        FROM pageflow_entries
+        WHERE pageflow_entries.account_id = pageflow_accounts.id
+      );
+    SQL
+  end
+
+  def self.down
+    remove_column :pageflow_accounts, :users_count
+    remove_column :pageflow_accounts, :entries_count
+  end
+end

--- a/lib/pageflow/user_mixin.rb
+++ b/lib/pageflow/user_mixin.rb
@@ -9,20 +9,20 @@ module Pageflow
     include Suspendable
 
     included do
-      belongs_to :account, :class_name => 'Pageflow::Account'
+      belongs_to :account, counter_cache: true, class_name: 'Pageflow::Account'
 
-      has_many :memberships, :dependent => :destroy, :class_name => 'Pageflow::Membership'
-      has_many :entries, :through => :memberships, :class_name => 'Pageflow::Entry'
+      has_many :memberships, dependent: :destroy, class_name: 'Pageflow::Membership'
+      has_many :entries, through: :memberships, class_name: 'Pageflow::Entry'
 
-      has_many :revisions, :class_name => 'Pageflow::Revision', :foreign_key => :creator_id
+      has_many :revisions, class_name: 'Pageflow::Revision', foreign_key: :creator_id
 
-      validates :first_name, :last_name, :presence => true
-      validates :role, :inclusion => ROLES
-      validates :account, :presence => true
+      validates :first_name, :last_name, presence: true
+      validates :role, inclusion: ROLES
+      validates :account, presence: true
 
-      scope :admins, -> { where(:role => 'admin') }
-      scope :account_managers, -> { where(:role => 'account_manager') }
-      scope :editors, -> { where(:role => 'editor') }
+      scope :admins, -> { where(role: 'admin') }
+      scope :account_managers, -> { where(role: 'account_manager') }
+      scope :editors, -> { where(role: 'editor') }
     end
 
     def admin?


### PR DESCRIPTION
Counter caches are being used for users and entries which belong to an account. Translations must be added manually.