### PR TITLE
Make the html meta tags more configurable

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
@@ -23,7 +23,9 @@ pageflow.EditMetaDataView = Backbone.Marionette.Layout.extend({
     });
 
     configurationEditor.tab('general', function() {
-      this.input('title', pageflow.TextInputView);
+      this.input('title', pageflow.TextInputView, {
+        placeholder: entry.attributes.entry_title
+      });
       this.input('locale', pageflow.SelectInputView, {
         values: pageflow.config.availablePublicLocales,
         texts: _.map(pageflow.config.availablePublicLocales, function(locale) {
@@ -32,6 +34,9 @@ pageflow.EditMetaDataView = Backbone.Marionette.Layout.extend({
       });
 
       this.input('credits', pageflow.TextAreaInputView);
+      this.input('author', pageflow.TextInputView);
+      this.input('publisher', pageflow.TextInputView);
+      this.input('keywords', pageflow.TextInputView);
     });
 
     configurationEditor.tab('widgets', function() {

--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -84,7 +84,8 @@ module Pageflow
     def entry_params
       params.require(:entry).permit(:title, :summary, :credits, :manual_start, :home_url, :home_button_enabled,
                                     :emphasize_chapter_beginning, :emphasize_new_pages,
-                                    :share_image_id, :share_image_x, :share_image_y, :locale)
+                                    :share_image_id, :share_image_x, :share_image_y, :locale,
+                                    :author, :publisher, :keywords)
     end
 
     def entry_request_scope

--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -1,5 +1,9 @@
 module Pageflow
   module EntriesHelper
+    def pretty_entry_title(entry)
+      [entry.title, entry.theming.cname_domain.presence].compact.join(' - ')
+    end
+
     def pretty_entry_url(entry)
       pageflow.short_entry_url(entry.to_model, Pageflow.config.theming_url_options(entry.theming))
     end

--- a/app/helpers/pageflow/meta_tags_helper.rb
+++ b/app/helpers/pageflow/meta_tags_helper.rb
@@ -1,0 +1,11 @@
+module Pageflow
+  module MetaTagsHelper
+    def meta_tags_for_entry(entry)
+      render partial: 'pageflow/meta_tags/entry', locals: {
+        keywords: entry.keywords.presence || Pageflow.config.default_keywords_meta_tag,
+        author: entry.author.presence || Pageflow.config.default_author_meta_tag,
+        publisher: entry.publisher.presence || Pageflow.config.default_publisher_meta_tag
+      }
+    end
+  end
+end

--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -21,11 +21,17 @@ module Pageflow
              :files,
              :image_files, :video_files, :audio_files,
              :locale,
+             :author, :publisher, :keywords,
              :to => :draft)
 
     def initialize(entry, draft = nil)
       @entry = entry
       @draft = draft || entry.draft
+    end
+
+    # So we can always get to the original Entry title.
+    def entry_title
+      entry.title
     end
 
     def create_file(model, attributes)

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -17,11 +17,12 @@ module Pageflow
              :storylines, :main_storyline_chapters, :chapters, :pages,
              :files,
              :image_files, :video_files, :audio_files,
-             :title, :summary, :credits, :manual_start,
+             :summary, :credits, :manual_start,
              :emphasize_chapter_beginning,
              :emphasize_new_pages,
              :share_image_id, :share_image_x, :share_image_y,
              :locale,
+             :author, :publisher, :keywords,
              :password_protected?,
              :to => :revision)
 
@@ -29,6 +30,10 @@ module Pageflow
       @entry = entry
       @revision = revision || entry.published_revision
       @custom_revision = !!revision
+    end
+
+    def title
+      revision.title.presence || entry.title
     end
 
     def stylesheet_model

--- a/app/views/layouts/pageflow/_meta_tags.html.erb
+++ b/app/views/layouts/pageflow/_meta_tags.html.erb
@@ -1,5 +1,0 @@
-  <meta name="dc.language" content="<%= I18n.locale %>" />
-  <meta name="keywords" content="pageflow, multimedia, reportage">
-  <meta name="description" content="">
-  <meta name="author" content="Pageflow">
-  <meta name="publisher" content="Pageflow">

--- a/app/views/layouts/pageflow/application.html.erb
+++ b/app/views/layouts/pageflow/application.html.erb
@@ -10,7 +10,6 @@
   <%= javascript_include_tag "pageflow/application", "data-turbolinks-track" => true %>
 
   <%= csrf_meta_tags %>
-  <%= render 'layouts/pageflow/meta_tags' %>
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, minimum-scale=1, maximum-scale=1" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
 

--- a/app/views/pageflow/editor/entries/_entry.json.jbuilder
+++ b/app/views/pageflow/editor/entries/_entry.json.jbuilder
@@ -1,4 +1,4 @@
-json.(entry, :id, :published_until, :slug, :enabled_feature_names)
+json.(entry, :id, :entry_title, :published_until, :slug, :enabled_feature_names)
 
 json.pretty_url pretty_entry_url(entry)
 
@@ -7,7 +7,7 @@ json.published(entry.published?)
 json.password_protected(entry.password_digest.present?)
 
 json.configuration do
-  json.(entry, :title, :summary, :credits, :manual_start, :emphasize_chapter_beginning, :emphasize_new_pages, :share_image_id, :share_image_x, :share_image_y, :locale)
+  json.(entry, :title, :summary, :credits, :author, :publisher, :keywords, :manual_start, :emphasize_chapter_beginning, :emphasize_new_pages, :share_image_id, :share_image_x, :share_image_y, :locale)
   json.home_url entry.home_button.url_value
   json.home_button_enabled entry.home_button.enabled_value
 end

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = @entry.title %>
+<% @page_title = pretty_entry_title(@entry) %>
 
 <% content_for(:head) do %>
   <%= cache [@entry, :head, @entry.share_target] do %>
@@ -10,6 +10,7 @@
     <%= render_widget_head_fragments(@entry) %>
 
     <%= tag :link, :rel => 'icon', :href => image_path("pageflow/themes/#{@entry.theming.theme.directory_name}/favicon.ico"), :type => 'image/ico' %>
+    <%= meta_tags_for_entry(@entry) %>
   <% end %>
 <% end %>
 

--- a/app/views/pageflow/meta_tags/_entry.html.erb
+++ b/app/views/pageflow/meta_tags/_entry.html.erb
@@ -1,0 +1,4 @@
+  <meta name="dc.language" content="<%= I18n.locale %>" />
+  <% if keywords.present? %><meta name="keywords" content="<%= keywords %>"><% end %>
+  <% if author.present? %><meta name="author" content="<%= author %>"><% end %>
+  <% if publisher.present? %><meta name="publisher" content="<%= publisher %>"><% end %>

--- a/app/views/pageflow/social_share/_entry_meta_tags.html.erb
+++ b/app/views/pageflow/social_share/_entry_meta_tags.html.erb
@@ -2,7 +2,7 @@
 
 <%= social_share_entry_image_tags(entry) %>
 
-<%= tag :meta, :property => "og:title", :content => "#{entry.title} - #{entry.theming.cname_domain}" %>
+<%= tag :meta, :property => "og:title", :content => pretty_entry_title(entry) %>
 <%= tag :meta, :property => "og:description", :name => "description", :content => social_share_entry_description(entry) %>
 <%= tag :meta, :property => "og:url", :content => pretty_entry_url(entry) %>
 <%= tag :meta, :property => "og:site_name", :content => entry.theming.cname_domain %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -430,7 +430,7 @@ de:
       long: ! '%e. %B %Y'
       short: ! '%e. %b'
     month_names:
-    -
+    - 
     - Januar
     - Februar
     - März

--- a/config/locales/new/dynamic_meta_de.yml
+++ b/config/locales/new/dynamic_meta_de.yml
@@ -1,0 +1,7 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/entry:
+        author: Autor
+        keywords: Schlüsselwörter
+        publisher: Herausgeber

--- a/config/locales/new/dynamic_meta_en.yml
+++ b/config/locales/new/dynamic_meta_en.yml
@@ -1,0 +1,7 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/entry:
+        author: Author
+        keywords: Keywords
+        publisher: Publisher

--- a/db/migrate/20160216130336_add_meta_fields_to_revision.rb
+++ b/db/migrate/20160216130336_add_meta_fields_to_revision.rb
@@ -1,0 +1,7 @@
+class AddMetaFieldsToRevision < ActiveRecord::Migration
+  def change
+    add_column :pageflow_revisions, :author, :string
+    add_column :pageflow_revisions, :publisher, :string
+    add_column :pageflow_revisions, :keywords, :string
+  end
+end

--- a/lib/generators/pageflow/initializer/templates/pageflow.rb
+++ b/lib/generators/pageflow/initializer/templates/pageflow.rb
@@ -76,6 +76,13 @@ Pageflow.configure do |config|
     :s3_protocol => ENV.fetch('S3_PROTOCOL','http'),
     :attachments_version => 'v1'
   )
+
+  # Specify default meta tags to use in published stories.
+  # These defaults will be included in the page <head> unless overriden by the Entry.
+  # If you set these to <tt>nil</tt> or <tt>""</tt> the meta tag won't be included.
+  config.default_keywords_meta_tag = 'pageflow, multimedia, reportage'
+  config.default_author_meta_tag = 'Pageflow'
+  config.default_publisher_meta_tag = 'Pageflow'
 end
 
 # Comment out this call if you wish to run rails generators or rake

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -219,6 +219,15 @@ module Pageflow
     # @since 0.9
     attr_accessor :public_https_mode
 
+    # Meta tag defaults.
+    #
+    # These defaults will be included in the page <head> unless overriden by the Entry.
+    # If you set these to <tt>nil</tt> or <tt>""</tt> the meta tag won't be included.
+    # @since edge
+    attr_accessor :default_keywords_meta_tag
+    attr_accessor :default_author_meta_tag
+    attr_accessor :default_publisher_meta_tag
+
     def initialize
       @paperclip_filesystem_default_options = {validate_media_type: false}
       @paperclip_s3_default_options = {validate_media_type: false}
@@ -252,6 +261,10 @@ module Pageflow
       @available_public_locales = PublicI18n.available_locales
 
       @public_https_mode = :prevent
+
+      @default_keywords_meta_tag = 'pageflow, multimedia, reportage'
+      @default_author_meta_tag = 'Pageflow'
+      @default_publisher_meta_tag = 'Pageflow'
     end
 
     # Activate a plugin.

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -5,6 +5,25 @@ ActionView::TestCase::TestController.send(:include, Pageflow::Engine.routes.url_
 
 module Pageflow
   describe EntriesHelper do
+    describe '#pretty_entry_title' do
+      it 'equals the entry title by default' do
+        entry = PublishedEntry.new(build(:entry, title: 'test'), build(:revision))
+        expect(helper.pretty_entry_title(entry)).to eq('test')
+      end
+
+      it 'includes the cname domain when present' do
+        theming = build(:theming, cname: 'www.example.com')
+        entry = PublishedEntry.new(build(:entry, title: 'test', theming: theming), build(:revision))
+        expect(helper.pretty_entry_title(entry)).to eq('test - example.com')
+      end
+
+      it 'does not include empty cname domain' do
+        theming = build(:theming, cname: '')
+        entry = PublishedEntry.new(build(:entry, title: 'test', theming: theming), build(:revision))
+        expect(helper.pretty_entry_title(entry)).to eq('test')
+      end
+    end
+
     describe '#pretty_entry_url' do
       it 'uses default host' do
         theming = create(:theming, cname: '')

--- a/spec/helpers/pageflow/meta_tags_helper_spec.rb
+++ b/spec/helpers/pageflow/meta_tags_helper_spec.rb
@@ -5,70 +5,98 @@ module Pageflow
     let(:entry) { create(:entry, :published) }
     let(:published_entry) { PublishedEntry.new(entry) }
 
-    it 'renders default keywords from configuration' do
-      html = helper.meta_tags_for_entry(published_entry)
-
-      expect(html).to have_css(
-        %{meta[content="pageflow, multimedia, reportage"][name="keywords"]},
-        visible: false,
-        count: 1
-      )
+    def html
+      helper.meta_tags_for_entry(published_entry)
     end
 
-    it 'allows default keywords being set from configuration' do
-      pageflow_configure { |config| config.default_keywords_meta_tag = 'story, environment' }
+    describe 'keywords' do
+      it 'has default value from configuration' do
+        expect(html).to have_css(
+          %{meta[content="pageflow, multimedia, reportage"][name="keywords"]},
+          visible: false,
+          count: 1
+        )
+      end
 
-      html = helper.meta_tags_for_entry(published_entry)
+      it 'can have default set in configuration' do
+        pageflow_configure { |config| config.default_keywords_meta_tag = 'story, environment' }
 
-      expect(html).to have_css(
-        %{meta[content="story, environment"][name="keywords"]},
-        visible: false,
-        count: 1
-      )
+        expect(html).to have_css(
+          %{meta[content="story, environment"][name="keywords"]},
+          visible: false,
+          count: 1
+        )
+      end
+
+      it 'can be overriden per revision' do
+        entry.published_revision.update! keywords: 'longform, journalism'
+
+        expect(html).to have_css(
+          %{meta[content="longform, journalism"][name="keywords"]},
+          visible: false,
+          count: 1
+        )
+      end
     end
 
-    it 'renders default author from configuration' do
-      html = helper.meta_tags_for_entry(published_entry)
+    describe 'author' do
+      it 'has default value from configuration' do
+        expect(html).to have_css(
+          %{meta[content="Pageflow"][name="author"]},
+          visible: false,
+          count: 1
+        )
+      end
 
-      expect(html).to have_css(
-        %{meta[content="Pageflow"][name="author"]},
-        visible: false,
-        count: 1
-      )
+      it 'can have default set in configuration' do
+        pageflow_configure { |config| config.default_author_meta_tag = 'Prof. Dr. Sahra Isak' }
+
+        expect(html).to have_css(
+          %{meta[content="Prof. Dr. Sahra Isak"][name="author"]},
+          visible: false,
+          count: 1
+        )
+      end
+
+      it 'can be overriden per revision' do
+        entry.published_revision.update! author: 'Henri zu Walter'
+
+        expect(html).to have_css(
+          %{meta[content="Henri zu Walter"][name="author"]},
+          visible: false,
+          count: 1
+        )
+      end
     end
 
-    it 'allows author being set from configuration' do
-      pageflow_configure { |config| config.default_author_meta_tag = 'Acme, Inc.' }
+    describe 'publisher' do
+      it 'has default value from configuration' do
+        expect(html).to have_css(
+          %{meta[content="Pageflow"][name="publisher"]},
+          visible: false,
+          count: 1
+        )
+      end
 
-      html = helper.meta_tags_for_entry(published_entry)
+      it 'can have default set in configuration' do
+        pageflow_configure { |config| config.default_publisher_meta_tag = 'Kempe-Heuck' }
 
-      expect(html).to have_css(
-        %{meta[content="Acme, Inc."][name="author"]},
-        visible: false,
-        count: 1
-      )
-    end
+        expect(html).to have_css(
+          %{meta[content="Kempe-Heuck"][name="publisher"]},
+          visible: false,
+          count: 1
+        )
+      end
 
-    it 'renders default publisher from configuration' do
-      html = helper.meta_tags_for_entry(published_entry)
+      it 'can be overriden per revision' do
+        entry.published_revision.update! publisher: 'Adams, Kähler und Tafelmeier'
 
-      expect(html).to have_css(
-        %{meta[content="Pageflow"][name="publisher"]},
-        visible: false,
-        count: 1
-      )
-    end
-
-    it 'allows publisher being set from configuration' do
-      pageflow_configure { |config| config.default_publisher_meta_tag = 'Acme, Inc.' }
-
-      html = helper.meta_tags_for_entry(published_entry)
-
-      expect(html).to have_css(
-        %{meta[content="Acme, Inc."][name="publisher"]},
-        visible: false,
-        count: 1
-      )
+        expect(html).to have_css(
+          %{meta[content="Adams, Kähler und Tafelmeier"][name="publisher"]},
+          visible: false,
+          count: 1
+        )
+      end
     end
   end
 end

--- a/spec/helpers/pageflow/meta_tags_helper_spec.rb
+++ b/spec/helpers/pageflow/meta_tags_helper_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+module Pageflow
+  RSpec.describe MetaTagsHelper, type: :helper do
+    let(:entry) { create(:entry, :published) }
+    let(:published_entry) { PublishedEntry.new(entry) }
+
+    it 'renders default keywords from configuration' do
+      html = helper.meta_tags_for_entry(published_entry)
+
+      expect(html).to have_css(
+        %{meta[content="pageflow, multimedia, reportage"][name="keywords"]},
+        visible: false,
+        count: 1
+      )
+    end
+
+    it 'allows default keywords being set from configuration' do
+      pageflow_configure { |config| config.default_keywords_meta_tag = 'story, environment' }
+
+      html = helper.meta_tags_for_entry(published_entry)
+
+      expect(html).to have_css(
+        %{meta[content="story, environment"][name="keywords"]},
+        visible: false,
+        count: 1
+      )
+    end
+
+    it 'renders default author from configuration' do
+      html = helper.meta_tags_for_entry(published_entry)
+
+      expect(html).to have_css(
+        %{meta[content="Pageflow"][name="author"]},
+        visible: false,
+        count: 1
+      )
+    end
+
+    it 'allows author being set from configuration' do
+      pageflow_configure { |config| config.default_author_meta_tag = 'Acme, Inc.' }
+
+      html = helper.meta_tags_for_entry(published_entry)
+
+      expect(html).to have_css(
+        %{meta[content="Acme, Inc."][name="author"]},
+        visible: false,
+        count: 1
+      )
+    end
+
+    it 'renders default publisher from configuration' do
+      html = helper.meta_tags_for_entry(published_entry)
+
+      expect(html).to have_css(
+        %{meta[content="Pageflow"][name="publisher"]},
+        visible: false,
+        count: 1
+      )
+    end
+
+    it 'allows publisher being set from configuration' do
+      pageflow_configure { |config| config.default_publisher_meta_tag = 'Acme, Inc.' }
+
+      html = helper.meta_tags_for_entry(published_entry)
+
+      expect(html).to have_css(
+        %{meta[content="Acme, Inc."][name="publisher"]},
+        visible: false,
+        count: 1
+      )
+    end
+  end
+end

--- a/spec/models/pageflow/published_entry_spec.rb
+++ b/spec/models/pageflow/published_entry_spec.rb
@@ -2,6 +2,21 @@ require 'spec_helper'
 
 module Pageflow
   describe PublishedEntry do
+    describe '#title' do
+      let(:entry) { create(:entry, title: 'Metropolis') }
+      let(:published_entry) { PublishedEntry.new(entry) }
+
+      it 'is fetched from the revision when present' do
+        create(:revision, :published, entry: entry, title: 'Blade Runner')
+        expect(published_entry.title).to eq('Blade Runner')
+      end
+
+      it 'is fetched from the entry when absent from the revision' do
+        create(:revision, :published, entry: entry, title: '')
+        expect(published_entry.title).to eq('Metropolis')
+      end
+    end
+
     describe '#thumbnail_file' do
       it 'returns positioned share image of published revision' do
         entry = create(:entry)


### PR DESCRIPTION
* allow meta author, keywords and publisher to be set per entry
* allow meta author, keywords and publisher defaults to be configured

Also moves rendering of the meta tags into a helper, where we
encapsulate the logic of rendering the values or falling back to the
configured defaults.

This is a breaking change for folks who have overriden the
app/views/layouts/pageflow/_meta_tags.html.erb partial!

Fixes codevise/pageflow#499