### PR TITLE
Decouple overview and navigation widgets

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/navigation.js
+++ b/app/assets/javascripts/pageflow/widgets/navigation.js
@@ -72,11 +72,6 @@
         pageLinks.off('mouseup touchend', goToPage);
       }
 
-      function closeOverview() {
-        $('.overview').removeClass("active");
-        $('.navigation_index', element).removeClass("active");
-      }
-
       function hideOverlay() {
         $(overlays).addClass('hidden').removeClass('visible');
       }
@@ -86,8 +81,6 @@
           return;
         }
         hideOverlay();
-        closeOverview();
-        $('.page .content, .scroll_indicator').removeClass('hidden');
         pageflow.slides.goToById(this.getAttribute("data-link"));
         e.preventDefault();
       }

--- a/app/assets/javascripts/pageflow/widgets/overview.js
+++ b/app/assets/javascripts/pageflow/widgets/overview.js
@@ -11,7 +11,6 @@ jQuery(function($) {
         scrollerWidth = noOfChapterParts * chapterParts.outerWidth(true),
         closeButton = $('.close', this.element),
         indexButton = $('.navigation_index'),
-        homeButton = $('.navigation_home'),
         overview = $('.overview'),
         wrapper = $('.wrapper', this.element);
 
@@ -25,11 +24,19 @@ jQuery(function($) {
 
         $('section.page').toggleClass('hidden_by_overlay', state);
         scrollIndicator.toggleClass('hidden', state);
+
+        if (overview.hasClass('active')) {
+          pageflow.events.once('page:change', function() {
+            toggleContent(false);
+          }, that);
+        }
+        else {
+          pageflow.events.off('page:change', null, that);
+        }
       };
 
       var goToPage = function() {
         if (!$(this).hasClass('active')) {
-          toggleContent();
           pageflow.slides.goToById(this.getAttribute("data-link"));
         }
       };
@@ -97,10 +104,6 @@ jQuery(function($) {
 
       closeButton.click(toggleContent);
       indexButton.click(toggleContent);
-
-      homeButton.click(function() {
-        toggleContent(false);
-      });
 
       $('body').keyup(function(e) {
         if (e.which == 27 && overview.hasClass('active')) {


### PR DESCRIPTION
Overview hides content on show. Navigation used to re-display the
content on page change, but now failed to do so since the css classes
used in the overview widget changed.

Remove this coupling by making the overview register event listeners
for next page change and re-displaying content itself.