### PR TITLE
Increase FastClick compatibility of share menu

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/share_menu.js
+++ b/app/assets/javascripts/pageflow/widgets/share_menu.js
@@ -9,7 +9,8 @@
           $closeOnMouseLeaving = options.closeOnMouseLeaving,
           scroller = options.scroller;
 
-      $links.on('touchend click', function(event) {
+      $links.on('click', function(event) {
+
         var $this = $(this),
             $a = $this.find('a').length ? $this.find('a') : $this,
             active = $a.hasClass('active');


### PR DESCRIPTION
In the presence of FastClick binding both touchend and click to toggle
the share menu, double fires and makes it impossible to open the menu.