### PR TITLE
Allow registering default widget types in features

### DIFF
--- a/admins/pageflow/accounts.rb
+++ b/admins/pageflow/accounts.rb
@@ -24,8 +24,8 @@ module Pageflow
 
     controller do
       helper Pageflow::Admin::FeaturesHelper
+      helper Pageflow::Admin::WidgetsHelper
       helper ThemesHelper
-      helper WidgetsHelper
 
       def new
         @account = Account.new

--- a/app/controllers/pageflow/editor/widgets_controller.rb
+++ b/app/controllers/pageflow/editor/widgets_controller.rb
@@ -9,7 +9,7 @@ module Pageflow
         subject = find_subject
         authorize!(:edit, subject.to_model)
 
-        @widgets = subject.widgets.resolve(include_placeholders: true)
+        @widgets = subject.resolve_widgets(include_placeholders: true)
         respond_with(@widgets)
       end
 

--- a/app/helpers/pageflow/admin/widgets_helper.rb
+++ b/app/helpers/pageflow/admin/widgets_helper.rb
@@ -1,0 +1,18 @@
+module Pageflow
+  module Admin
+    module WidgetsHelper
+      def admin_widgets_fields(form, config)
+        render('pageflow/admin/widgets/fields',
+               widgets: form.object.widgets.resolve(config, include_placeholders: true),
+               form: form,
+               config: config)
+      end
+
+      def admin_widget_types_collection_for_role(config, role)
+        config.widget_types.find_all_by_role(role).each_with_object({}) do |widget_type, result|
+          result[I18n.t(widget_type.translation_key)] = widget_type.name
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/pageflow/widgets_helper.rb
+++ b/app/helpers/pageflow/widgets_helper.rb
@@ -1,7 +1,7 @@
 module Pageflow
   module WidgetsHelper
     def render_widget_head_fragments(entry, options = {})
-      fragments = entry.widgets.resolve(options).map do |widget|
+      fragments = entry.resolve_widgets(options).map do |widget|
         widget.widget_type.render_head_fragment(self, entry)
       end
 
@@ -9,7 +9,7 @@ module Pageflow
     end
 
     def render_widgets(entry, options = {})
-      fragments = entry.widgets.resolve(options).map do |widget|
+      fragments = entry.resolve_widgets(options).map do |widget|
         widget.widget_type.render(self, entry)
       end
 
@@ -17,7 +17,7 @@ module Pageflow
     end
 
     def present_widgets_css_class(entry)
-      entry.widgets.resolve.map do |widget|
+      entry.resolve_widgets.map do |widget|
         "widget_#{widget.widget_type.name}_present"
       end.join(' ')
     end
@@ -32,12 +32,6 @@ module Pageflow
           }
         end
       end.to_json.html_safe
-    end
-
-    def widget_types_collection_for_role(config, role)
-      config.widget_types.find_all_by_role(role).each_with_object({}) do |widget_type, result|
-        result[I18n.t(widget_type.translation_key)] = widget_type.name
-      end
     end
   end
 end

--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -87,5 +87,9 @@ module Pageflow
     def home_button
       HomeButton.new(draft, theming)
     end
+
+    def resolve_widgets(options = {})
+      widgets.resolve(Pageflow.config_for(entry), options)
+    end
   end
 end

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -66,6 +66,10 @@ module Pageflow
       HomeButton.new(revision, theming)
     end
 
+    def resolve_widgets(options = {})
+      widgets.resolve(Pageflow.config_for(entry), options)
+    end
+
     private
 
     def custom_revision?

--- a/app/models/pageflow/theming.rb
+++ b/app/models/pageflow/theming.rb
@@ -11,6 +11,10 @@ module Pageflow
     validates :account, :presence => true
     validates_inclusion_of :theme_name, :in => ->(_) { Pageflow.config.themes.names }
 
+    def resolve_widgets(options = {})
+      widgets.resolve(Pageflow.config_for(account), options)
+    end
+
     def cname_domain
       cname.split('.').pop(2).join('.')
     end

