### PR TITLE
Generate theme documentation

### DIFF
--- a/.sassdocrc
+++ b/.sassdocrc
@@ -1,0 +1,13 @@
+package:
+  title: "Pageflow Theme"
+groups:
+  standard: "Defaults"
+  widgets: "Widget Defaults"
+  default-navigation-bar: "Default Navigation Bar"
+  navigation_mobile: "Mobile Navigation"
+  overview: "Overview"
+  logo: "Logo"
+  indicators: "Indicators"
+  page-colors: "Page Colors"
+  page-typography: "Page Typography"
+descriptionPath: app/assets/stylesheets/pageflow/themes/default/README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,17 @@ cache: bundler
 
 env:
   - PAGEFLOW_RAILS_VERSION=4.0.4
-  - PAGEFLOW_RAILS_VERSION=4.1.6
+  - PAGEFLOW_RAILS_VERSION=4.1.6 PUBLISH_THEME_DOC=true
 
 services:
   - redis-server
 
 before_install:
+  - nvm install stable
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
 script:
   - bin/rspec
   - bin/teaspoon
+  - bundle exec publish-pageflow-theme-doc

--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,5 @@ gem 'teaspoon', '~> 0.9.0'
 
 gem 'spring-commands-rspec', group: :development
 gem 'spring-commands-teaspoon', group: :development
+
+gem 'pageflow-theme-doc-publisher', git: 'https://github.com/tf/pageflow-theme-doc-publisher'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ In addition to this README, there is also a [Getting Started Wiki page](https://
 to guide you through the steps of setting up a Rails application with Pageflow
 on your development machine.
 
+* [Theme Settings](http://codevise.github.io/pageflow/theme/master/)
+
 ## Updating
 
 For instructions on how to update from a prior version of the gem see


### PR DESCRIPTION
Use the `pageflow-theme-doc-publisher` gem to generate SassDoc for the
default theme and push it to GitHub pages.