### PR TITLE
introduce .logo_header

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/page.css.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page.css.scss
@@ -74,8 +74,7 @@ $page-color: $main-color;
 
 .js .page:first-child {
 
-  .content_and_background .scroller > div:after {
-    content: " ";
+  .logo_header {
     position: absolute;
     background-image: image-url("pageflow/themes/#{$theme-name}/logo_header.png");
     background-repeat: no-repeat;
@@ -95,7 +94,7 @@ $page-color: $main-color;
     }
   }
 
-  &.invert .content_and_background .scroller > div:after {
+  &.invert .logo_header {
     background-image: image-url("pageflow/themes/#{$theme-name}/logo_header_invert.png");
   }
 

--- a/app/views/pageflow/pages/templates/_audio.html.erb
+++ b/app/views/pageflow/pages/templates/_audio.html.erb
@@ -50,6 +50,7 @@
     </div>
     <div class="scroller">
       <div>
+        <div class="logo_header"></div>
         <div class="contentWrapper">
           <div class="contentText audioPage">
             <p class="non_js_audio">

--- a/app/views/pageflow/pages/templates/_audio_loop.html.erb
+++ b/app/views/pageflow/pages/templates/_audio_loop.html.erb
@@ -18,6 +18,7 @@
   <div class="content">
     <div class="scroller">
       <div>
+        <div class="logo_header"></div>
         <div class="contentWrapper">
           <div class="contentText audioLoopPage">
             <p class="non_js_audio">

--- a/app/views/pageflow/pages/templates/_background_image.html.erb
+++ b/app/views/pageflow/pages/templates/_background_image.html.erb
@@ -6,6 +6,7 @@
   </div>
   <div class="content scroller">
     <div>
+      <div class="logo_header"></div>
       <div class="contentWrapper">
         <div class="page_header">
           <h2>

--- a/app/views/pageflow/pages/templates/_background_video.html.erb
+++ b/app/views/pageflow/pages/templates/_background_video.html.erb
@@ -9,6 +9,7 @@
   </div>
   <div class="content scroller">
     <div>
+      <div class="logo_header"></div>
       <div class="contentWrapper">
         <div class="page_header">
           <h2>

--- a/app/views/pageflow/pages/templates/_video.html.erb
+++ b/app/views/pageflow/pages/templates/_video.html.erb
@@ -23,6 +23,7 @@
     </div>
     <div class="scroller">
       <div>
+        <div class="logo_header"></div>
         <div class="contentWrapper">
           <div class="contentText">
             <p><%= raw configuration['text'] %></p>


### PR DESCRIPTION
In the current theme, the logo header on the first page is styled using
a CSS pseudo element. This can be troublesome to work with, since the
element does not have a class.

It is also troublesome to discover that this element exists and change
it according to one's own needs. The CSS-rule is quite exact and does
not allow for much flexibility.

This patch aims to change that.

By introducing a new div with class name "logo_header" it becomes much
easier to style this element using CSS, and to override it in a custom
theme. The element becomes easier to inspect in the browser and change
some style attributes there. Lastly it's evident what this element does,
and ties in directly with the image name that's already in use.

It does mean that there is now a DIV in each page. This is an acceptable
tradeoff to me; in fact I prefer this since it will allow me to style
the header on the last page too. It gives me more power and flexibility.

@tf thoughts?