--- a/app/views/admin/accounts/_form.html.erb
+++ b/app/views/admin/accounts/_form.html.erb
@@ -29,15 +29,7 @@
         <%= form_input.build(theming) %>
       <% end %>
 
-      <% theming.object.widgets.resolve(:include_placeholders => true).each do |widget| %>
-        <%= f.semantic_fields_for(widget) do |w| %>
-          <%= w.input(:type_name,
-                      :label => t(widget.role, :scope => 'pageflow.widgets.roles'),
-                      :input_html => {:name => "widgets[#{widget.role}]"},
-                      :include_blank => t('pageflow.widgets.none'),
-                      :collection => widget_types_collection_for_role(account_config, widget.role)) %>
-        <% end %>
-      <% end %>
+      <%= admin_widgets_fields(theming, account_config) %>
     <% end %>
   <% end %>
   <%= f.actions do %>

--- a/app/views/pageflow/admin/widgets/_fields.html.erb
+++ b/app/views/pageflow/admin/widgets/_fields.html.erb
@@ -1,0 +1,9 @@
+<% widgets.each do |widget| %>
+  <%= form.semantic_fields_for(widget) do |fields| %>
+    <%= fields.input(:type_name,
+                     label: t(widget.role, scope: 'pageflow.widgets.roles'),
+                     input_html: {name: "widgets[#{widget.role}]"},
+                     include_blank: t('pageflow.widgets.none'),
+                     collection: admin_widget_types_collection_for_role(config, widget.role)) %>
+  <% end %>
+<% end %>

--- a/spec/controllers/pageflow/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/entries_controller_spec.rb
@@ -203,36 +203,52 @@ module Pageflow
         end
 
         it 'renders widgets for entry' do
-          Pageflow.config.widget_types.register(TestWidgetType.new(:name => 'test_widget',
-                                                                   :rendered => '<div class="test_widget"></div>'))
-          entry = create(:entry, :published)
-          create(:widget, :subject => entry.published_revision, :type_name => 'test_widget')
+          widget_type = TestWidgetType.new(name: 'test_widget',
+                                           rendered: '<div class="test_widget"></div>')
 
-          get(:show, :id => entry)
+          pageflow_configure do |config|
+            config.widget_types.register(widget_type)
+          end
+
+          entry = create(:entry, :published)
+          create(:widget, subject: entry.published_revision, type_name: 'test_widget')
+
+          get(:show, id: entry)
 
           expect(response.body).to have_selector('div.test_widget')
         end
 
         it 'renders widgets which are disabled in editor and preview' do
-          Pageflow.config.widget_types.register(TestWidgetType.new(:name => 'test_widget',
-                                                                   :enabled_in_editor => false,
-                                                                   :enabled_in_preview => false,
-                                                                   :rendered => '<div class="test_widget"></div>'))
-          entry = create(:entry, :published)
-          create(:widget, :subject => entry.published_revision, :type_name => 'test_widget')
+          widget_type = TestWidgetType.new(name: 'test_widget',
+                                           enabled_in_editor: false,
+                                           enabled_in_preview: false,
+                                           rendered: '<div class="test_widget"></div>')
 
-          get(:show, :id => entry)
+          pageflow_configure do |config|
+            config.widget_types.register(widget_type)
+          end
+
+          entry = create(:entry, :published)
+          create(:widget, subject: entry.published_revision, type_name: 'test_widget')
+
+          get(:show, id: entry)
 
           expect(response.body).to have_selector('div.test_widget')
         end
 
         it 'renders widgets head fragments for entry' do
-          Pageflow.config.widget_types.register(TestWidgetType.new(:name => 'test_widget',
-                                                                   :rendered_head_fragment => '<meta name="some_test" content="value">'))
-          entry = create(:entry, :published)
-          create(:widget, :subject => entry.published_revision, :type_name => 'test_widget')
+          widget_type =
+            TestWidgetType.new(name: 'test_widget',
+                               rendered_head_fragment: '<meta name="some_test" content="value">')
 
