### PR TITLE
Make author and publisher fields dynamic

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
@@ -23,7 +23,9 @@ pageflow.EditMetaDataView = Backbone.Marionette.Layout.extend({
     });
 
     configurationEditor.tab('general', function() {
-      this.input('title', pageflow.TextInputView);
+      this.input('title', pageflow.TextInputView, {
+        placeholder: entry.attributes.entry_title
+      });
       this.input('locale', pageflow.SelectInputView, {
         values: pageflow.config.availablePublicLocales,
         texts: _.map(pageflow.config.availablePublicLocales, function(locale) {

--- a/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
@@ -32,6 +32,9 @@ pageflow.EditMetaDataView = Backbone.Marionette.Layout.extend({
       });
 
       this.input('credits', pageflow.TextAreaInputView);
+      this.input('author', pageflow.TextInputView);
+      this.input('publisher', pageflow.TextInputView);
+      this.input('keywords', pageflow.TextInputView);
     });
 
     configurationEditor.tab('widgets', function() {

--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -84,7 +84,8 @@ module Pageflow
     def entry_params
       params.require(:entry).permit(:title, :summary, :credits, :manual_start, :home_url, :home_button_enabled,
                                     :emphasize_chapter_beginning, :emphasize_new_pages,
-                                    :share_image_id, :share_image_x, :share_image_y, :locale)
+                                    :share_image_id, :share_image_x, :share_image_y, :locale,
+                                    :author, :publisher, :keywords)
     end
 
     def entry_request_scope

--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -1,5 +1,12 @@
 module Pageflow
   module EntriesHelper
+    def pretty_entry_title(entry)
+      [].tap do |title|
+        title << entry.title
+        title << entry.theming.cname_domain if entry.theming.cname_domain.present?
+      end.join(' - ')
+    end
+
     def pretty_entry_url(entry)
       pageflow.short_entry_url(entry.to_model, Pageflow.config.theming_url_options(entry.theming))
     end

--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -1,10 +1,7 @@
 module Pageflow
   module EntriesHelper
     def pretty_entry_title(entry)
-      [].tap do |title|
-        title << entry.title
-        title << entry.theming.cname_domain if entry.theming.cname_domain.present?
-      end.join(' - ')
+      [entry.title, entry.theming.cname_domain.presence].compact.join(' - ')
     end
 
     def pretty_entry_url(entry)

--- a/app/helpers/pageflow/meta_tags_helper.rb
+++ b/app/helpers/pageflow/meta_tags_helper.rb
@@ -1,0 +1,11 @@
+module Pageflow
+  module MetaTagsHelper
+    def meta_tags_for_entry(entry)
+      render partial: 'pageflow/meta_tags/entry', locals: {
+        keywords: entry.keywords.presence || Pageflow.config.default_keywords_meta_tag,
+        author: entry.author.presence || Pageflow.config.default_author_meta_tag,
+        publisher: entry.publisher.presence || Pageflow.config.default_publisher_meta_tag
+      }
+    end
+  end
+end

--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -21,6 +21,7 @@ module Pageflow
              :files,
              :image_files, :video_files, :audio_files,
              :locale,
+             :author, :publisher, :keywords,
              :to => :draft)
 
     def initialize(entry, draft = nil)

--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -29,6 +29,11 @@ module Pageflow
       @draft = draft || entry.draft
     end
 
+    # So we can always get to the original Entry title.
+    def entry_title
+      entry.title
+    end
+
     def create_file(model, attributes)
       file = model.create(attributes) do |f|
         f.entry = entry

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -11,6 +11,7 @@ module Pageflow
              :enabled_feature_names,
              :to_model, :to_key, :persisted?,
              :authenticate,
+             :users,
              :to => :entry)
 
     delegate(:widgets,

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -23,6 +23,7 @@ module Pageflow
              :emphasize_new_pages,
              :share_image_id, :share_image_x, :share_image_y,
              :locale,
+             :author, :publisher, :keywords,
              :password_protected?,
              :to => :revision)
 

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -33,11 +33,7 @@ module Pageflow
     end
 
     def title
-      if revision
-        revision.title.presence || entry.title
-      else
-        entry.title
-      end
+      revision.title.presence || entry.title
     end
 
     def stylesheet_model

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -11,7 +11,6 @@ module Pageflow
              :enabled_feature_names,
              :to_model, :to_key, :persisted?,
              :authenticate,
-             :users,
              :to => :entry)
 
     delegate(:widgets,

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -18,7 +18,7 @@ module Pageflow
              :storylines, :main_storyline_chapters, :chapters, :pages,
              :files,
              :image_files, :video_files, :audio_files,
-             :title, :summary, :credits, :manual_start,
+             :summary, :credits, :manual_start,
              :emphasize_chapter_beginning,
              :emphasize_new_pages,
              :share_image_id, :share_image_x, :share_image_y,
@@ -30,6 +30,14 @@ module Pageflow
       @entry = entry
       @revision = revision || entry.published_revision
       @custom_revision = !!revision
+    end
+
+    def title
+      if revision
+        revision.title.presence || entry.title
+      else
+        entry.title
+      end
     end
 
     def stylesheet_model

--- a/app/views/layouts/pageflow/_meta_tags.html.erb
+++ b/app/views/layouts/pageflow/_meta_tags.html.erb
@@ -1,5 +1,5 @@
   <meta name="dc.language" content="<%= I18n.locale %>" />
   <meta name="keywords" content="pageflow, multimedia, reportage">
   <meta name="description" content="">
-  <meta name="author" content="Pageflow">
-  <meta name="publisher" content="Pageflow">
+  <meta name="author" content="<%= content_for?(:author) ? yield(:author) : 'Pageflow' %>">
+  <meta name="publisher" content="<%= content_for?(:publisher) ? yield(:publisher) : 'Pageflow' %>">

--- a/app/views/layouts/pageflow/_meta_tags.html.erb
+++ b/app/views/layouts/pageflow/_meta_tags.html.erb
@@ -1,4 +1,4 @@
   <meta name="dc.language" content="<%= I18n.locale %>" />
-  <meta name="keywords" content="pageflow, multimedia, reportage">
-  <meta name="author" content="<%= content_for?(:author) ? yield(:author) : 'Pageflow' %>">
-  <meta name="publisher" content="<%= content_for?(:publisher) ? yield(:publisher) : 'Pageflow' %>">
+  <% if content_for?(:keywords) %><meta name="keywords" content="<%= yield(:keywords) %>"><% end %>
+  <% if content_for?(:author) %><meta name="author" content="<%= yield(:author) %>"><% end %>
+  <% if content_for?(:publisher) %><meta name="publisher" content="<%= yield(:publisher) %>"><% end %>

--- a/app/views/layouts/pageflow/_meta_tags.html.erb
+++ b/app/views/layouts/pageflow/_meta_tags.html.erb
@@ -1,5 +1,4 @@
   <meta name="dc.language" content="<%= I18n.locale %>" />
   <meta name="keywords" content="pageflow, multimedia, reportage">
-  <meta name="description" content="">
   <meta name="author" content="<%= content_for?(:author) ? yield(:author) : 'Pageflow' %>">
   <meta name="publisher" content="<%= content_for?(:publisher) ? yield(:publisher) : 'Pageflow' %>">

--- a/app/views/layouts/pageflow/_meta_tags.html.erb
+++ b/app/views/layouts/pageflow/_meta_tags.html.erb
@@ -1,4 +1,0 @@
-  <meta name="dc.language" content="<%= I18n.locale %>" />
-  <% if content_for?(:keywords) %><meta name="keywords" content="<%= yield(:keywords) %>"><% end %>
-  <% if content_for?(:author) %><meta name="author" content="<%= yield(:author) %>"><% end %>
-  <% if content_for?(:publisher) %><meta name="publisher" content="<%= yield(:publisher) %>"><% end %>

--- a/app/views/layouts/pageflow/application.html.erb
+++ b/app/views/layouts/pageflow/application.html.erb
@@ -10,7 +10,6 @@
   <%= javascript_include_tag "pageflow/application", "data-turbolinks-track" => true %>
 
   <%= csrf_meta_tags %>
-  <%= render 'layouts/pageflow/meta_tags' %>
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, minimum-scale=1, maximum-scale=1" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
 

--- a/app/views/pageflow/editor/entries/_entry.json.jbuilder
+++ b/app/views/pageflow/editor/entries/_entry.json.jbuilder
@@ -1,4 +1,4 @@
-json.(entry, :id, :published_until, :slug, :enabled_feature_names)
+json.(entry, :id, :entry_title, :published_until, :slug, :enabled_feature_names)
 
 json.pretty_url pretty_entry_url(entry)
 

--- a/app/views/pageflow/editor/entries/_entry.json.jbuilder
+++ b/app/views/pageflow/editor/entries/_entry.json.jbuilder
@@ -7,7 +7,7 @@ json.published(entry.published?)
 json.password_protected(entry.password_digest.present?)
 
 json.configuration do
-  json.(entry, :title, :summary, :credits, :manual_start, :emphasize_chapter_beginning, :emphasize_new_pages, :share_image_id, :share_image_x, :share_image_y, :locale)
+  json.(entry, :title, :summary, :credits, :author, :publisher, :keywords, :manual_start, :emphasize_chapter_beginning, :emphasize_new_pages, :share_image_id, :share_image_x, :share_image_y, :locale)
   json.home_url entry.home_button.url_value
   json.home_button_enabled entry.home_button.enabled_value
 end

--- a/app/views/pageflow/entries/_meta_tags.html.erb
+++ b/app/views/pageflow/entries/_meta_tags.html.erb
@@ -1,4 +1,0 @@
-  <meta name="dc.language" content="<%= I18n.locale %>" />
-  <% if entry.keywords.present? %><meta name="keywords" content="<%= entry.keywords %>"><% end %>
-  <% if entry.author.present? %><meta name="author" content="<%= entry.author %>"><% end %>
-  <% if entry.publisher.present? %><meta name="publisher" content="<%= entry.publisher %>"><% end %>

--- a/app/views/pageflow/entries/_meta_tags.html.erb
+++ b/app/views/pageflow/entries/_meta_tags.html.erb
@@ -1,0 +1,4 @@
+  <meta name="dc.language" content="<%= I18n.locale %>" />
+  <% if entry.keywords.present? %><meta name="keywords" content="<%= entry.keywords %>"><% end %>
+  <% if entry.author.present? %><meta name="author" content="<%= entry.author %>"><% end %>
+  <% if entry.publisher.present? %><meta name="publisher" content="<%= entry.publisher %>"><% end %>

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = pretty_entry_title(@entry.title) %>
+<% @page_title = pretty_entry_title(@entry) %>
 
 <% content_for(:head) do %>
   <%= cache [@entry, :head, @entry.share_target] do %>

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = @entry.title %>
+<% @page_title = pretty_entry_title(@entry.title) %>
 
 <% content_for(:head) do %>
   <%= cache [@entry, :head, @entry.share_target] do %>

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -33,3 +33,6 @@
 
   <%= render 'pageflow/entries/analytics', :entry => @entry %>
 <% end %>
+
+<% content_for :author, @entry.users.map(&:full_name).to_sentence if @entry.users.present? %>
+<% content_for :publisher, @entry.account.name %>

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -34,5 +34,6 @@
   <%= render 'pageflow/entries/analytics', :entry => @entry %>
 <% end %>
 
-<% content_for :author, @entry.users.map(&:full_name).to_sentence if @entry.users.present? %>
-<% content_for :publisher, @entry.account.name %>
+<% content_for :author, @entry.author %>
+<% content_for :publisher, @entry.publisher %>
+<% content_for :keywords, @entry.keywords %>

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -10,7 +10,7 @@
     <%= render_widget_head_fragments(@entry) %>
 
     <%= tag :link, :rel => 'icon', :href => image_path("pageflow/themes/#{@entry.theming.theme.directory_name}/favicon.ico"), :type => 'image/ico' %>
-    <%= render 'pageflow/entries/meta_tags', :entry => @entry %>
+    <%= meta_tags_for_entry(@entry) %>
   <% end %>
 <% end %>
 

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -10,6 +10,7 @@
     <%= render_widget_head_fragments(@entry) %>
 
     <%= tag :link, :rel => 'icon', :href => image_path("pageflow/themes/#{@entry.theming.theme.directory_name}/favicon.ico"), :type => 'image/ico' %>
+    <%= render 'pageflow/entries/meta_tags', :entry => @entry %>
   <% end %>
 <% end %>
 
@@ -33,7 +34,3 @@
 
   <%= render 'pageflow/entries/analytics', :entry => @entry %>
 <% end %>
-
-<% content_for :author, @entry.author %>
-<% content_for :publisher, @entry.publisher %>
-<% content_for :keywords, @entry.keywords %>

--- a/app/views/pageflow/meta_tags/_entry.html.erb
+++ b/app/views/pageflow/meta_tags/_entry.html.erb
@@ -1,0 +1,4 @@
+  <meta name="dc.language" content="<%= I18n.locale %>" />
+  <% if keywords.present? %><meta name="keywords" content="<%= keywords %>"><% end %>
+  <% if author.present? %><meta name="author" content="<%= author %>"><% end %>
+  <% if publisher.present? %><meta name="publisher" content="<%= publisher %>"><% end %>

--- a/app/views/pageflow/social_share/_entry_meta_tags.html.erb
+++ b/app/views/pageflow/social_share/_entry_meta_tags.html.erb
@@ -5,7 +5,6 @@
 <%= tag :meta, :property => "og:title", :content => "#{entry.title} - #{entry.theming.cname_domain}" %>
 <%= tag :meta, :property => "og:description", :name => "description", :content => social_share_entry_description(entry) %>
 <%= tag :meta, :property => "og:url", :content => pretty_entry_url(entry) %>
-<%= tag :meta, :property => "og:site_name", :content => entry.theming.cname_domain %>
 <%= tag :meta, :property => "og:type", :content => "website" %>
 
 <%= tag :meta, :name => "twitter:card", :content => "summary_large_image" %>

--- a/app/views/pageflow/social_share/_entry_meta_tags.html.erb
+++ b/app/views/pageflow/social_share/_entry_meta_tags.html.erb
@@ -2,7 +2,7 @@
 
 <%= social_share_entry_image_tags(entry) %>
 
-<%= tag :meta, :property => "og:title", :content => "#{entry.title} - #{entry.theming.cname_domain}" %>
+<%= tag :meta, :property => "og:title", :content => pretty_entry_title(entry) %>
 <%= tag :meta, :property => "og:description", :name => "description", :content => social_share_entry_description(entry) %>
 <%= tag :meta, :property => "og:url", :content => pretty_entry_url(entry) %>
 <%= tag :meta, :property => "og:type", :content => "website" %>

--- a/app/views/pageflow/social_share/_entry_meta_tags.html.erb
+++ b/app/views/pageflow/social_share/_entry_meta_tags.html.erb
@@ -5,6 +5,7 @@
 <%= tag :meta, :property => "og:title", :content => pretty_entry_title(entry) %>
 <%= tag :meta, :property => "og:description", :name => "description", :content => social_share_entry_description(entry) %>
 <%= tag :meta, :property => "og:url", :content => pretty_entry_url(entry) %>
+<%= tag :meta, :property => "og:site_name", :content => entry.theming.cname_domain %>
 <%= tag :meta, :property => "og:type", :content => "website" %>
 
 <%= tag :meta, :name => "twitter:card", :content => "summary_large_image" %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -169,15 +169,18 @@ de:
         title: Titel
       pageflow/entry:
         account: Konto
+        author: Autor
         created_at: Erstellt am
         credits: Credits
         emphasize_chapter_beginning: Kapitelanfang hervorheben
         emphasize_new_pages: Neue Seiten hervorheben
         home_button_enabled: Home-Button anzeigen
         home_url: Home-Button URL
+        keywords: Schlüsselwörter
         locale: Sprache
         manual_start: Multimedia Hinweis vor dem Start anzeigen
         published?: Veröffentlichungstatus
+        publisher: Herausgeber
         share_image_id: Social Sharing Bild
         summary: Zusammenfassung
         title: Titel

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -430,7 +430,7 @@ de:
       long: ! '%e. %B %Y'
       short: ! '%e. %b'
     month_names:
-    -
+    - 
     - Januar
     - Februar
     - März

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -169,18 +169,15 @@ de:
         title: Titel
       pageflow/entry:
         account: Konto
-        author: Autor
         created_at: Erstellt am
         credits: Credits
         emphasize_chapter_beginning: Kapitelanfang hervorheben
         emphasize_new_pages: Neue Seiten hervorheben
         home_button_enabled: Home-Button anzeigen
         home_url: Home-Button URL
-        keywords: Schlüsselwörter
         locale: Sprache
         manual_start: Multimedia Hinweis vor dem Start anzeigen
         published?: Veröffentlichungstatus
-        publisher: Herausgeber
         share_image_id: Social Sharing Bild
         summary: Zusammenfassung
         title: Titel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,15 +169,18 @@ en:
         title: Title
       pageflow/entry:
         account: Account
+        author: Author
         created_at: Created at
         credits: Credits
         emphasize_chapter_beginning: Emphasize chapter beginning
         emphasize_new_pages: Emphasize new pages
         home_button_enabled: Show 'Home' button
         home_url: ! '''Home'' Button URL'
+        keywords: Keywords
         locale: Language
         manual_start: Show Instruction-Overlay
         published?: Publication state
+        publisher: Publisher
         share_image_id: Social Sharing Image
         summary: Summary
         title: Title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,18 +169,15 @@ en:
         title: Title
       pageflow/entry:
         account: Account
-        author: Author
         created_at: Created at
         credits: Credits
         emphasize_chapter_beginning: Emphasize chapter beginning
         emphasize_new_pages: Emphasize new pages
         home_button_enabled: Show 'Home' button
         home_url: ! '''Home'' Button URL'
-        keywords: Keywords
         locale: Language
         manual_start: Show Instruction-Overlay
         published?: Publication state
-        publisher: Publisher
         share_image_id: Social Sharing Image
         summary: Summary
         title: Title

--- a/config/locales/new/dynamic_meta_de.yml
+++ b/config/locales/new/dynamic_meta_de.yml
@@ -1,0 +1,7 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/entry:
+        author: Autor
+        keywords: Schlüsselwörter
+        publisher: Herausgeber

--- a/config/locales/new/dynamic_meta_en.yml
+++ b/config/locales/new/dynamic_meta_en.yml
@@ -1,0 +1,7 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/entry:
+        author: Author
+        keywords: Keywords
+        publisher: Publisher

--- a/db/migrate/20160216130336_add_meta_fields_to_revision.rb
+++ b/db/migrate/20160216130336_add_meta_fields_to_revision.rb
@@ -1,0 +1,7 @@
+class AddMetaFieldsToRevision < ActiveRecord::Migration
+  def change
+    add_column :pageflow_revisions, :author, :string
+    add_column :pageflow_revisions, :publisher, :string
+    add_column :pageflow_revisions, :keywords, :string
+  end
+end

--- a/lib/generators/pageflow/initializer/templates/pageflow.rb
+++ b/lib/generators/pageflow/initializer/templates/pageflow.rb
@@ -76,6 +76,13 @@ Pageflow.configure do |config|
     :s3_protocol => ENV.fetch('S3_PROTOCOL','http'),
     :attachments_version => 'v1'
   )
+
+  # Specify default meta tags to use in published stories.
+  # These defaults will be included in the page <head> unless overriden by the Entry.
+  # If you set these to <tt>nil</tt> or <tt>""</tt> the meta tag won't be included.
+  config.default_keywords_meta_tag = 'pageflow, multimedia, reportage'
+  config.default_author_meta_tag = 'Pageflow'
+  config.default_publisher_meta_tag = 'Pageflow'
 end
 
 # Comment out this call if you wish to run rails generators or rake

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -219,6 +219,15 @@ module Pageflow
     # @since 0.9
     attr_accessor :public_https_mode
 
+    # Meta tag defaults.
+    #
+    # These defaults will be included in the page <head> unless overriden by the Entry.
+    # If you set these to <tt>nil</tt> or <tt>""</tt> the meta tag won't be included.
+    # @since edge
+    attr_accessor :default_keywords_meta_tag
+    attr_accessor :default_author_meta_tag
+    attr_accessor :default_publisher_meta_tag
+
     def initialize
       @paperclip_filesystem_default_options = {validate_media_type: false}
       @paperclip_s3_default_options = {validate_media_type: false}
@@ -252,6 +261,10 @@ module Pageflow
       @available_public_locales = PublicI18n.available_locales
 
       @public_https_mode = :prevent
+
+      @default_keywords_meta_tag = 'pageflow, multimedia, reportage'
+      @default_author_meta_tag = 'Pageflow'
+      @default_publisher_meta_tag = 'Pageflow'
     end
 
     # Activate a plugin.

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -5,6 +5,25 @@ ActionView::TestCase::TestController.send(:include, Pageflow::Engine.routes.url_
 
 module Pageflow
   describe EntriesHelper do
+    describe '#pretty_entry_title' do
+      it 'equals the entry title by default' do
+        entry = PublishedEntry.new(build(:entry, title: 'test'))
+        expect(helper.pretty_entry_title(entry)).to eq('test')
+      end
+
+      it 'includes the cname domain when present' do
+        theming = build(:theming, cname: 'www.example.com')
+        entry = PublishedEntry.new(build(:entry, title: 'test', theming: theming))
+        expect(helper.pretty_entry_title(entry)).to eq('test - example.com')
+      end
+
+      it 'does not include empty cname domain' do
+        theming = build(:theming, cname: '')
+        entry = PublishedEntry.new(build(:entry, title: 'test', theming: theming))
+        expect(helper.pretty_entry_title(entry)).to eq('test')
+      end
+    end
+
     describe '#pretty_entry_url' do
       it 'uses default host' do
         theming = create(:theming, cname: '')

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -7,19 +7,19 @@ module Pageflow
   describe EntriesHelper do
     describe '#pretty_entry_title' do
       it 'equals the entry title by default' do
-        entry = PublishedEntry.new(build(:entry, title: 'test'))
+        entry = PublishedEntry.new(build(:entry, title: 'test'), build(:revision))
         expect(helper.pretty_entry_title(entry)).to eq('test')
       end
 
       it 'includes the cname domain when present' do
         theming = build(:theming, cname: 'www.example.com')
-        entry = PublishedEntry.new(build(:entry, title: 'test', theming: theming))
+        entry = PublishedEntry.new(build(:entry, title: 'test', theming: theming), build(:revision))
         expect(helper.pretty_entry_title(entry)).to eq('test - example.com')
       end
 
       it 'does not include empty cname domain' do
         theming = build(:theming, cname: '')
-        entry = PublishedEntry.new(build(:entry, title: 'test', theming: theming))
+        entry = PublishedEntry.new(build(:entry, title: 'test', theming: theming), build(:revision))
         expect(helper.pretty_entry_title(entry)).to eq('test')
       end
     end

--- a/spec/helpers/pageflow/meta_tags_helper_spec.rb
+++ b/spec/helpers/pageflow/meta_tags_helper_spec.rb
@@ -2,22 +2,34 @@ require 'spec_helper'
 
 module Pageflow
   RSpec.describe MetaTagsHelper, type: :helper do
-    let(:entry) { create(:entry, :published)}
-    let(:published_entry) { PublishedEntry.new(entry)}
+    let(:entry) { create(:entry, :published) }
+    let(:published_entry) { PublishedEntry.new(entry) }
 
     it 'renders default keywords from configuration' do
       html = helper.meta_tags_for_entry(published_entry)
-      expect(html).to have_css(%Q{meta[content="pageflow, multimedia, reportage"][name="keywords"]}, visible: false, count: 1)
+      expect(html).to have_css(
+        %{meta[content="pageflow, multimedia, reportage"][name="keywords"]},
+        visible: false,
+        count: 1
+      )
     end
 
     it 'renders default author from configuration' do
       html = helper.meta_tags_for_entry(published_entry)
-      expect(html).to have_css(%Q{meta[content="Pageflow"][name="author"]}, visible: false, count: 1)
+      expect(html).to have_css(
+        %{meta[content="Pageflow"][name="author"]},
+        visible: false,
+        count: 1
+      )
     end
 
     it 'renders default publisher from configuration' do
       html = helper.meta_tags_for_entry(published_entry)
-      expect(html).to have_css(%Q{meta[content="Pageflow"][name="publisher"]}, visible: false, count: 1)
+      expect(html).to have_css(
+        %{meta[content="Pageflow"][name="publisher"]},
+        visible: false,
+        count: 1
+      )
     end
   end
 end

--- a/spec/helpers/pageflow/meta_tags_helper_spec.rb
+++ b/spec/helpers/pageflow/meta_tags_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+module Pageflow
+  RSpec.describe MetaTagsHelper, type: :helper do
+    let(:entry) { create(:entry, :published)}
+    let(:published_entry) { PublishedEntry.new(entry)}
+
+    it 'renders default keywords from configuration' do
+      html = helper.meta_tags_for_entry(published_entry)
+      expect(html).to have_css(%Q{meta[content="pageflow, multimedia, reportage"][name="keywords"]}, visible: false, count: 1)
+    end
+
+    it 'renders default author from configuration' do
+      html = helper.meta_tags_for_entry(published_entry)
+      expect(html).to have_css(%Q{meta[content="Pageflow"][name="author"]}, visible: false, count: 1)
+    end
+
+    it 'renders default publisher from configuration' do
+      html = helper.meta_tags_for_entry(published_entry)
+      expect(html).to have_css(%Q{meta[content="Pageflow"][name="publisher"]}, visible: false, count: 1)
+    end
+  end
+end

--- a/spec/helpers/pageflow/meta_tags_helper_spec.rb
+++ b/spec/helpers/pageflow/meta_tags_helper_spec.rb
@@ -5,9 +5,9 @@ module Pageflow
     let(:entry) { create(:entry, :published) }
     let(:published_entry) { PublishedEntry.new(entry) }
 
-    let(:html) { helper.meta_tags_for_entry(published_entry) }
-
     it 'renders default keywords from configuration' do
+      html = helper.meta_tags_for_entry(published_entry)
+
       expect(html).to have_css(
         %{meta[content="pageflow, multimedia, reportage"][name="keywords"]},
         visible: false,
@@ -15,8 +15,10 @@ module Pageflow
       )
     end
 
-    it 'allows keywords being set from configuration' do
-      Pageflow.configure { |config| config.default_keywords_meta_tag = 'story, environment' }
+    it 'allows default keywords being set from configuration' do
+      pageflow_configure { |config| config.default_keywords_meta_tag = 'story, environment' }
+
+      html = helper.meta_tags_for_entry(published_entry)
 
       expect(html).to have_css(
         %{meta[content="story, environment"][name="keywords"]},
@@ -26,6 +28,8 @@ module Pageflow
     end
 
     it 'renders default author from configuration' do
+      html = helper.meta_tags_for_entry(published_entry)
+
       expect(html).to have_css(
         %{meta[content="Pageflow"][name="author"]},
         visible: false,
@@ -34,7 +38,9 @@ module Pageflow
     end
 
     it 'allows author being set from configuration' do
-      Pageflow.configure { |config| config.default_author_meta_tag = 'Acme, Inc.' }
+      pageflow_configure { |config| config.default_author_meta_tag = 'Acme, Inc.' }
+
+      html = helper.meta_tags_for_entry(published_entry)
 
       expect(html).to have_css(
         %{meta[content="Acme, Inc."][name="author"]},
@@ -44,6 +50,8 @@ module Pageflow
     end
 
     it 'renders default publisher from configuration' do
+      html = helper.meta_tags_for_entry(published_entry)
+
       expect(html).to have_css(
         %{meta[content="Pageflow"][name="publisher"]},
         visible: false,
@@ -52,7 +60,9 @@ module Pageflow
     end
 
     it 'allows publisher being set from configuration' do
-      Pageflow.configure { |config| config.default_publisher_meta_tag = 'Acme, Inc.' }
+      pageflow_configure { |config| config.default_publisher_meta_tag = 'Acme, Inc.' }
+
+      html = helper.meta_tags_for_entry(published_entry)
 
       expect(html).to have_css(
         %{meta[content="Acme, Inc."][name="publisher"]},

--- a/spec/helpers/pageflow/meta_tags_helper_spec.rb
+++ b/spec/helpers/pageflow/meta_tags_helper_spec.rb
@@ -5,8 +5,9 @@ module Pageflow
     let(:entry) { create(:entry, :published) }
     let(:published_entry) { PublishedEntry.new(entry) }
 
+    let(:html) { helper.meta_tags_for_entry(published_entry) }
+
     it 'renders default keywords from configuration' do
-      html = helper.meta_tags_for_entry(published_entry)
       expect(html).to have_css(
         %{meta[content="pageflow, multimedia, reportage"][name="keywords"]},
         visible: false,
@@ -14,8 +15,17 @@ module Pageflow
       )
     end
 
+    it 'allows keywords being set from configuration' do
+      Pageflow.configure { |config| config.default_keywords_meta_tag = 'story, environment' }
+
+      expect(html).to have_css(
+        %{meta[content="story, environment"][name="keywords"]},
+        visible: false,
+        count: 1
+      )
+    end
+
     it 'renders default author from configuration' do
-      html = helper.meta_tags_for_entry(published_entry)
       expect(html).to have_css(
         %{meta[content="Pageflow"][name="author"]},
         visible: false,
@@ -23,10 +33,29 @@ module Pageflow
       )
     end
 
+    it 'allows author being set from configuration' do
+      Pageflow.configure { |config| config.default_author_meta_tag = 'Acme, Inc.' }
+
+      expect(html).to have_css(
+        %{meta[content="Acme, Inc."][name="author"]},
+        visible: false,
+        count: 1
+      )
+    end
+
     it 'renders default publisher from configuration' do
-      html = helper.meta_tags_for_entry(published_entry)
       expect(html).to have_css(
         %{meta[content="Pageflow"][name="publisher"]},
+        visible: false,
+        count: 1
+      )
+    end
+
+    it 'allows publisher being set from configuration' do
+      Pageflow.configure { |config| config.default_publisher_meta_tag = 'Acme, Inc.' }
+
+      expect(html).to have_css(
+        %{meta[content="Acme, Inc."][name="publisher"]},
         visible: false,
         count: 1
       )

--- a/spec/models/pageflow/published_entry_spec.rb
+++ b/spec/models/pageflow/published_entry_spec.rb
@@ -2,6 +2,22 @@ require 'spec_helper'
 
 module Pageflow
   describe PublishedEntry do
+    describe '#title' do
+      let(:entry) { create(:entry, title: "Metropolis") }
+      let(:published_entry) { PublishedEntry.new(entry) }
+
+      it 'is fetched from the revision' do
+        create(:revision, :published, entry: entry, title: "Blade Runner")
+        expect(published_entry.title).to eq("Blade Runner")
+      end
+
+      context 'not present on the revision' do
+        it 'is fetched from the entry' do
+          expect(published_entry.title).to eq("Metropolis")
+        end
+      end
+    end
+
     describe '#thumbnail_file' do
       it 'returns positioned share image of published revision' do
         entry = create(:entry)

--- a/spec/models/pageflow/published_entry_spec.rb
+++ b/spec/models/pageflow/published_entry_spec.rb
@@ -3,17 +3,17 @@ require 'spec_helper'
 module Pageflow
   describe PublishedEntry do
     describe '#title' do
-      let(:entry) { create(:entry, title: "Metropolis") }
+      let(:entry) { create(:entry, title: 'Metropolis') }
       let(:published_entry) { PublishedEntry.new(entry) }
 
       it 'is fetched from the revision' do
-        create(:revision, :published, entry: entry, title: "Blade Runner")
-        expect(published_entry.title).to eq("Blade Runner")
+        create(:revision, :published, entry: entry, title: 'Blade Runner')
+        expect(published_entry.title).to eq('Blade Runner')
       end
 
       context 'not present on the revision' do
         it 'is fetched from the entry' do
-          expect(published_entry.title).to eq("Metropolis")
+          expect(published_entry.title).to eq('Metropolis')
         end
       end
     end

--- a/spec/models/pageflow/published_entry_spec.rb
+++ b/spec/models/pageflow/published_entry_spec.rb
@@ -6,15 +6,14 @@ module Pageflow
       let(:entry) { create(:entry, title: 'Metropolis') }
       let(:published_entry) { PublishedEntry.new(entry) }
 
-      it 'is fetched from the revision' do
+      it 'is fetched from the revision when present' do
         create(:revision, :published, entry: entry, title: 'Blade Runner')
         expect(published_entry.title).to eq('Blade Runner')
       end
 
-      context 'not present on the revision' do
-        it 'is fetched from the entry' do
-          expect(published_entry.title).to eq('Metropolis')
-        end
+      it 'is fetched from the entry when absent from the revision' do
+        create(:revision, :published, entry: entry, title: '')
+        expect(published_entry.title).to eq('Metropolis')
       end
     end
 


### PR DESCRIPTION
Set the :author and :publisher values in entry show, which allows them
to be picked up in the page <head>. Fallback to static value 'Pageflow'
for now.