### PR TITLE
Prevent creation of loops in the storyline hierarchy 

### DIFF
--- a/app/assets/javascripts/pageflow/editor/api.js
+++ b/app/assets/javascripts/pageflow/editor/api.js
@@ -140,9 +140,13 @@ pageflow.EditorApi = pageflow.Object.extend({
     /**
      * Returns a promise which resolves to a page selected by the
      * user.
+     *
+     * Supported options:
+     * - isAllowed: function which given a page returns true or false depending on
+     *   whether the page is a valid selection
      */
-    this.selectPage = function() {
-      return pageflow.PageSelectionView.selectPage();
+    this.selectPage = function(options) {
+      return pageflow.PageSelectionView.selectPage(options);
     };
 
     /**

--- a/app/assets/javascripts/pageflow/editor/models/storyline.js
+++ b/app/assets/javascripts/pageflow/editor/models/storyline.js
@@ -59,6 +59,10 @@ pageflow.Storyline = Backbone.Model.extend({
     return pageflow.pages.getByPermaId(this.parentPagePermaId());
   },
 
+  transitiveChildPages: function() {
+    return new pageflow.StorylineTransitiveChildPages(this, pageflow.storylines, pageflow.pages);
+  },
+
   addChapter: function(attributes) {
     var chapter = this.buildChapter(attributes);
     chapter.save();

--- a/app/assets/javascripts/pageflow/editor/models/storyline_transitive_child_pages.js
+++ b/app/assets/javascripts/pageflow/editor/models/storyline_transitive_child_pages.js
@@ -1,0 +1,33 @@
+pageflow.StorylineTransitiveChildPages = function(storyline, storylines, pages) {
+  var isTranstiveChildStoryline;
+
+  this.contain = function(page) {
+    if (!isTranstiveChildStoryline) {
+      search();
+    }
+
+    return !!isTranstiveChildStoryline[page.chapter.storyline.id];
+  };
+
+  function search() {
+    isTranstiveChildStoryline = storylines.reduce(function(memo, other) {
+      var current = other;
+
+      while (current) {
+        if (current === storyline || memo[current.id]) {
+          memo[other.id] = true;
+          return memo;
+        }
+
+        current = parentStoryline(current);
+      }
+
+      return memo;
+    }, {});
+  }
+
+  function parentStoryline(storyline) {
+    var parentPage = pages.getByPermaId(storyline.parentPagePermaId());
+    return parentPage && parentPage.chapter && parentPage.chapter.storyline;
+  }
+};

--- a/app/assets/javascripts/pageflow/editor/views/edit_storyline_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_storyline_view.js
@@ -23,7 +23,7 @@ pageflow.EditStorylineView = Backbone.Marionette.Layout.extend({
       attributeTranslationKeyPrefixes: ['pageflow.storyline_attributes']
     });
 
-    this.configure(configurationEditor);
+    this.configure(configurationEditor, this.model.transitiveChildPages());
     this.formContainer.show(configurationEditor);
 
     this.updateDestroyButton();
@@ -42,7 +42,7 @@ pageflow.EditStorylineView = Backbone.Marionette.Layout.extend({
     }
   },
 
-  configure: function(configurationEditor) {
+  configure: function(configurationEditor, storylineChildPages) {
     configurationEditor.tab('general', function() {
       this.input('title', pageflow.TextInputView);
       this.input('main', pageflow.CheckBoxInputView, {
@@ -65,6 +65,9 @@ pageflow.EditStorylineView = Backbone.Marionette.Layout.extend({
         visibleBinding: 'main',
         visible: function(isMain) {
           return !isMain && pageflow.storylines.length > 1;
+        },
+        isAllowed: function(page) {
+          return !storylineChildPages.contain(page);
         }
       });
       this.input('scroll_successor_id', pageflow.PageLinkInputView);

--- a/app/assets/javascripts/pageflow/editor/views/inputs/page_link_input_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/inputs/page_link_input_view.js
@@ -1,6 +1,8 @@
 pageflow.PageLinkInputView = pageflow.ReferenceInputView.extend({
   choose: function() {
-    return pageflow.editor.selectPage();
+    return pageflow.editor.selectPage({
+      isAllowed: this.options.isAllowed
+    });
   },
 
   getTarget: function(permaId) {

--- a/app/assets/javascripts/pageflow/editor/views/page_item_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/page_item_view.js
@@ -27,6 +27,8 @@ pageflow.PageItemView = Backbone.Marionette.ItemView.extend({
     this.$el.attr('data-perma-id', this.model.get('perma_id'));
 
     this.$el.toggleClass('active', this.model.get('active'));
+    this.$el.toggleClass('disabled',
+                         !!(this.options.isDisabled && this.options.isDisabled(this.model)));
     this.$el.toggleClass('display_in_navigation', !!this.model.configuration.get('display_in_navigation'));
     this.$el
       .removeClass(pageflow.editor.pageTypes.pluck('name').join(' '))

--- a/app/assets/javascripts/pageflow/editor/views/page_selection_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/page_selection_view.js
@@ -17,17 +17,25 @@ pageflow.PageSelectionView = Backbone.Marionette.ItemView.extend({
   },
 
   onRender: function() {
+    var options = this.options;
+
     this.subview(new pageflow.StorylinePickerView({
-      el: this.ui.storylines
+      el: this.ui.storylines,
+      pageItemViewOptions: {
+        isDisabled: function(page) {
+          return options.isAllowed && !options.isAllowed(page);
+        }
+      }
     }));
   }
 });
 
-pageflow.PageSelectionView.selectPage = function() {
+pageflow.PageSelectionView.selectPage = function(options) {
   return $.Deferred(function(deferred) {
     var view = new pageflow.PageSelectionView({
       model: pageflow.entry,
-      onSelect: deferred.resolve
+      onSelect: deferred.resolve,
+      isAllowed: options && options.isAllowed
     });
 
     view.on('close', function() {

--- a/app/assets/javascripts/pageflow/editor/views/storyline_outline_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/storyline_outline_view.js
@@ -24,9 +24,9 @@ pageflow.StorylineOutlineView = Backbone.Marionette.Layout.extend({
       itemViewOptions: {
         sortable: this.options.sortable,
         pageItemView: this.options.navigatable ? pageflow.NavigatablePageItemView : pageflow.PageItemView,
-        pageItemViewOptions: {
+        pageItemViewOptions: _.extend({
           displayInNavigationHint: this.options.displayInNavigationHint
-        }
+        }, this.options.pageItemViewOptions || {})
       }
     }).render();
   }

--- a/app/assets/javascripts/pageflow/editor/views/storyline_picker_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/storyline_picker_view.js
@@ -80,6 +80,7 @@ pageflow.StorylinePickerView = Backbone.Marionette.Layout.extend({
       sortable: this.options.editable,
       chapterItemView: this.options.chapterItemView,
       pageItemView: this.options.pageItemView,
+      pageItemViewOptions: this.options.pageItemViewOptions,
       displayInNavigationHint: this.options.displayInNavigationHint
     }));
   },

--- a/app/assets/stylesheets/pageflow/editor/outline.css.scss
+++ b/app/assets/stylesheets/pageflow/editor/outline.css.scss
@@ -95,6 +95,11 @@ ul.pages {
 
   > li {
     margin-bottom: 2px;
+
+    &.disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
   }
 }
 

--- a/spec/javascripts/models/storyline_transitive_child_pages_spec.js
+++ b/spec/javascripts/models/storyline_transitive_child_pages_spec.js
@@ -1,0 +1,98 @@
+describe('pageflow.StorylineTransitiveChildPages', function() {
+  var p = pageflow;
+
+  describe('#contain', function() {
+    it('returns true for page of storyline', function() {
+      var pages = new p.PagesCollection([
+        {perma_id: 1, chapter_id: 10}
+      ]);
+      var chapters = new p.ChaptersCollection([
+        {id: 10, storyline_id: 100}
+      ], {pages: pages});
+      var storylines = new p.StorylinesCollection([
+        {id: 100, title: 'parent'}
+      ], {chapters: chapters});
+      var storyline = storylines.get(100);
+      var childPages = new p.StorylineTransitiveChildPages(storyline, storylines, pages);
+
+      expect(childPages.contain(pages.getByPermaId(1))).to.eq(true);
+    });
+
+    it('returns false for page of unrelated storyline', function() {
+      var pages = new p.PagesCollection([
+        {perma_id: 1, chapter_id: 10}
+      ]);
+      var chapters = new p.ChaptersCollection([
+        {id: 10, storyline_id: 110}
+      ], {pages: pages});
+      var storylines = new p.StorylinesCollection([
+        {id: 100, title: 'parent'},
+        {id: 110, title: 'other'}
+      ], {chapters: chapters});
+      var storyline = storylines.get(100);
+      var childPages = new p.StorylineTransitiveChildPages(storyline, storylines, pages);
+
+      expect(childPages.contain(pages.getByPermaId(1))).to.eq(false);
+    });
+
+    it('returns true for page of direct child storyline', function() {
+      var pages = new p.PagesCollection([
+        {perma_id: 1, chapter_id: 10},
+        {perma_id: 2, chapter_id: 20},
+      ]);
+      var chapters = new p.ChaptersCollection([
+        {id: 10, storyline_id: 100},
+        {id: 20, storyline_id: 200}
+      ], {pages: pages});
+      var storylines = new p.StorylinesCollection([
+        {id: 100, title: 'parent'},
+        {id: 200, title: 'child', configuration: {parent_page_perma_id: 1}}
+      ], {chapters: chapters});
+      var storyline = storylines.get(100);
+      var childPages = new p.StorylineTransitiveChildPages(storyline, storylines, pages);
+
+      expect(childPages.contain(pages.getByPermaId(2))).to.eq(true);
+    });
+
+    it('returns true for page of indirect child storyline', function() {
+      var pages = new p.PagesCollection([
+        {perma_id: 1, chapter_id: 10},
+        {perma_id: 2, chapter_id: 20},
+        {perma_id: 3, chapter_id: 30}
+      ]);
+      var chapters = new p.ChaptersCollection([
+        {id: 10, storyline_id: 100},
+        {id: 20, storyline_id: 200},
+        {id: 30, storyline_id: 300}
+      ], {pages: pages});
+      var storylines = new p.StorylinesCollection([
+        {id: 100, title: 'parent'},
+        {id: 200, title: 'child', configuration: {parent_page_perma_id: 1}},
+        {id: 300, title: 'grandson', configuration: {parent_page_perma_id: 2}}
+      ], {chapters: chapters});
+      var storyline = storylines.get(100);
+      var childPages = new p.StorylineTransitiveChildPages(storyline, storylines, pages);
+
+      expect(childPages.contain(pages.getByPermaId(3))).to.eq(true);
+    });
+
+    it('returns false for page of parent storyline', function() {
+      var pages = new p.PagesCollection([
+        {perma_id: 1, chapter_id: 10},
+        {perma_id: 2, chapter_id: 20},
+      ]);
+      var chapters = new p.ChaptersCollection([
+        {id: 10, storyline_id: 100},
+        {id: 20, storyline_id: 200}
+      ], {pages: pages});
+      var storylines = new p.StorylinesCollection([
+        {id: 100, title: 'parent'},
+        {id: 200, title: 'child', confiuration: {parent_page_perma_id: 1}}
+      ], {chapters: chapters});
+      var storyline = storylines.get(200);
+      var childPages = new p.StorylineTransitiveChildPages(storyline, storylines, pages);
+
+      expect(childPages.contain(pages.getByPermaId(1))).to.eq(false);
+    });
+  });
+});


### PR DESCRIPTION
* Allow filtering allowed pages in selectPage call 
* Do not allow pages of child storylines or the storyline itself to be selected as parent page.