### PR TITLE
Ensure background videos loop on desktop safari 9

### DIFF
--- a/app/assets/javascripts/pageflow/browser/agent.js
+++ b/app/assets/javascripts/pageflow/browser/agent.js
@@ -1,0 +1,25 @@
+pageflow.browser.agent = {
+  matchesSilk: function() {
+    return navigator.userAgent.match(/\bSilk\b/);
+  },
+
+  matchesDesktopSafari9: function() {
+    return this.matchesSafari9() && !this.matchesMobilePlatform();
+  },
+
+  matchesSafari9: function() {
+    var matchers = [/Safari\//i, /Version\/9/i];
+
+    return _.all(matchers, function(matcher) {
+      return navigator.userAgent.match(matcher);
+    });
+  },
+
+  matchesMobilePlatform: function() {
+    var matchers = [/iPod/i, /iPad/i, /iPhone/i, /Android/i, /Silk/i, /IEMobile/i];
+
+    return _.any(matchers, function(matcher) {
+      return navigator.userAgent.match(matcher);
+    });
+  }
+};

--- a/app/assets/javascripts/pageflow/browser/mobile_platform.js
+++ b/app/assets/javascripts/pageflow/browser/mobile_platform.js
@@ -1,8 +1,5 @@
 pageflow.browser.feature('mobile platform', function() {
-  var matchers = [/iPod/i, /iPad/i, /iPhone/i, /Android/i, /Silk/i, /IEMobile/i];
-  return _.any(matchers, function(matcher) {
-    return navigator.userAgent.match(matcher);
-  });
+  return pageflow.browser.agent.matchesMobilePlatform();
 });
 
 if (navigator.userAgent.match(/iPad;.*CPU.*OS 7_\d/i) && !window.navigator.standalone) {

--- a/app/assets/javascripts/pageflow/browser/video.js
+++ b/app/assets/javascripts/pageflow/browser/video.js
@@ -14,3 +14,10 @@ pageflow.browser.feature('buffer underrun waiting support', function(has) {
 pageflow.browser.feature('prebuffering support', function(has) {
   return has.not('mobile platform');
 });
+
+pageflow.browser.feature('mp4 support only', function(has) {
+  // - Silk does not play videos with hls source
+  // - Desktop Safari 9.1 does not loop hls videos
+  return pageflow.browser.agent.matchesSilk() ||
+    pageflow.browser.agent.matchesDesktopSafari9();
+});

--- a/app/assets/javascripts/pageflow/video_player.js
+++ b/app/assets/javascripts/pageflow/video_player.js
@@ -8,13 +8,13 @@
 //= require ./video_player/src_from_options_method
 //= require ./video_player/play_button_patch
 //= require ./video_player/player_buffered_patch
-//= require ./video_player/filter_for_silk
+//= require ./video_player/filter_sources
 //= require ./video_player/lazy
 
 pageflow.VideoPlayer = function(element, options) {
   options = options || {};
 
-  element = pageflow.VideoPlayer.filterSourcesForSilkBrowser(element);
+  element = pageflow.VideoPlayer.filterSources(element);
   var player = vjs(element, options);
 
   pageflow.VideoPlayer.prebuffering(player);

--- a/app/assets/javascripts/pageflow/video_player/filter_sources.js
+++ b/app/assets/javascripts/pageflow/video_player/filter_sources.js
@@ -1,5 +1,5 @@
-pageflow.VideoPlayer.filterSourcesForSilkBrowser = function(playerElement) {
-  if (/\bSilk\b/.test(navigator.userAgent)) {
+pageflow.VideoPlayer.filterSources = function(playerElement) {
+  if (pageflow.browser.has('mp4 support only')) {
     // keep only mp4 source
     $(playerElement).find('source').not('source[type="video/mp4"]').remove();
 


### PR DESCRIPTION
Video tag loop attribute is broken for hls videos in Safari 9. Filter sources to ensure mp4 is used.