### PR TITLE
destroy dependent account objects

### DIFF
--- a/app/models/pageflow/account.rb
+++ b/app/models/pageflow/account.rb
@@ -4,9 +4,9 @@ module Pageflow
 
     has_many :users
     has_many :entries
-    has_many :folders
+    has_many :folders, dependent: :destroy
 
-    has_many :themings
+    has_many :themings, dependent: :destroy
     belongs_to :default_theming, :class_name => 'Theming'
 
     validates :default_theming, :presence => true

--- a/spec/models/pageflow/account_spec.rb
+++ b/spec/models/pageflow/account_spec.rb
@@ -18,6 +18,19 @@ module Pageflow
 
         expect(theming.account).to eq(account)
       end
+
+      it 'destroys default theming when account is destroyed' do
+        account = create(:account)
+
+        expect { account.destroy }.to change(Theming, :count).by(-1)
+      end
+    end
+
+    it 'destroys folders when account is destroyed' do
+      account = create(:account)
+      create(:folder, account: account)
+
+      expect { account.destroy }.to change(Folder, :count).by(-1)
     end
   end
 end


### PR DESCRIPTION
themings and folders must not be orphaned, because they will break the UI in some ways.

I don't know if you like this spec style, I can do it differently, but this is what I usually do.