### PR TITLE
Add config option to forbid deleting user account

### DIFF
--- a/admins/pageflow/user.rb
+++ b/admins/pageflow/user.rb
@@ -120,7 +120,8 @@ module Pageflow
 
     collection_action 'delete_me', :title => I18n.t('pageflow.admin.users.account'), :method => [:get, :delete] do
       if request.delete?
-        if current_user.destroy_with_password(params.require(:user)[:current_password])
+        if authorized?(:delete_own_user, current_user) &&
+           current_user.destroy_with_password(params.require(:user)[:current_password])
           redirect_to admin_root_path, :notice => I18n.t('pageflow.admin.users.me.updated')
         end
       end

--- a/app/helpers/pageflow/admin/users_helper.rb
+++ b/app/helpers/pageflow/admin/users_helper.rb
@@ -4,6 +4,15 @@ module Pageflow
       def collection_for_user_roles
         User.roles_accessible_by(current_ability).index_by { |role| t(role, :scope => 'pageflow.admin.users.roles') }
       end
+
+      def delete_own_user_section
+        user_deletion_permission = Pageflow.config.authorize_user_deletion.call(current_user)
+        if user_deletion_permission == true
+          render('pageflow/admin/users/may_delete')
+        else
+          render('pageflow/admin/users/cannot_delete', reason: user_deletion_permission)
+        end
+      end
     end
   end
 end

--- a/app/views/admin/users/me.html.erb
+++ b/app/views/admin/users/me.html.erb
@@ -1,7 +1,7 @@
 <%= semantic_form_for current_user, :url => me_admin_users_path, :html => {:class => 'profile'} do |form| %>
   <%= form.inputs :first_name, :last_name %>
 
-  <%= form.inputs  do %>
+  <%= form.inputs do %>
     <%= form.input :locale,
                    as: :select,
                    include_blank: false,
@@ -13,9 +13,8 @@
     <%= form.input :password %>
     <%= form.input :password_confirmation %>
   <% end %>
+
   <%= form.actions %>
-  <p>
-    <%= t('pageflow.admin.users.me.delete_account_hint') %>
-    <%= link_to(t('pageflow.admin.users.me.delete_account'), delete_me_admin_users_path, :class => 'delete_account') %>
-  </p>
+
+  <%= delete_own_user_section %>
 <% end %>

--- a/app/views/pageflow/admin/users/_cannot_delete.html.erb
+++ b/app/views/pageflow/admin/users/_cannot_delete.html.erb
@@ -1,0 +1,3 @@
+<p class="cannot_delete">
+  <%= reason %>
+</p>

--- a/app/views/pageflow/admin/users/_may_delete.html.erb
+++ b/app/views/pageflow/admin/users/_may_delete.html.erb
@@ -1,0 +1,6 @@
+<p class="may_delete">
+  <%= t('pageflow.admin.users.me.delete_account_hint') %>
+    <%= link_to(t('pageflow.admin.users.me.delete_account'),
+                main_app.delete_me_admin_users_path,
+                class: 'delete_account') %>
+</p>

--- a/lib/pageflow/ability_mixin.rb
+++ b/lib/pageflow/ability_mixin.rb
@@ -35,6 +35,10 @@ module Pageflow
 
       can :view, [Admin::MembersTab, Admin::RevisionsTab]
 
+      can :delete_own_user, ::User do |user_to_delete|
+        Pageflow.config.authorize_user_deletion.call(user_to_delete) == true
+      end
+
       if user.admin?
         can [:read, :create, :update], Account
         can :destroy, Account do |account|

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -228,6 +228,21 @@ module Pageflow
     attr_accessor :default_author_meta_tag
     attr_accessor :default_publisher_meta_tag
 
+    # Whether a user can be deleted.
+    #
+    # @example
+    #
+    #     config.authorize_user_deletion =
+    #       lambda do |user_to_delete|
+    #         if user_to_delete.account.users.length > 1
+    #           true
+    #         else
+    #           'Last user on account. Permission denied'
+    #         end
+    #       end
+    # @since edge
+    attr_accessor :authorize_user_deletion
+
     def initialize
       @paperclip_filesystem_default_options = {validate_media_type: false}
       @paperclip_s3_default_options = {validate_media_type: false}
