### PR TITLE
Add option to hide overview button

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/theming.js
+++ b/app/assets/javascripts/pageflow/editor/models/theming.js
@@ -9,6 +9,10 @@ pageflow.Theming = Backbone.Model.extend({
     return this.get('home_button');
   },
 
+  hasOverviewButton: function() {
+    return this.get('overview_button');
+  },
+
   supportsEmphasizedPages: function() {
     return this.get('emphasized_pages');
   },

--- a/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
@@ -47,6 +47,10 @@ pageflow.EditMetaDataView = Backbone.Marionette.Layout.extend({
         disabled: !pageflow.theming.hasHomeButton(),
         displayUncheckedIfDisabled: true
       });
+      this.input('overview_button_enabled', pageflow.CheckBoxInputView, {
+        disabled: !pageflow.theming.hasOverviewButton(),
+        displayUncheckedIfDisabled: true
+      });
       if (pageflow.theming.hasHomeButton()) {
         this.input('home_url', pageflow.TextInputView, {
           placeholder: pageflow.theming.get('pretty_url'),

--- a/app/assets/javascripts/pageflow/widgets/navigation.js
+++ b/app/assets/javascripts/pageflow/widgets/navigation.js
@@ -5,7 +5,6 @@
     _create: function() {
       var element = this.element,
           overlays = element.find('.navigation_site_detail'),
-          hasHomeButton = !!element.find('.navigation_home').length,
           toggleIndicators = function() {};
 
       element.addClass('js').append(overlays);
@@ -13,8 +12,7 @@
       $('a.navigation_top', element).topButton();
 
       $('.navigation_bar_bottom', element)
-        .append($('.navigation_bar_top > li', element).slice(hasHomeButton ? 4 : 3));
-
+        .append($('.navigation_bar_top > li', element).slice(-2));
 
       $('.navigation_volume_box', element).volumeSlider({orientation: 'h'});
       $('.navigation_mute', element).muteButton();

--- a/app/assets/stylesheets/pageflow/themes/default/navigation.css.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/navigation.css.scss
@@ -23,9 +23,6 @@ $navigation-sprite-options: () !default;
 /// Display button to toggle header
 $navigation-display-header-button: false !default;
 
-/// Display button to toggle overview
-$navigation-display-overview-button: true !default;
-
 /// Display social share menu.
 $navigation-display-share-button: true !default;
 

--- a/app/assets/stylesheets/pageflow/themes/default/navigation/dimensions.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/navigation/dimensions.scss
@@ -16,14 +16,6 @@ $scroll-indicator-offset: 35px;
   }
 }
 
-@if $navigation-display-overview-button {
-  $top-height: $top-height + $item-height;
-} @else {
-  &.js .navigation_bar_top a.navigation_index {
-    display: none;
-  }
-}
-
 @if not $navigation-display-share-button {
   $bottom-height: 232px;
 
@@ -35,8 +27,6 @@ $scroll-indicator-offset: 35px;
 &.js {
   .navigation_bar_top {
     top: 0;
-    height: $top-height;
-
     box-sizing: border-box;
     padding-top: $navigation-bar-padding-top;
   }
@@ -47,23 +37,18 @@ $scroll-indicator-offset: 35px;
   }
 
   .scroller {
-    top: $top-height;
     bottom: $bottom-height;
   }
 
   .scroll_indicator {
     height: $scroll-indicator-height;
 
-    &.top {
-      top: $top-height - $scroll-indicator-offset;
-    }
-
     &.bottom {
       bottom: $bottom-height - $scroll-indicator-offset;
     }
   }
 
-  &.with_home_button {
+  @mixin top_positions($top-height) {
     .navigation_bar_top {
       height: $top-height + $item-height;
     }
@@ -75,5 +60,16 @@ $scroll-indicator-offset: 35px;
     .scroll_indicator.top {
       top: $top-height + $item-height - $scroll-indicator-offset;
     }
+  }
+
+  @include top_positions($top-height);
+
+  &.with_home_button,
+  &.with_overview_button {
+    @include top_positions($top-height + $item-height);
+  }
+
+  &.with_home_button.with_overview_button {
+    @include top_positions($top-height + 2 * $item-height);
   }
 }

--- a/app/assets/stylesheets/pageflow/themes/default/navigation/separator_lines.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/navigation/separator_lines.scss
@@ -19,9 +19,3 @@ $navigation-separator-line-color: #9c9c9c !default;
     border-bottom: none;
   }
 }
-
-@if not $navigation-display-overview-button {
-  .navigation_top .button {
-    border-bottom: none;
-  }
-}

--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -10,6 +10,7 @@ module Pageflow
     helper_method :render_to_string
 
     helper PagesHelper
+    helper NavigationBarHelper
     helper BackgroundImageHelper
     helper RenderJsonHelper
 
@@ -83,7 +84,9 @@ module Pageflow
     protected
 
     def entry_params
-      params.require(:entry).permit(:title, :summary, :credits, :manual_start, :home_url, :home_button_enabled,
+      params.require(:entry).permit(:title, :summary, :credits, :manual_start,
+                                    :home_url, :home_button_enabled,
+                                    :overview_button_enabled,
                                     :emphasize_chapter_beginning, :emphasize_new_pages,
                                     :share_image_id, :share_image_x, :share_image_y, :locale,
                                     :author, :publisher, :keywords)

--- a/app/helpers/pageflow/navigation_bar_helper.rb
+++ b/app/helpers/pageflow/navigation_bar_helper.rb
@@ -1,0 +1,11 @@
+module Pageflow
+  module NavigationBarHelper
+    def navigation_bar_css_class(entry, options = {})
+      [
+        options[:class],
+        entry.home_button.enabled? ? 'with_home_button' : nil,
+        entry.overview_button.enabled? ? 'with_overview_button' : nil
+      ].compact.join(' ')
+    end
+  end
+end

--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -88,6 +88,10 @@ module Pageflow
       HomeButton.new(draft, theming)
     end
 
+    def overview_button
+      OverviewButton.new(draft, theming)
+    end
+
     def resolve_widgets(options = {})
       widgets.resolve(Pageflow.config_for(entry), options)
     end

--- a/app/models/pageflow/overview_button.rb
+++ b/app/models/pageflow/overview_button.rb
@@ -1,0 +1,19 @@
+module Pageflow
+  class OverviewButton
+    attr_reader :revision, :theming
+
+    def initialize(revision, theming)
+      @revision = revision
+      @theming = theming
+    end
+
+    def enabled?
+      revision.overview_button_enabled? &&
+        theming.theme.has_overview_button?
+    end
+
+    def enabled_value
+      revision.overview_button_enabled?
+    end
+  end
+end

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -66,6 +66,10 @@ module Pageflow
       HomeButton.new(revision, theming)
     end
 
+    def overview_button
+      OverviewButton.new(revision, theming)
+    end
+
     def resolve_widgets(options = {})
       widgets.resolve(Pageflow.config_for(entry), options)
     end

--- a/app/views/pageflow/editor/entries/_entry.json.jbuilder
+++ b/app/views/pageflow/editor/entries/_entry.json.jbuilder
@@ -10,4 +10,5 @@ json.configuration do
   json.(entry, :title, :summary, :credits, :author, :publisher, :keywords, :manual_start, :emphasize_chapter_beginning, :emphasize_new_pages, :share_image_id, :share_image_x, :share_image_y, :locale)
   json.home_url entry.home_button.url_value
   json.home_button_enabled entry.home_button.enabled_value
+  json.overview_button_enabled entry.overview_button.enabled_value
 end

--- a/app/views/pageflow/editor/themings/_theming.json.jbuilder
+++ b/app/views/pageflow/editor/themings/_theming.json.jbuilder
@@ -1,5 +1,6 @@
 json.pretty_url pretty_theming_url(theming)
 json.home_button theming.theme.has_home_button?
+json.overview_button theming.theme.has_overview_button?
 json.page_change_by_scrolling theming.theme.page_change_by_scrolling?
 json.hide_text_on_swipe theming.theme.hide_text_on_swipe?
 json.emphasized_pages theming.theme.supports_emphasized_pages?

--- a/app/views/pageflow/entries/_navigation.html.erb
+++ b/app/views/pageflow/entries/_navigation.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag(:div,
-                class: ["navigation", entry.home_button.enabled? ? 'with_home_button' : nil].compact.join(' '),
+                class: navigation_bar_css_class(entry, class: 'navigation'),
                 data: {widget: 'default_navigation'}) do %>
   <%= render 'pageflow/entries/navigation/bar_top', :entry => entry %>
   <div class="scroller">

--- a/app/views/pageflow/entries/navigation/_bar_top.html.erb
+++ b/app/views/pageflow/entries/navigation/_bar_top.html.erb
@@ -12,12 +12,7 @@
       <span class="button"></span>
     </a>
   </li>
-  <li>
-    <a class="navigation_bullet navigation_index" tabindex="2" title="<%= t('pageflow.public.open_overview') %>" data-active-title="<%= t('pageflow.public.close_overview') %>">
-      <span class="hint"><%= t('pageflow.public.open_overview') %></span>
-      <span class="button"></span>
-    </a>
-  </li>
+  <%= render('pageflow/entries/navigation/overview_button', overview_button: entry.overview_button) %>
   <li class="navigation_menu share" tabindex="2">
     <div class="navigation_menu_box navigation_share_box">
       <%= render 'pageflow/entries/share_menu/facebook_link', entry: entry %>

--- a/app/views/pageflow/entries/navigation/_overview_button.html.erb
+++ b/app/views/pageflow/entries/navigation/_overview_button.html.erb
@@ -1,0 +1,8 @@
+<% if overview_button.enabled? %>
+  <li>
+    <a class="navigation_bullet navigation_index" tabindex="2" title="<%= t('pageflow.public.open_overview') %>" data-active-title="<%= t('pageflow.public.close_overview') %>">
+      <span class="hint"><%= t('pageflow.public.open_overview') %></span>
+      <span class="button"></span>
+    </a>
+  </li>
+<% end %>

--- a/config/locales/new/optional_overview_button.de.yml
+++ b/config/locales/new/optional_overview_button.de.yml
@@ -1,0 +1,11 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/entry:
+        overview_button_enabled: "Übersicht-Button anzeigen"
+  pageflow:
+    ui:
+      inline_help:
+        pageflow/entry:
+          overview_button_enabled: "In der Übersicht werden die Kapitel und Seiten des Haupterzählstrangs angezeigt."
+          overview_button_enabled_disabled: "Diese Funktion steht in diesem Theme nicht zur Verfügung."

--- a/config/locales/new/optional_overview_button.en.yml
+++ b/config/locales/new/optional_overview_button.en.yml
@@ -1,0 +1,11 @@
+en:
+  activerecord:
+    attributes:
+      pageflow/entry:
+        overview_button_enabled: "Show 'Overview' button"
+  pageflow:
+    ui:
+      inline_help:
+        pageflow/entry:
+          overview_button_enabled: "The overview displays chapters and pages of the main storyline."
+          overview_button_enabled_disabled: "This option is not available for your theme."

--- a/db/migrate/20160225075853_add_overview_button_enabled_to_revisions.rb
+++ b/db/migrate/20160225075853_add_overview_button_enabled_to_revisions.rb
@@ -1,0 +1,5 @@
+class AddOverviewButtonEnabledToRevisions < ActiveRecord::Migration
+  def change
+    add_column :pageflow_revisions, :overview_button_enabled, :boolean, default: true, null: false
+  end
+end

--- a/lib/pageflow/theme.rb
+++ b/lib/pageflow/theme.rb
@@ -16,6 +16,10 @@ module Pageflow
       !@options[:no_home_button]
     end
 
+    def has_overview_button?
+      !@options[:no_overview_button]
+    end
+
     def has_scroll_back_indicator?
       !!@options[:scroll_back_indicator]
     end

--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -17,6 +17,24 @@ module Pageflow
         published
         published_until { 1.day.ago }
       end
+
+      trait :with_home_button do
+        home_button_enabled true
+        home_url 'http://example.com'
+      end
+
+      trait :without_home_button do
+        home_button_enabled false
+        home_url 'http://example.com'
+      end
+
+      trait :with_overview_button do
+        overview_button_enabled true
+      end
+
+      trait :without_overview_button do
+        overview_button_enabled false
+      end
     end
   end
 end

--- a/spec/helpers/pageflow/navigation_bar_helper_spec.rb
+++ b/spec/helpers/pageflow/navigation_bar_helper_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+module Pageflow
+  describe NavigationBarHelper do
+    describe '#navigation_bar_css_class' do
+      it 'contains given css class' do
+        entry = PublishedEntry.new(create(:entry),
+                                   create(:revision))
+
+        css_classes = helper.navigation_bar_css_class(entry, class: 'some_navigation').split(' ')
+
+        expect(css_classes).to include('some_navigation')
+      end
+
+      it 'contains with_home_button class if home button is enabled' do
+        entry = PublishedEntry.new(create(:entry),
+                                   create(:revision, :with_home_button))
+
+        css_classes = helper.navigation_bar_css_class(entry, class: 'some_navigation').split(' ')
+
+        expect(css_classes).to include('with_home_button')
+      end
+
+      it 'contains with_home_button class if home button is disabled' do
+        entry = PublishedEntry.new(create(:entry),
+                                   create(:revision, :without_home_button))
+
+        css_classes = helper.navigation_bar_css_class(entry, class: 'some_navigation').split(' ')
+
+        expect(css_classes).not_to include('with_home_button')
+      end
+
+      it 'contains with_overview_button class if overview button is enabled' do
+        entry = PublishedEntry.new(create(:entry),
+                                   create(:revision, :with_overview_button))
+
+        css_classes = helper.navigation_bar_css_class(entry, class: 'some_navigation').split(' ')
+
+        expect(css_classes).to include('with_overview_button')
+      end
+
+      it 'contains with_home_button class if overview button is disabled' do
+        entry = PublishedEntry.new(create(:entry),
+                                   create(:revision, :without_overview_button))
+
+        css_classes = helper.navigation_bar_css_class(entry, class: 'some_navigation').split(' ')
+
+        expect(css_classes).not_to include('with_overview_button')
+      end
+
+      it 'also works for draft entry' do
+        entry = DraftEntry.new(create(:entry),
+                               create(:revision))
+
+        css_classes = helper.navigation_bar_css_class(entry, class: 'some_navigation').split(' ')
+
+        expect(css_classes).to include('some_navigation')
+      end
+    end
+  end
+end

--- a/spec/models/pageflow/overview_button_spec.rb
+++ b/spec/models/pageflow/overview_button_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+module Pageflow
+  describe OverviewButton do
+    describe '#enabled?' do
+      it 'is true if overview button is enabled in revision and supported by theme' do
+        Pageflow.config.themes.register(:with_overview_button)
+        revision = Revision.new(overview_button_enabled: true)
+        theming = Theming.new(theme_name: 'with_overview_button')
+        overview_button = OverviewButton.new(revision, theming)
+
+        expect(overview_button).to be_enabled
+      end
+
+      it 'is false if overview button is disabled' do
+        Pageflow.config.themes.register(:with_overview_button)
+        revision = Revision.new(overview_button_enabled: false)
+        theming = Theming.new(theme_name: 'with_overview_button')
+        overview_button = OverviewButton.new(revision, theming)
+
+        expect(overview_button).not_to be_enabled
+      end
+
+      it 'is false if theme does not support overview button' do
+        Pageflow.config.themes.register(:no_overview_button, no_overview_button: true)
+        revision = Revision.new(overview_button_enabled: true)
+        theming = Theming.new(theme_name: 'no_overview_button')
+        overview_button = OverviewButton.new(revision, theming)
+
+        expect(overview_button).not_to be_enabled
+      end
+    end
+
+    describe '#enabled_value' do
+      it 'is true if overview button is enabled in revision' do
+        Pageflow.config.themes.register(:with_overview_button)
+        revision = Revision.new(overview_button_enabled: true)
+        theming = Theming.new(theme_name: 'with_overview_button')
+        overview_button = OverviewButton.new(revision, theming)
+
+        expect(overview_button.enabled_value).to eq(true)
+      end
+
+      it 'is false if overview button is disabled' do
+        Pageflow.config.themes.register(:with_overview_button)
+        revision = Revision.new(overview_button_enabled: false)
+        theming = Theming.new(theme_name: 'with_overview_button')
+        overview_button = OverviewButton.new(revision, theming)
+
+        expect(overview_button.enabled_value).to eq(false)
+      end
+
+      it 'is true if overview button is enabled but theme does not support it' do
+        Pageflow.config.themes.register(:no_overview_button, no_overview_button: true)
+        revision = Revision.new(overview_button_enabled: true)
+        theming = Theming.new(theme_name: 'no_overview_button')
+        overview_button = OverviewButton.new(revision, theming)
+
+        expect(overview_button.enabled_value).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For some entries with multiple storylines or very short entries, the
overview in its current form does not make sense. Add an option to
hide the overview button in navigation bars.

Whether the option is available at all, can be controlled via a theme
option `no_overview_button`. This replaces the SCSS based hiding of
the overview button.