### PR TITLE
Storyline Editor Fixes

### DIFF
--- a/app/assets/javascripts/pageflow/editor/collections/chapter_pages_collection.js
+++ b/app/assets/javascripts/pageflow/editor/collections/chapter_pages_collection.js
@@ -23,6 +23,8 @@ pageflow.ChapterPagesCollection = pageflow.SubsetCollection.extend({
 
     this.listenTo(this, 'add', function(model) {
       model.chapter = chapter;
+      model.set('chapter_id', chapter.id);
+
       pageflow.editor.trigger('add:page', model);
     });
 

--- a/app/assets/javascripts/pageflow/editor/collections/storyline_chapters_collection.js
+++ b/app/assets/javascripts/pageflow/editor/collections/storyline_chapters_collection.js
@@ -23,6 +23,8 @@ pageflow.StorylineChaptersCollection = pageflow.SubsetCollection.extend({
 
     this.listenTo(this, 'add', function(model) {
       model.storyline = storyline;
+      model.set('storyline_id', storyline.id);
+
       pageflow.editor.trigger('add:chapter', model);
     });
 

--- a/app/assets/javascripts/pageflow/editor/models/storyline_ordering.js
+++ b/app/assets/javascripts/pageflow/editor/models/storyline_ordering.js
@@ -2,7 +2,7 @@ pageflow.StorylineOrdering = function(storylines, pages) {
   var storylinesByParent;
 
   this.watch = function() {
-    storylines.on('change:configuration', function() {
+    storylines.on('add change:configuration', function() {
       this.sort();
     }, this);
 

--- a/app/assets/javascripts/pageflow/editor/models/storyline_ordering.js
+++ b/app/assets/javascripts/pageflow/editor/models/storyline_ordering.js
@@ -6,7 +6,7 @@ pageflow.StorylineOrdering = function(storylines, pages) {
       this.sort();
     }, this);
 
-    pages.on('change:position', function() {
+    pages.on('change:position change:chapter_id', function() {
       this.sort();
     }, this);
   };
@@ -47,7 +47,7 @@ pageflow.StorylineOrdering = function(storylines, pages) {
     return storylines
       .groupBy(function(storyline) {
         var parentPage = getParentPage(storyline);
-        return parentPage ? parentPage.chapter.storyline.cid : -1;
+        return parentPage && parentPage.chapter ? parentPage.chapter.storyline.cid : -1;
       });
   }
 

--- a/app/assets/javascripts/pageflow/editor/views/entry_preview_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/entry_preview_view.js
@@ -30,6 +30,7 @@ pageflow.EntryPreviewView = Backbone.Marionette.ItemView.extend({
       pageflow.entry.once('sync', this.update, this);
     });
 
+    this.listenTo(pageflow.storylines, 'sync', this.update);
     this.listenTo(pageflow.chapters, 'sync', this.update);
     this.listenTo(pageflow.pages, 'sync', this.update);
 

--- a/app/assets/javascripts/pageflow/editor/views/storyline_picker_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/storyline_picker_view.js
@@ -36,7 +36,7 @@ pageflow.StorylinePickerView = Backbone.Marionette.Layout.extend({
       storyline_id: this.defaultStorylineId()
     });
 
-    this.listenTo(pageflow.storylines, 'remove', this.updateSelect);
+    this.listenTo(pageflow.storylines, 'add sort remove', this.updateSelect);
     this.listenTo(this.model, 'change', this.load);
   },
 

--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -11,7 +11,7 @@ module Pageflow
     belongs_to :restored_from, :class_name => 'Pageflow::Revision'
 
     has_many :widgets, :as => :subject
-    has_many :storylines
+    has_many :storylines, -> { order('pageflow_storylines.position ASC') }
     has_many :chapters, -> { order('position ASC') }, through: :storylines
     has_many :pages, -> { reorder(PAGE_ORDER) }, through: :storylines
 

--- a/spec/controllers/pageflow/storylines_controller_spec.rb
+++ b/spec/controllers/pageflow/storylines_controller_spec.rb
@@ -60,7 +60,7 @@ module Pageflow
         acquire_edit_lock(user, entry)
         post(:scaffold,
              entry_id: entry, storyline: attributes_for(:valid_storyline), format: 'json')
-        storyline = entry.draft.storylines.last
+        storyline = entry.draft.storylines.reorder('id').last
 
         expect(storyline.chapters).not_to be_empty
       end
@@ -89,10 +89,10 @@ module Pageflow
           acquire_edit_lock(user, entry)
           post(:scaffold,
                entry_id: entry,
-               storyline: attributes_for(:valid_storyline),
+               storyline: attributes_for(:valid_storyline, position: 1),
                depth: 'page',
                format: 'json')
-          storyline = entry.draft.storylines.last
+          storyline = entry.draft.storylines.reorder('id').last
           chapter = storyline.chapters.last
 
           expect(chapter.pages).not_to be_empty

--- a/spec/models/pageflow/revision_spec.rb
+++ b/spec/models/pageflow/revision_spec.rb
@@ -298,6 +298,17 @@ module Pageflow
         expect(chapters[1]).to eq(chapter_1)
       end
 
+      it 'uses position to get first storyline' do
+        revision = create(:revision)
+        create(:storyline, revision: revision, position: 2)
+        storyline_2 = create(:storyline, revision: revision, position: 1)
+        chapter_1 = create(:chapter, storyline: storyline_2, position: 2)
+
+        chapters = revision.main_storyline_chapters
+
+        expect(chapters[0]).to eq(chapter_1)
+      end
+
       it 'returns empty scope if no storyline is present' do
         revision = create(:revision)
 


### PR DESCRIPTION
* Update foreign keys when moving chapters and pages 
* Prevent exception in StorylineOrdering when moving pages
* Update foreign keys when moving chapters and page
* Update storyline picker more often