@@ -265,6 +280,8 @@ module Pageflow
       @default_keywords_meta_tag = 'pageflow, multimedia, reportage'
       @default_author_meta_tag = 'Pageflow'
       @default_publisher_meta_tag = 'Pageflow'
+
+      @authorize_user_deletion = lambda { |_user| true }
     end
 
     # Activate a plugin.

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -146,5 +146,32 @@ module Pageflow
         expect(user.reload.account).to eq(other_account)
       end
     end
+
+    describe '#delete_me' do
+      it 'allows to destroy the user by default' do
+        sign_in(create(:user, password: '@qwert123'))
+
+        expect do
+          delete(:delete_me, user: {current_password: '@qwert123'})
+        end.to change { User.count }
+      end
+
+      it 'does not allow to destroy the user when authorize_user_deletion non-true' do
+        user = create(:user, password: '@qwert123')
+        sign_in(user)
+        Pageflow.config.authorize_user_deletion =
+          lambda do |user_to_delete|
+            if user_to_delete.account.users.length > 1
+              true
+            else
+              'Last user on account. Permission denied'
+            end
+          end
+
+        expect do
+          delete(:delete_me, user: {current_password: '@qwert123'})
+        end.not_to change { User.count }
+      end
+    end
   end
 end

--- a/spec/features/editor/deleting_account_spec.rb
+++ b/spec/features/editor/deleting_account_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-feature 'editing profile' do
-  scenario 'change first and last name' do
+feature 'deleting own user' do
+  scenario 'user is deleted per default configuration' do
     create(:user, :email => 'john@example.com', :password => '@qwert12345')
 
     Dom::Admin::Page.sign_in(:email => 'john@example.com', :password => '@qwert12345')

--- a/spec/helpers/pageflow/admin/users_helper_spec.rb
+++ b/spec/helpers/pageflow/admin/users_helper_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Pageflow
+  module Admin
+    describe UsersHelper do
+      describe '#delete_own_user_section' do
+        it 'renders may_delete if authorize_user_deletion gives true' do
+          Pageflow.config.authorize_user_deletion = lambda { |_user| true }
+
+          allow(helper).to receive(:current_user).and_return(create(:user))
+
+          section = helper.delete_own_user_section
+
+          expect(section).to have_selector('.may_delete')
+          expect(section).not_to have_selector('.cannot_delete')
+        end
+
+        it 'renders cannot_delete if authorize_user_deletion gives any string' do
+          Pageflow.config.authorize_user_deletion =
+            lambda { |user| "#{user.full_name} is indestructible" }
+
+          allow(helper).to receive(:current_user).and_return(create(:user,
+                                                                    first_name: 'Chuck',
+                                                                    last_name: 'Doe'))
+
+          section = helper.delete_own_user_section
+
+          expect(section).to have_content('Chuck Doe is indestructible')
+          expect(section).not_to have_selector('.may_delete')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/pageflow/user_spec.rb
+++ b/spec/models/pageflow/user_spec.rb
@@ -30,7 +30,7 @@ module Pageflow
     end
 
     describe '#destroy_with_password' do
-      it 'allows to destroy the use  when given current password' do
+      it 'allows to destroy the user when given current password' do
         user = create(:user, :password => '@qwert123')
 
         user.destroy_with_password('@qwert123')
@@ -47,7 +47,7 @@ module Pageflow
           expect(user.errors[:current_password]).to be_present
         end
 
-        it 'allows to destroy the use  when given current password' do
+        it 'does not allow to destroy the user when given wrong password' do
           user = create(:user, :password => '@qwert123')
 
           user.destroy_with_password('wrong')


### PR DESCRIPTION
In some cases it might make sense to prevent the last user of an account from loosing his ability to sign in. This configuration option leaves the details of this policy to the host application.