### PR TITLE
Provide public translations for js

### DIFF
--- a/app/assets/javascripts/pageflow/base.js
+++ b/app/assets/javascripts/pageflow/base.js
@@ -13,6 +13,7 @@
 
 //= require polyfills/bind
 
+//= require i18n
 //= require jquery
 //= require jquery-ui/widget
 //= require jquery_ujs

--- a/app/helpers/pageflow/common_entry_seed_helper.rb
+++ b/app/helpers/pageflow/common_entry_seed_helper.rb
@@ -6,6 +6,7 @@ module Pageflow
   module CommonEntrySeedHelper
     def common_entry_seed(entry)
       {
+        locale: entry.locale,
         page_types: PageTypesSeed.new(entry, Pageflow.config_for(entry)).as_json
       }
     end

--- a/app/helpers/pageflow/public_i18n_helper.rb
+++ b/app/helpers/pageflow/public_i18n_helper.rb
@@ -1,0 +1,13 @@
+module Pageflow
+  module PublicI18nHelper
+    def public_i18n_javascript_tag(entry)
+      render('pageflow/public_i18n/javascript_tag',
+             entry_locale: entry.locale,
+             translations: {
+               pageflow: {
+                 public: I18n.t('pageflow.public', locale: entry.locale)
+               }
+             })
+    end
+  end
+end

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -32,5 +32,7 @@
     pageflow.enabledFeatureNames = <%= @entry.enabled_feature_names.to_json.html_safe %>;
   </script>
 
+  <%= public_i18n_javascript_tag(@entry) %>
+
   <%= render 'pageflow/entries/analytics', :entry => @entry %>
 <% end %>

--- a/app/views/pageflow/public_i18n/_javascript_tag.html.erb
+++ b/app/views/pageflow/public_i18n/_javascript_tag.html.erb
@@ -1,0 +1,5 @@
+<script>
+  I18n.translations = I18n.translations || {};
+  I18n.translations["<%= entry_locale %>"] = <%= translations.to_json.html_safe %>
+  I18n.locale = "<%= entry_locale %>";
+</script>

--- a/spec/helpers/pageflow/common_entry_seed_helper_spec.rb
+++ b/spec/helpers/pageflow/common_entry_seed_helper_spec.rb
@@ -43,6 +43,18 @@ module Pageflow
           ])
         end
       end
+
+      describe '["locale"]' do
+        it 'equals entry locale' do
+          entry = PublishedEntry.new(create(:entry,
+                                            :published,
+                                            published_revision_attributes: {locale: 'fr'}))
+
+          result = common_entry_seed(entry)
+
+          expect(result[:locale]).to eq('fr')
+        end
+      end
     end
   end
 end

--- a/spec/helpers/pageflow/pubic_i18n_helper_spec.rb
+++ b/spec/helpers/pageflow/pubic_i18n_helper_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+module Pageflow
+  describe PublicI18nHelper do
+    describe '#public_i18n_javascript_tag' do
+      it 'includes js to set I18n.locale' do
+        entry = PublishedEntry.new(create(:entry,
+                                          :published,
+                                          published_revision_attributes: {locale: 'fr'}))
+
+        html = helper.public_i18n_javascript_tag(entry)
+
+        expect(html).to include('I18n.locale = "fr"')
+      end
+
+      it 'includes js to load translations' do
+        entry = PublishedEntry.new(create(:entry,
+                                          :published,
+                                          published_revision_attributes: {locale: 'de'}))
+
+        html = helper.public_i18n_javascript_tag(entry)
+
+        expect(html).to include('I18n.translations["de"] = {')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change allows javascript access to translations from the
`pageflow.public` namespace in the published entry.

* Include entry locale in common seed
* Render public translations of entry locale in published entry