-          get(:show, :id => entry)
+          pageflow_configure do |config|
+            config.widget_types.register(widget_type)
+          end
+
+          entry = create(:entry, :published)
+          create(:widget, subject: entry.published_revision, type_name: 'test_widget')
+
+          get(:show, id: entry)
 
           expect(response.body).to have_meta_tag.with_name('some_test')
         end
@@ -463,31 +479,45 @@ module Pageflow
       end
 
       it 'renders editor enabled widgets for entry' do
-        Pageflow.config.widget_types.register(TestWidgetType.new(:name => 'test_widget',
-                                                                 :enabled_in_editor => true,
-                                                                 :rendered => '<div class="test_widget"></div>'))
-        Pageflow.config.widget_types.register(TestWidgetType.new(:name => 'non_editor_widget',
-                                                                 :enabled_in_editor => false,
-                                                                 :rendered => '<div class="non_editor_widget"></div>'))
+        widget_type =
+          TestWidgetType.new(name: 'test_widget',
+                             enabled_in_editor: true,
+                             rendered: '<div class="test_widget"></div>')
+        non_editor_widget_type =
+          TestWidgetType.new(name: 'non_editor_widget',
+                             enabled_in_editor: false,
+                             rendered: '<div class="non_editor_widget"></div>')
+
+        pageflow_configure do |config|
+          config.widget_types.register(widget_type)
+          config.widget_types.register(non_editor_widget_type)
+        end
+
         user = create(:user)
-        entry = create(:entry, :with_member => user)
-        create(:widget, :subject => entry.draft, :role => 'header', :type_name => 'test_widget')
-        create(:widget, :subject => entry.draft, :role => 'footer', :type_name => 'non_editor_widget')
+        entry = create(:entry, with_member: user)
+        create(:widget, subject: entry.draft, role: 'header', type_name: 'test_widget')
+        create(:widget, subject: entry.draft, role: 'footer', type_name: 'non_editor_widget')
 
         sign_in(user)
-        get(:partials, :id => entry)
+        get(:partials, id: entry)
 
         expect(response.body).to have_selector('div.test_widget')
         expect(response.body).not_to have_selector('div.non_editor_widget')
       end
 
       it 'uses locale of entry' do
-        Pageflow.config.widget_types.register(TestWidgetType.new(name: 'test_widget',
-                                                                 enabled_in_editor: true,
-                                                                 rendered: lambda { %'<div lang="#{I18n.locale}"></div>' }))
+        widget_type =
+          TestWidgetType.new(name: 'test_widget',
+                             enabled_in_editor: true,
+                             rendered: lambda { %'<div lang="#{I18n.locale}"></div>' })
+
+        pageflow_configure do |config|
+          config.widget_types.register(widget_type)
+        end
+
         user = create(:user)
         entry = create(:entry, with_member: user)
-        create(:widget, :subject => entry.draft, :type_name => 'test_widget')
+        create(:widget, subject: entry.draft, type_name: 'test_widget')
 
         sign_in(user)
         entry.draft.update(locale: 'de')

--- a/spec/controllers/pageflow/revisions_controller_spec.rb
+++ b/spec/controllers/pageflow/revisions_controller_spec.rb
@@ -22,34 +22,46 @@ module Pageflow
       end
 
       it 'renders widgets which are enabled in preview' do
-        Pageflow.config.widget_types.register(TestWidgetType.new(:name => 'test_widget',
-                                                                 :enabled_in_preview => true,
-                                                                 :rendered_head_fragment => '<meta name="some_test" content="value">',
-                                                                 :rendered => '<div class="test_widget"></div>'))
+        widget_type =
+          TestWidgetType.new(name: 'test_widget',
+                             enabled_in_preview: true,
+                             rendered_head_fragment: '<meta name="some_test" content="value">',
+                             rendered: '<div class="test_widget"></div>')
+
+        pageflow_configure do |config|
+          config.widget_types.register(widget_type)
+        end
+
         user = create(:user)
