### PR TITLE
ignore a few more files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.rails_version
+/.ruby-version
+/coverage
 /Gemfile.lock
 .bundle/
 log/*.log


### PR DESCRIPTION
.ruby-version can be used to test various ruby versions
/coverage needs not to be committed either