### PR TITLE
Move share button in mobile navigation to bottom

### DIFF
--- a/app/assets/stylesheets/pageflow/navigation_mobile.css.scss
+++ b/app/assets/stylesheets/pageflow/navigation_mobile.css.scss
@@ -89,7 +89,7 @@ body {
       bottom: 16px;
     }
     &.sharing {
-      top: 80px;
+      bottom: 80px;
       opacity: 0;
       pointer-events: none;
     }


### PR DESCRIPTION
Align with normal navigation layout.