### PR TITLE
Ensure delayed text is displayed id no CSS animation support

### DIFF
--- a/app/assets/javascripts/pageflow/browser/css_animations.js
+++ b/app/assets/javascripts/pageflow/browser/css_animations.js
@@ -1,0 +1,18 @@
+// See https://developer.mozilla.org/de/docs/Web/CSS/CSS_Animations/Detecting_CSS_animation_support
+
+pageflow.browser.feature('css animations', function() {
+  var prefixes = ['Webkit', 'Moz', 'O', 'ms', 'Khtml'],
+      elm = document.createElement('div');
+
+  if (elm.style.animationName !== undefined) {
+    return true;
+  }
+
+  for (var i = 0; i < prefixes.length; i++) {
+    if (elm.style[prefixes[i] + 'AnimationName'] !== undefined) {
+      return true;
+    }
+  }
+
+  return false;
+});

--- a/app/assets/stylesheets/pageflow/delayed_text_fade_in.css.scss
+++ b/app/assets/stylesheets/pageflow/delayed_text_fade_in.css.scss
@@ -1,4 +1,4 @@
-section.active {
+.has_css_animations section.active {
 
   &.delayed_text_fade_in_short {
     .page_header {


### PR DESCRIPTION
IE 9 does not know css animations. Feature detect and only apply the
fade in styles if animtions are supported. Otherwise text is never
displayed.