### PR TITLE
Fix keyboard access to sub share menu

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/navigation.js
+++ b/app/assets/javascripts/pageflow/widgets/navigation.js
@@ -45,9 +45,9 @@
 
       /* share-button */
       $('.navigation_menu .navigation_menu_box a', element).focus(function() {
-        $(this).parent().parent().addClass('focused');
+        $(this).parents('.navigation_menu').addClass('focused');
       }).blur(function() {
-        $(this).parent().parent().removeClass('focused');
+        $(this).parents('.navigation_menu').removeClass('focused');
       });
 
       var shareBox = $('.navigation_share_box', element),


### PR DESCRIPTION
Menu box used to close whenever focus left top level share buttons.