-        entry = create(:entry, :with_member => user)
-        revision = create(:revision, :entry => entry)
-        create(:widget, :subject => revision, :type_name => 'test_widget')
+        entry = create(:entry, with_member: user)
+        revision = create(:revision, entry: entry)
+        create(:widget, subject: revision, type_name: 'test_widget')
 
         sign_in(user)
-        get(:show, :id => revision)
+        get(:show, id: revision)
 
         expect(response.body).to have_selector('div.test_widget')
         expect(response.body).to have_meta_tag.with_name('some_test')
       end
 
       it 'does not render widgets which are disabled in preview' do
-        Pageflow.config.widget_types.register(TestWidgetType.new(:name => 'test_widget',
-                                                                 :enabled_in_preview => false,
-                                                                 :rendered_head_fragment => '<meta name="some_test" content="value">',
-                                                                 :rendered => '<div class="test_widget"></div>'))
+        widget_type =
+          TestWidgetType.new(name: 'test_widget',
+                             enabled_in_preview: false,
+                             rendered_head_fragment: '<meta name="some_test" content="value">',
+                             rendered: '<div class="test_widget"></div>')
+
+        pageflow_configure do |config|
+          config.widget_types.register(widget_type)
+        end
+
         user = create(:user)
-        entry = create(:entry, :with_member => user)
-        revision = create(:revision, :entry => entry)
-        create(:widget, :subject => revision, :type_name => 'test_widget')
+        entry = create(:entry, with_member: user)
+        revision = create(:revision, entry: entry)
+        create(:widget, subject: revision, type_name: 'test_widget')
 
         sign_in(user)
-        get(:show, :id => revision)
+        get(:show, id: revision)
 
         expect(response.body).not_to have_selector('div.test_widget')
       end

--- a/spec/helpers/pageflow/admin/widgets_helper_spec.rb
+++ b/spec/helpers/pageflow/admin/widgets_helper_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+module Pageflow
+  module Admin
+    describe WidgetsHelper do
+      describe '#admin_widgets_fields' do
+        it 'renders selects for each widget role' do
+          widget_type = TestWidgetType.new(name: 'test_widget', roles: ['header'])
+          config = Configuration.new
+          config.widget_types.register(widget_type)
+          theming = create(:theming)
+
+          result = helper.semantic_form_for(theming, url: '/theming') do |form|
+            helper.admin_widgets_fields(form, config)
+          end
+
+          expect(result).to have_selector('select[name="widgets[header]"]')
+        end
+
+        it 'marks selected widget' do
+          widget_type = TestWidgetType.new(name: 'test_widget', roles: ['header'])
+          config = Configuration.new
+          config.widget_types.register(widget_type)
+          theming = create(:theming)
+          create(:widget, subject: theming, type_name: 'test_widget', role: 'header')
+
+          result = helper.semantic_form_for(theming, url: '/theming') do |form|
+            helper.admin_widgets_fields(form, config)
+          end
+
+          expect(result).to have_selector('option[selected][value=test_widget]')
+        end
+      end
+
+      describe '#admin_widget_types_collection_for_role' do
+        it 'returns widget types name by translated name' do
+          widget_type = TestWidgetType.new(name: 'test_widget', roles: ['header'])
+          config = Configuration.new
+          config.widget_types.register(widget_type)
+
+          result = admin_widget_types_collection_for_role(config, 'header')
+
+          expect(result.size).to eq(1)
+          expect(result.keys.first).to include('test_widget.widget_type_name')
+          expect(result.values.first).to eq('test_widget')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
So far resolving widgets for a subject did not take into consideration
whether a widget type is scoped to a feature. Therefore default widget
types registered inside a feature were always displayed.

Ensure that resolving widgets always looks up widget types in the
account or entry specific configuration.

fixes #474 