### PR TITLE
Do not set video src on video page activate

### DIFF
--- a/app/assets/javascripts/pageflow/page_types/video.js
+++ b/app/assets/javascripts/pageflow/page_types/video.js
@@ -49,10 +49,11 @@ pageflow.pageType.register('video', _.extend({
     var videoPlayer = this.videoPlayer;
     var that = this;
 
-    if (pageflow.browser.has('mobile platform')) {
-       videoPlayer.src(videoPlayer.srcFromOptions()); // needed for iOS
+    if (pageflow.browser.has('ios platform')) {
+      videoPlayer.src(videoPlayer.srcFromOptions());
     }
-    else {
+
+    if (!pageflow.browser.has('mobile platform')) {
       videoPlayer.prebuffer().done(function() {
         videoPlayer.hidePosterImage();
 


### PR DESCRIPTION
While historically this might have been required for iOS, it causes
crashes of Chrome on Android now. Keep for iOS to prevent making
things worse there.