### PR TITLE
use <tt>render :partial</tt> when rendering a partial

### DIFF
--- a/app/views/pageflow/pages/_page.html.erb
+++ b/app/views/pageflow/pages/_page.html.erb
@@ -1,6 +1,10 @@
 <%= cache page do %>
-  <%= content_tag :section, :id => page.perma_id, :class => page_css_class(page), :data => {:template => page.template, :id => page.id, :chapter_id => page.chapter_id} do %>
-    <%= render :template => Pageflow.config.page_types.find_by_name!(page.template).template_path, :locals => {:page => page, :configuration => page.configuration} %>
+  <%= content_tag :section,
+    id: page.perma_id, class: page_css_class(page), data: {
+      template: page.template, id: page.id, chapter_id: page.chapter_id
+    } do %>
+    <%= render partial: Pageflow.config.page_types.find_by_name!(page.template).partial_path,
+      locals: {page: page, configuration: page.configuration} %>
     <a class="to_top" href="#content"><%= t('pageflow.public.goto_top') %></a>
   <% end %>
 <% end %>

--- a/lib/pageflow/built_in_page_type.rb
+++ b/lib/pageflow/built_in_page_type.rb
@@ -24,6 +24,10 @@ module Pageflow
       File.join('pageflow', 'pages', 'templates', "_#{name}.html.erb")
     end
 
+    def partial_path
+      File.join('pageflow', 'pages', 'templates', name)
+    end
+
     def translation_key
       "activerecord.values.pageflow/page.template.#{name}"
     end


### PR DESCRIPTION
Even though <tt>render :template</tt> works, the templates that are
being referenced are partials. By using the recommended API we reduce
non-standard things in the code.

I also suspect, but cannot proof, that render partial behaves slightly
different with the locals hash.