### PR TITLE
Update Sass to 3.4

### DIFF
--- a/app/assets/stylesheets/pageflow/editor/base.css.scss
+++ b/app/assets/stylesheets/pageflow/editor/base.css.scss
@@ -1,8 +1,9 @@
 @import "bourbon";
+
+@import "pageflow/jquery_ui";
 @import "pageflow/ui";
 @import "pageflow/animations";
 
-@import 'pageflow/jquery_ui';
 @import "./blank_entry";
 @import "./dialogs";
 @import "./colors";

--- a/app/assets/stylesheets/pageflow/jquery_ui.css.scss
+++ b/app/assets/stylesheets/pageflow/jquery_ui.css.scss
@@ -1,6 +1,16 @@
 @import "jquery-layout-default";
+
+// sass-rails ignores sprockets requires in imported files. We have to
+// mimic the require calls inside jquery-ui-rails with imports.
+//
+// See also:
+// https://github.com/rails/sass-rails/issues/297
+// https://github.com/rails/sass-rails/issues/306
+@import "jquery-ui/theme";
+@import "jquery-ui/core";
 @import "jquery-ui/slider";
 @import "jquery-ui/datepicker";
+@import "jquery-ui/menu";
 @import "jquery-ui/selectmenu";
 
 div.ui-datepicker{

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -62,8 +62,17 @@ Gem::Specification.new do |s|
 
   # Use jquery as the JavaScript library
   s.add_dependency 'jquery-rails', '~> 3.0'
-  s.add_dependency 'jquery-ui-rails', '~> 5.0'
+
+  # Advanced ui widgets for the editor.
+  #
+  # WARNING: This gem has compatibility issues with sass-rails. See
+  # pageflow/jquery_ui.scss for details and update instructions.
+  s.add_dependency 'jquery-ui-rails', '5.0.5'
+
+  # Split screen functionality for editor sidebar
   s.add_dependency 'jquery-layout-rails', '~> 0.1.0'
+
+  # Editor file upload helper
   s.add_dependency 'jquery-fileupload-rails', '0.4.1'
 
   s.add_dependency 'backbone-rails', '~> 1.0.0'
@@ -71,12 +80,14 @@ Gem::Specification.new do |s|
   # Further helpers and conventions on top of Backbone
   s.add_dependency 'marionette-rails', '~> 1.1.0'
 
-
   # Templating engine used to render jst tempaltes.
   s.add_dependency 'ejs', '~> 1.1'
 
   # Templating engine used to compile scss templates.
-  s.add_dependency 'sass-rails', '~> 4.0'
+  s.add_dependency 'sass-rails', '~> 5.0'
+
+  # Scss compiler
+  s.add_dependency 'sass', '~> 3.4'
 
   # Using translations from rails locales in javascript code.
   s.add_dependency 'i18n-js', '~> 2.1'


### PR DESCRIPTION
* Update `sass-rails` to major version 5 which support `sass` 3.4.
* Require `sass` at least 3.4 for maps support
* Fix `jquery-ui-rails` version and explicitly require internal files. The gem uses sprockets requires inside which are now ignored by Scss imports.
* Ensure `jquery-ui-rails` is imported before `pageflow/ui` to ensure correct css precedence.