### PR TITLE
Parent page transition

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/edit_storyline_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_storyline_view.js
@@ -43,13 +43,17 @@ pageflow.EditStorylineView = Backbone.Marionette.Layout.extend({
   },
 
   configure: function(configurationEditor) {
-    var view = this;
-
     configurationEditor.tab('general', function() {
       this.input('title', pageflow.TextInputView);
       this.input('main', pageflow.CheckBoxInputView, {
         disabled: true,
         visibleBinding: 'main'
+      });
+      this.input('page_transition', pageflow.SelectInputView, {
+        translationKeyPrefix: 'pageflow.page_transitions',
+        includeBlank: true,
+        blankTranslationKey: 'pageflow.editor.views.edit_storyline_view.default_parent_page_transition',
+        values: pageflow.pageTransitions.names()
       });
       this.input('main', pageflow.CheckBoxInputView, {
         visibleBinding: 'main',

--- a/app/assets/javascripts/pageflow/slideshow.js
+++ b/app/assets/javascripts/pageflow/slideshow.js
@@ -75,8 +75,7 @@ pageflow.Slideshow = function($el, configurations) {
   };
 
   this.goToParentPage = function() {
-    this.goToByPermaId(pageflow.entryData.getParentPagePermaIdByPagePermaId(currentPagePermaId()),
-                       {transition: 'scroll_over_from_right'});
+    this.goToByPermaId(pageflow.entryData.getParentPagePermaIdByPagePermaId(currentPagePermaId()));
   };
 
   this.goToById = function(id, options) {

--- a/app/assets/javascripts/pageflow/slideshow/dom_order_scroll_navigator.js
+++ b/app/assets/javascripts/pageflow/slideshow/dom_order_scroll_navigator.js
@@ -4,28 +4,20 @@ pageflow.DomOrderScrollNavigator = function(slideshow, entryData) {
   };
 
   this.back = function(currentPage, pages) {
-    var forcedTransition = null;
+    var position = 'bottom';
     var previousPage = this.getPreviousPage(currentPage, pages);
 
     if (previousPage.is(getParentPage(currentPage, pages))) {
-      forcedTransition = 'scroll_over_from_right';
+      position = null;
     }
 
     slideshow.goTo(previousPage, {
-      position: forcedTransition ? null :'bottom',
-      transition: forcedTransition
+      position: position
     });
   };
 
   this.next = function(currentPage, pages) {
-    var forcedTransition = null;
-    var nextPage = this.getNextPage(currentPage, pages);
-
-    if (nextPage.is(getParentPage(currentPage, pages))) {
-      forcedTransition = 'scroll_over_from_right';
-    }
-
-    slideshow.goTo(nextPage, {transition: forcedTransition});
+    slideshow.goTo(this.getNextPage(currentPage, pages));
   };
 
   this.nextPageExists = function(currentPage, pages) {
@@ -67,10 +59,20 @@ pageflow.DomOrderScrollNavigator = function(slideshow, entryData) {
   };
 
   this.getDefaultTransition = function(previousPage, currentPage, pages) {
-    if (previousPage.is(getParentPage(currentPage, pages))) {
-      return 'scroll_over_from_right';
+    if (inParentStorylineOf(currentPage, previousPage, pages)) {
+      return getStorylinePageTransition(currentPage);
+    }
+    else if (inParentStorylineOf(previousPage, currentPage, pages)) {
+      return getStorylinePageTransition(previousPage);
     }
   };
+
+  function inParentStorylineOf(page, otherPage, pages) {
+    var parentPage = getParentPage(page, pages);
+
+    return entryData.getStorylineIdByPagePermaId(parentPage.page('getPermaId')) ==
+      entryData.getStorylineIdByPagePermaId(otherPage.page('getPermaId'));
+  }
 
   function sameStoryline(page1, page2) {
     return entryData.getStorylineIdByPagePermaId(page1.page('getPermaId')) ==
@@ -87,6 +89,11 @@ pageflow.DomOrderScrollNavigator = function(slideshow, entryData) {
     }
 
     return $();
+  }
+
+  function getStorylinePageTransition(page) {
+    var storylineConfiguration = getStorylineConfiguration(page);
+    return storylineConfiguration.page_transition || 'scroll_over_from_right';
   }
 
   function getScrollSuccessor(page, pages) {

--- a/config/locales/new/storylines.en.yml
+++ b/config/locales/new/storylines.en.yml
@@ -1,0 +1,52 @@
+en:
+  pageflow:
+    storylines:
+      feature_name: "Storylines"
+      untitled: Unnamed storyline
+      main: Main storyline
+    editor:
+      templates:
+        storyline_outline:
+          header: Outline
+          new_chapter: New chapter
+        edit_entry:
+          outline: "DELELTED"
+          new_chapter: "DELETED"
+        edit_storyline:
+          destroy: Delete
+          outline: Outline
+          retry: Retry
+          save_error: Errors were detected while saving the storyline.
+        storyline_picker:
+          add: "Add"
+          edit: "Edit settings"
+      views:
+        storylines_picker_view:
+          label: Storyline
+          without_parent_page: Without parent page
+        edit_storyline_view:
+          confirm_destroy: Really delete storyline
+          cannot_destroy: Only empty storylines can be deleted.
+          default_parent_page_transition: "(Default)"
+    storyline_attributes:
+      title:
+        label: "Title"
+      main:
+        label: "Main storyline"
+        inline_help: "Turns the first page of this storyline into the start page of the entry."
+        inline_help_disabled: "The first page of this storyline is the start page of the entry."
+      parent_page_perma_id:
+        label: "Parent page"
+        inline_help: "The user is redirected to this page when reaching the end of the storyline or when clicking the back button. The parent page settings determine the chapter hierachy. For more information on the chapter hierarchy see the 'Storylines' help topic."
+      page_transition:
+        label: "Transition effect"
+        inline_help: "By default, comming from the parent page, the first page of the storyline is scrolled in from the right. When clicking the back button, pages of the storyline are scrolled back out to the right. Here you can choose an alternative effect."
+      scroll_successor_id:
+        label: "Scroll successor"
+        inline_help: "Page to go to when scrolling down from the last page of the storyline. By default the user is brought back to the storyline's parent page."
+      navigation_bar_mode:
+        label: "Navigation bar mode"
+        values:
+          non: "Hide"
+          current_storyline: "Current storyline"
+          inherit_from_parent: "Display parent storyline"

--- a/config/locales/new/storylines.yml
+++ b/config/locales/new/storylines.yml
@@ -36,7 +36,7 @@ de:
         inline_help_disabled: "Die erste Seite dieses Erzählstrangs ist die Startseite des Beitrags."
       parent_page_perma_id:
         label: "Übergeordnete Seite"
-        inline_help: "Zielseite, um den Erzählstrang zu verlassen. Bestimmt die Kapitelhierarchie. Alle Kapitel des Erzählstrangs werden dem Kapitel dieser Seite untergeordnet."
+        inline_help: "Die Auswahl einer übergeordneten Seite bestimmt, auf welcher Seite der User am Ende eines untergeordneten Erzählstrangs oder bei Klick auf den Zurück-Button landet. Mit einer solchen Seite kann die Kapitelhierarchie bestimmt werden, falls mehr als zwei Erzählstränge benutzt werden. Mehr Informationen zur Kapitelhierachie findest Du im Hilfethema 'Erzählstränge'."
       scroll_successor_id:
         label: "Scroll Nachfolger"
         inline_help: "Seite, die beim Weiterscrollen am Ende des Erzählstrangs erreicht werden soll. Standardmäßig gelangt der Leser zur übergeordneten Seite zurück."

--- a/config/locales/new/storylines.yml
+++ b/config/locales/new/storylines.yml
@@ -27,6 +27,7 @@ de:
         edit_storyline_view:
           confirm_destroy: Erzählstrang wirklich löschen?
           cannot_destroy: Nur leere Erzählstränge können gelöscht werden.
+          default_parent_page_transition: "(Standard)"
     storyline_attributes:
       title:
         label: "Titel"
@@ -37,6 +38,9 @@ de:
       parent_page_perma_id:
         label: "Übergeordnete Seite"
         inline_help: "Die Auswahl einer übergeordneten Seite bestimmt, auf welcher Seite der User am Ende eines untergeordneten Erzählstrangs oder bei Klick auf den Zurück-Button landet. Mit einer solchen Seite kann die Kapitelhierarchie bestimmt werden, falls mehr als zwei Erzählstränge benutzt werden. Mehr Informationen zur Kapitelhierachie findest Du im Hilfethema 'Erzählstränge'."
+      page_transition:
+        label: "Seitenübergangseffekt"
+        inline_help: "Standardmäßig wird beim Erreichen des Erzählstrangs von der übergeordneten Seite die erste Seite des Erzählstrangs von rechts hineingeschoben. Bei Klick auf den Zurück-Button fährt die Seite wieder nach rechts hinaus. Hier kannst Du einen alternativen Effekt wählen."
       scroll_successor_id:
         label: "Scroll Nachfolger"
         inline_help: "Seite, die beim Weiterscrollen am Ende des Erzählstrangs erreicht werden soll. Standardmäßig gelangt der Leser zur übergeordneten Seite zurück."
@@ -45,5 +49,4 @@ de:
         values:
           non: "Ausblenden"
           current_storyline: "Aktueller Erzählstrang"
-          current_chapter: "Aktueller Kapitel"
           inherit_from_parent: "Von übergeordnetem Kapitel erben"


### PR DESCRIPTION
Save a page transition per storyline which is used when:

* Entering the storyline from a page of the parent page's storyline
* Returning to a page of the parent's page storyline. In this case the
  animation is played reversed.