### PR TITLE
Update to Rails 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ sudo: false
 cache: bundler
 
 env:
-  - PAGEFLOW_RAILS_VERSION=4.0.4
-  - PAGEFLOW_RAILS_VERSION=4.1.6 PUBLISH_THEME_DOC=true
+  - PAGEFLOW_RAILS_VERSION=4.2.6 PUBLISH_THEME_DOC=true
 
 services:
   - redis-server

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'state_machine', git: 'https://github.com/codevise/state_machine.git', branc
 
 # Ensure that teaspoon is required via Bundler.require inside the
 # dummy app. Otherwise teaspoon fails to initialize correctly.
-gem 'teaspoon', '~> 0.9.0'
+gem 'teaspoon-mocha', '~> 2.3'
 
 gem 'spring-commands-rspec', group: :development
 gem 'spring-commands-teaspoon', group: :development

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', Pageflow::RailsVersion.detect
 
 gem 'pageflow-support', path: 'spec/support'
 
-gem 'state_machine', git: 'https://github.com/tf/state_machine.git', branch: 'master'
+gem 'state_machine', git: 'https://github.com/codevise/state_machine.git', branch: 'master'
 
 # Ensure that teaspoon is required via Bundler.require inside the
 # dummy app. Otherwise teaspoon fails to initialize correctly.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Pageflow assumes the following choice of libraries:
 Pageflow runs in environments with:
 
 * Ruby >= 1.9.3 and < 2.2.0 because of [ActiveAdmin](https://github.com/activeadmin/activeadmin/issues/3715)
-* Rails 4.0 or 4.1
+* Rails 4.2
 * Redis server (for Resque)
 * A database server supported by Active Record (tested with MySQL)
 * ImageMagick

--- a/lib/pageflow/engine.rb
+++ b/lib/pageflow/engine.rb
@@ -63,7 +63,7 @@ module Pageflow
                                    pageflow/lt_ie9.js pageflow/lt_ie9.css pageflow/ie9.js pageflow/ie9.css
                                    video-js.swf vjs.eot vjs.svg vjs.ttf vjs.woff)
 
-    config.assets.precompile << lambda do |path|
+    config.assets.precompile << lambda do |path, _filename|
       Pageflow.config.themes.any? do |theme|
         path == theme.stylesheet_path
       end

--- a/lib/pageflow/engine.rb
+++ b/lib/pageflow/engine.rb
@@ -69,6 +69,11 @@ module Pageflow
       end
     end
 
+    config.assets.precompile << lambda do |path, filename|
+      filename.start_with?(Engine.root.join('app/assets').to_s) &&
+        !['.js', '.css', ''].include?(File.extname(path))
+    end
+
     # Make sure the configuration is recreated when classes are
     # reloded. Otherwise registered page types might still point to
     # unloaded classes in development mode.

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{admins,app,config,db,lib,vendor,spec/factories,spec/fixtures}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md', 'CHANGELOG.md']
 
-  s.add_dependency 'rails', '>= 4.0.2', '< 4.2'
+  s.add_dependency 'rails', '~> 4.2.6'
 
   # Framework for admin interface
   s.add_dependency 'activeadmin', '1.0.0.pre2'
@@ -94,11 +94,6 @@ Gem::Specification.new do |s|
 
   # Scss compiler
   s.add_dependency 'sass', '~> 3.4'
-
-  # Newer sprocket version allow sprockets 3 which causes
-  # precompilation errors due to the arity of the lambda added to
-  # `config.assets.precompile` in `pageflow/engine.rb`.
-  s.add_dependency 'sprockets-rails', '~> 2.0.1'
 
   # Using translations from rails locales in javascript code.
   s.add_dependency 'i18n-js', '~> 2.1'

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -149,7 +149,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'colorize', '~> 0.7.5'
 
   # Javascript unit testing
-  s.add_development_dependency 'teaspoon', '~> 0.9.0'
+  s.add_development_dependency 'teaspoon-mocha', '~> 2.3'
 
   # Stub HTTP requests in tests
   s.add_development_dependency 'webmock', '~> 1.20'

--- a/spec/support/pageflow/dummy/rails_template.rb
+++ b/spec/support/pageflow/dummy/rails_template.rb
@@ -25,6 +25,9 @@ append_to_file('config/application.rb', <<-END)
   end
 END
 
+# Remove requires to missing gems (i.e. turbolinks)
+gsub_file('app/assets/javascripts/application.js', %r'//=.*', '')
+
 # Recreate db. Ignore if it does not exist.
 
 log :rake, 'db:drop:all'

--- a/spec/support/pageflow/rails_version.rb
+++ b/spec/support/pageflow/rails_version.rb
@@ -5,7 +5,7 @@ module Pageflow
     RAILS_VERSION_FILE = File.expand_path('../../../../.rails_version')
 
     def detect
-      from_env || from_file || '4.0.4'
+      from_env || from_file || '4.2.6'
     end
 
     private


### PR DESCRIPTION
Make Pageflow work with Rails 4.2. I'm considering dropping support for 4.0 and 4.1 since they are no longer maintained now that Rails 5 is out. This would allow us to rely on `ActiveJob`, which would be nice.