### PR TITLE
Encapsulate Active Admin load path setup

### DIFF
--- a/lib/generators/pageflow/active_admin_initializer/active_admin_initializer_generator.rb
+++ b/lib/generators/pageflow/active_admin_initializer/active_admin_initializer_generator.rb
@@ -3,6 +3,12 @@ module Pageflow
     class ActiveAdminInitializerGenerator < Rails::Generators::Base
       desc "Configure active admin utilitiy menu to contain profile link."
 
+      def configure_active_admin_load_path
+        prepend_to_file 'config/initializers/active_admin.rb' do
+          "ActiveAdmin.application.load_paths.unshift(Pageflow.active_admin_load_path)\n\n"
+        end
+      end
+
       def configure_active_admin
         inject_into_file 'config/initializers/active_admin.rb', after: "ActiveAdmin.setup do |config|\n" do
           <<-RUBY

--- a/lib/generators/pageflow/initializer/templates/pageflow.rb
+++ b/lib/generators/pageflow/initializer/templates/pageflow.rb
@@ -1,6 +1,3 @@
-# Register admins for pageflow models with active admin.
-ActiveAdmin.application.load_paths.unshift(Dir[Pageflow::Engine.root.join('admins')].first)
-
 Pageflow.configure do |config|
   # The email address to use as from header in invitation mails to new
   # users.

--- a/lib/pageflow.rb
+++ b/lib/pageflow.rb
@@ -25,4 +25,8 @@ module Pageflow
       I18n.locale = current_user.try(:locale) || http_accept_language.compatible_language_from(I18n.available_locales) || I18n.default_locale
     end
   end
+
+  def self.active_admin_load_path
+    Dir[Pageflow::Engine.root.join('admins')].first
+  end
 end

--- a/spec/pageflow_spec.rb
+++ b/spec/pageflow_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Pageflow do
+  describe '.active_admin_load_path' do
+    it 'returns path to admin directory' do
+      result = Pageflow.active_admin_load_path
+
+      expect(result).to match(/admins$/)
+    end
+  end
+end


### PR DESCRIPTION
* Move `load_path` manipulation to Active Admin initializer
* Introduce static method to hide load path construction details