### PR TITLE
Prevent edit lock warning when editing reused file

### DIFF
--- a/app/controllers/pageflow/editor/files_controller.rb
+++ b/app/controllers/pageflow/editor/files_controller.rb
@@ -29,7 +29,6 @@ module Pageflow
         file = file_type.model.find(params[:id])
 
         authorize!(:retry, file)
-        verify_edit_lock!(file.entry)
         file.retry!
 
         respond_with(:editor, file, location: editor_file_url(file, collection_name: params[:collection_name]))
@@ -39,7 +38,6 @@ module Pageflow
         file = file_type.model.find(params[:id])
 
         authorize!(:update, file)
-        verify_edit_lock!(file.entry)
         file.update_attributes!(update_params)
 
         head(:no_content)

--- a/spec/controllers/pageflow/editor/files_controller_spec.rb
+++ b/spec/controllers/pageflow/editor/files_controller_spec.rb
@@ -114,7 +114,6 @@ module Pageflow
         file = create(:image_file, :failed, :used_in => entry.draft)
 
         sign_in user
-        acquire_edit_lock(user, entry)
         post(:retry, :collection_name => 'image_files', :id => file, :format => 'json')
 
         expect(response.status).to eq(201)
@@ -144,7 +143,6 @@ module Pageflow
         image_file = create(:image_file, :used_in => entry.draft)
 
         sign_in user
-        acquire_edit_lock(user, entry)
         post(:retry, :collection_name => 'image_files', :id => image_file, :format => 'json')
 
         expect(response.status).to eq(400)
@@ -158,12 +156,11 @@ module Pageflow
         file = create(:image_file, :used_in => entry.draft, :rights => 'old')
 
         sign_in user
-        acquire_edit_lock(user, entry)
         patch(:update, :collection_name => 'image_files', :id => file, :image_file => {:rights => 'new'}, :format => 'json')
 
         expect(response.status).to eq(204)
         expect(file.reload.rights).to eq('new')
-    end
+      end
 
       it 'does not allow to update file if the signed in user is not member of' do
         user = create(:user)


### PR DESCRIPTION
Do not require edit lock for retrying or updating rights. We used to
require an edit lock for the entry the file had originally been
uploaded in.