### PR TITLE
Disable atmo on mobile platform

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/atmo.js
+++ b/app/assets/javascripts/pageflow/slideshow/atmo.js
@@ -61,7 +61,7 @@
     update: function() {
       var configuration = this.slideshow.currentPageConfiguration();
 
-      if (!this.disabled) {
+      if (!this.disabled && !pageflow.browser.has('mobile platform')) {
         this.multiPlayer.fadeTo(configuration[attributeName]);
       }
     },

--- a/config/locales/new/disable_atmo.de.yml
+++ b/config/locales/new/disable_atmo.de.yml
@@ -1,0 +1,6 @@
+de:
+  pageflow:
+    ui:
+      inline_help:
+        pageflow/page:
+          atmo_audio_file_id: Wähle eine Audio-Datei, die im Hintergrund abgespielt werden soll. Wenn diese Atmo auch auf Folgeseiten nahtlos weiterspielen soll, wähle auf diesen Seiten die selbe Datei aus. Diese Funktionalität steht im Moment nicht auf mobilen Geräten zur Verfügung.


### PR DESCRIPTION
As long as there are still auto play bugs, WDR does not want to have
it play at all.