### PR TITLE
Allow specifying custom share url

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_meta_data_view.js
@@ -79,6 +79,9 @@ pageflow.EditMetaDataView = Backbone.Marionette.Layout.extend({
         disableRichtext: true,
         disableLinks: true
       });
+      this.input('share_url', pageflow.TextInputView, {
+        placeholder: pageflow.entry.get('pretty_url')
+      });
     });
 
     this.formContainer.show(configurationEditor);

--- a/app/assets/javascripts/pageflow/widgets/share_menu.js
+++ b/app/assets/javascripts/pageflow/widgets/share_menu.js
@@ -15,10 +15,10 @@
             $a = $this.find('a').length ? $this.find('a') : $this,
             active = $a.hasClass('active');
 
-        $links.removeClass('active');
-        $a.addClass('active');
-
         if ($a.data('share-page')) {
+          $links.removeClass('active');
+          $a.addClass('active');
+
           event.preventDefault();
 
           var $currentPage = pageflow.slides.currentPage(),

--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -88,8 +88,8 @@ module Pageflow
                                     :home_url, :home_button_enabled,
                                     :overview_button_enabled,
                                     :emphasize_chapter_beginning, :emphasize_new_pages,
-                                    :share_image_id, :share_image_x, :share_image_y, :locale,
-                                    :author, :publisher, :keywords)
+                                    :share_url, :share_image_id, :share_image_x, :share_image_y,
+                                    :locale, :author, :publisher, :keywords)
     end
 
     def entry_request_scope

--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -4,8 +4,9 @@ module Pageflow
       [entry.title, entry.theming.cname_domain.presence].compact.join(' - ')
     end
 
-    def pretty_entry_url(entry)
-      pageflow.short_entry_url(entry.to_model, Pageflow.config.theming_url_options(entry.theming))
+    def pretty_entry_url(entry, options = {})
+      params = options.reverse_merge(Pageflow.config.theming_url_options(entry.theming) || {})
+      pageflow.short_entry_url(entry.to_model, params)
     end
 
     def entry_file_rights(entry)

--- a/app/helpers/pageflow/social_share_helper.rb
+++ b/app/helpers/pageflow/social_share_helper.rb
@@ -1,5 +1,7 @@
 module Pageflow
   module SocialShareHelper
+    include EntriesHelper
+
     def social_share_meta_tags_for(target)
       if target.is_a?(Page)
         render('pageflow/social_share/page_meta_tags', entry: @entry, page: @entry.share_target)
@@ -8,8 +10,19 @@ module Pageflow
       end
     end
 
-    def social_share_page_url(page)
-      "#{pretty_entry_url(page.chapter.entry)}?page=#{page.perma_id}"
+    def social_share_entry_url(entry)
+      entry.share_url.presence || pretty_entry_url(entry)
+    end
+
+    def social_share_page_url(entry, page_or_perma_id)
+      perma_id =
+        if page_or_perma_id.respond_to?(:perma_id)
+          page_or_perma_id.perma_id
+        else
+          page_or_perma_id
+        end
+
+      pretty_entry_url(entry, page: perma_id)
     end
 
     def social_share_page_title(page)
@@ -23,7 +36,7 @@ module Pageflow
       title.join(' ')
     end
 
-    def social_share_page_description(page, entry)
+    def social_share_page_description(entry, page)
       return social_share_sanitize(page.configuration['text']) if page.configuration['text'].present?
       return social_share_sanitize(page.configuration['description']) if page.configuration['description'].present?
       social_share_entry_description(entry)

--- a/app/helpers/pageflow/social_share_links_helper.rb
+++ b/app/helpers/pageflow/social_share_links_helper.rb
@@ -1,0 +1,32 @@
+module Pageflow
+  module SocialShareLinksHelper
+    include SocialShareHelper
+
+    PROVIDER_URL_TEMPLATES = {
+      facebook: 'http://www.facebook.com/sharer/sharer.php?u=%{url}',
+      google: 'https://plus.google.com/share?url=%{url}',
+      twitter: 'http://twitter.com/home?status=%{url}'
+    }.freeze
+
+    def social_share_link(provider, entry, &block)
+      block ||= ->() {}
+      page_share_link_url = social_share_link_url(provider, social_share_page_url(entry, 'permaId'))
+      data_attributes = entry.share_url.present? ? {} : {share_page: page_share_link_url}
+
+      link_to(social_share_link_url(provider, social_share_entry_url(entry)),
+              target: '_blank',
+              tabindex: '2',
+              class: ['share', provider],
+              data: data_attributes,
+              &block)
+    end
+
+    private
+
+    def social_share_link_url(provider, url)
+      return nil if url.blank?
+      encoded_url = ERB::Util.url_encode(url)
+      PROVIDER_URL_TEMPLATES[provider] % {url: encoded_url}
+    end
+  end
+end

--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -17,7 +17,7 @@ module Pageflow
              :storylines, :main_storyline_chapters, :chapters, :pages,
              :emphasize_chapter_beginning,
              :emphasize_new_pages,
-             :share_image_id, :share_image_x, :share_image_y,
+             :share_url, :share_image_id, :share_image_x, :share_image_y,
              :files,
              :image_files, :video_files, :audio_files,
              :locale,

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -20,7 +20,7 @@ module Pageflow
              :summary, :credits, :manual_start,
              :emphasize_chapter_beginning,
              :emphasize_new_pages,
-             :share_image_id, :share_image_x, :share_image_y,
+             :share_url, :share_image_id, :share_image_x, :share_image_y,
              :locale,
              :author, :publisher, :keywords,
              :password_protected?,

--- a/app/views/pageflow/editor/entries/_entry.json.jbuilder
+++ b/app/views/pageflow/editor/entries/_entry.json.jbuilder
@@ -7,7 +7,10 @@ json.published(entry.published?)
 json.password_protected(entry.password_digest.present?)
 
 json.configuration do
-  json.(entry, :title, :summary, :credits, :author, :publisher, :keywords, :manual_start, :emphasize_chapter_beginning, :emphasize_new_pages, :share_image_id, :share_image_x, :share_image_y, :locale)
+  json.(entry,
+        :title, :locale, :summary, :credits, :author, :publisher, :keywords,
+        :manual_start, :emphasize_chapter_beginning, :emphasize_new_pages,
+        :share_url, :share_image_id, :share_image_x, :share_image_y)
   json.home_url entry.home_button.url_value
   json.home_button_enabled entry.home_button.enabled_value
   json.overview_button_enabled entry.overview_button.enabled_value

--- a/app/views/pageflow/entries/share_menu/_facebook_link.html.erb
+++ b/app/views/pageflow/entries/share_menu/_facebook_link.html.erb
@@ -1,12 +1,5 @@
-<%= link_to("http://www.facebook.com/sharer/sharer.php?u=#{ERB::Util.url_encode(pretty_entry_url(entry))}&t=#{ERB::Util.url_encode(entry.title)}",
-            :target => "_blank",
-            :tabindex => "2",
-            :class => "share facebook",
-            :data => {
-              :"share-page" => "http://www.facebook.com/sharer/sharer.php?u=#{ERB::Util.url_encode(pretty_entry_url(entry))}%3Fpage%3DpermaId"
-            }) do %>
-
-    <span class="hint"><%= t('pageflow.public.share_on_facebook') %></span>
-    <span class="share_facebook button"></span>
-    <p>facebook</p>
+<%= social_share_link(:facebook, entry) do %>
+  <span class="hint"><%= t('pageflow.public.share_on_facebook') %></span>
+  <span class="share_facebook button"></span>
+  <p>facebook</p>
 <% end %>

--- a/app/views/pageflow/entries/share_menu/_google_link.html.erb
+++ b/app/views/pageflow/entries/share_menu/_google_link.html.erb
@@ -1,12 +1,5 @@
-<%= link_to("https://plus.google.com/share?url=#{ERB::Util.url_encode(pretty_entry_url(entry))}",
-            :target => "_blank",
-            :tabindex => "2",
-            :class => "share google",
-            :data => {
-              :"share-page" => "https://plus.google.com/share?url=#{ERB::Util.url_encode(pretty_entry_url(entry))}%3Fpage%3DpermaId"
-            }) do %>
-
-    <span class="hint"><%= t('pageflow.public.share_on_google') %></span>
-    <span class="share_google button"></span>
-    <p>google</p>
+<%= social_share_link(:google, entry) do %>
+  <span class="hint"><%= t('pageflow.public.share_on_google') %></span>
+  <span class="share_google button"></span>
+  <p>google</p>
 <% end %>

--- a/app/views/pageflow/entries/share_menu/_twitter_link.html.erb
+++ b/app/views/pageflow/entries/share_menu/_twitter_link.html.erb
@@ -1,12 +1,5 @@
-<%= link_to("http://twitter.com/home?status=#{ERB::Util.url_encode(pretty_entry_url(entry))}",
-            :target => "_blank",
-            :tabindex => "2",
-            :class => "share twitter",
-            :data => {
-              :"share-page" => "http://twitter.com/home?status=#{ERB::Util.url_encode(pretty_entry_url(entry))}%3Fpage%3DpermaId"
-            }) do %>
-
-    <span class="hint"><%= t('pageflow.public.share_on_twitter') %></span>
-    <span class="share_twitter button"></span>
-    <p>twitter</p>
+<%= social_share_link(:twitter, entry) do %>
+  <span class="hint"><%= t('pageflow.public.share_on_twitter') %></span>
+  <span class="share_twitter button"></span>
+  <p>twitter</p>
 <% end %>

--- a/app/views/pageflow/social_share/_entry_meta_tags.html.erb
+++ b/app/views/pageflow/social_share/_entry_meta_tags.html.erb
@@ -1,12 +1,12 @@
-<%= tag :link, :rel => "canonical", :href => pretty_entry_url(entry) %>
+<%= tag :link, rel: "canonical", href: social_share_entry_url(entry) %>
 
 <%= social_share_entry_image_tags(entry) %>
 
-<%= tag :meta, :property => "og:title", :content => pretty_entry_title(entry) %>
-<%= tag :meta, :property => "og:description", :name => "description", :content => social_share_entry_description(entry) %>
-<%= tag :meta, :property => "og:url", :content => pretty_entry_url(entry) %>
-<%= tag :meta, :property => "og:site_name", :content => entry.theming.cname_domain %>
-<%= tag :meta, :property => "og:type", :content => "website" %>
+<%= tag :meta, property: "og:title", content: pretty_entry_title(entry) %>
+<%= tag :meta, property: "og:description", name: "description", content: social_share_entry_description(entry) %>
+<%= tag :meta, property: "og:url", content: social_share_entry_url(entry) %>
+<%= tag :meta, property: "og:site_name", content: entry.theming.cname_domain %>
+<%= tag :meta, property: "og:type", content: "website" %>
 
-<%= tag :meta, :name => "twitter:card", :content => "summary_large_image" %>
-<%= tag :meta, :name => "twitter:description", :content => social_share_entry_description(entry) %>
+<%= tag :meta, name: "twitter:card", content: "summary_large_image" %>
+<%= tag :meta, name: "twitter:description", content: social_share_entry_description(entry) %>

--- a/app/views/pageflow/social_share/_image_tags.html.erb
+++ b/app/views/pageflow/social_share/_image_tags.html.erb
@@ -1,7 +1,7 @@
 <% image_urls.each do |image_url| %>
-  <%= tag :meta, :property => "og:image", :content => social_share_normalize_protocol(image_url) %>
+  <%= tag :meta, property: "og:image", content: social_share_normalize_protocol(image_url) %>
 <% end %>
 
 <% if image_urls.first.present? %>
-  <%= tag :meta, :name => "twitter:image:src", :content => social_share_normalize_protocol(image_urls.first) %>
+  <%= tag :meta, name: "twitter:image:src", content: social_share_normalize_protocol(image_urls.first) %>
 <% end %>

--- a/app/views/pageflow/social_share/_page_meta_tags.html.erb
+++ b/app/views/pageflow/social_share/_page_meta_tags.html.erb
@@ -1,12 +1,12 @@
-<%= tag :link, :rel => "canonical", :href => social_share_page_url(page) %>
+<%= tag :link, rel: "canonical", href: social_share_page_url(entry, page) %>
 
-<%= tag :meta, :property => "og:image", :content => social_share_normalize_protocol(page.thumbnail_url(:medium)) %>
+<%= tag :meta, property: "og:image", content: social_share_normalize_protocol(page.thumbnail_url(:medium)) %>
 
-<%= tag :meta, :property => "og:title", :content => social_share_page_title(page) %>
-<%= tag :meta, :property => "og:description", :name => "description", :content => social_share_page_description(page, entry) %>
-<%= tag :meta, :property => "og:url", :content => social_share_page_url(page) %>
-<%= tag :meta, :property => "og:site_name", :content => entry.theming.cname_domain %>
-<%= tag :meta, :property => "og:type", :content => "website" %>
+<%= tag :meta, property: "og:title", content: social_share_page_title(page) %>
+<%= tag :meta, property: "og:description", name: "description", content: social_share_page_description(entry, page) %>
+<%= tag :meta, property: "og:url", content: social_share_page_url(entry, page) %>
+<%= tag :meta, property: "og:site_name", content: entry.theming.cname_domain %>
+<%= tag :meta, property: "og:type", content: "website" %>
 
-<%= tag :meta, :name => "twitter:card", :content => "summary_large_image" %>
-<%= tag :meta, :name => "twitter:description", :content => social_share_page_description(page, entry) %>
+<%= tag :meta, name: "twitter:card", content: "summary_large_image" %>
+<%= tag :meta, name: "twitter:description", content: social_share_page_description(entry, page) %>

--- a/config/locales/new/share_url.de.yml
+++ b/config/locales/new/share_url.de.yml
@@ -1,0 +1,10 @@
+de:
+  pageflow:
+    ui:
+      inline_help:
+        pageflow/entry:
+          share_url: "URL, die geteilt werden soll, wenn der Benutzer auf einen der Social Media Buttons klickt. Feld frei lassen, um URL des veröffentlichten Beitrags zu verwenden."
+  activerecord:
+    attributes:
+      "pageflow/entry":
+        share_url: "Social Sharing URL"

--- a/config/locales/new/share_url.en.yml
+++ b/config/locales/new/share_url.en.yml
@@ -1,0 +1,10 @@
+en:
+  pageflow:
+    ui:
+      inline_help:
+        pageflow/entry:
+          share_url: "URL to share via social media buttons. Leave blank to use URL of published entry."
+  activerecord:
+    attributes:
+      "pageflow/entry":
+        share_url: "Social Sharing URL"

--- a/db/migrate/20160715105408_add_share_url_to_revisions.rb
+++ b/db/migrate/20160715105408_add_share_url_to_revisions.rb
@@ -1,0 +1,5 @@
+class AddShareUrlToRevisions < ActiveRecord::Migration
+  def change
+    add_column :pageflow_revisions, :share_url, :string, null: false, default: ''
+  end
+end

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -33,6 +33,14 @@ module Pageflow
         expect(helper.pretty_entry_url(entry)).to eq('http://test.host/test')
       end
 
+      it 'supports custom params' do
+        theming = create(:theming, cname: '')
+        entry = PublishedEntry.new(create(:entry, title: 'test', theming: theming),
+                                   create(:revision))
+
+        expect(helper.pretty_entry_url(entry, page: 4)).to eq('http://test.host/test?page=4')
+      end
+
       it 'uses theming cname if present' do
         theming = create(:theming, cname: 'my.example.com')
         entry = PublishedEntry.new(create(:entry, title: 'test', theming: theming),

--- a/spec/helpers/pageflow/social_share_helper_spec.rb
+++ b/spec/helpers/pageflow/social_share_helper_spec.rb
@@ -2,6 +2,51 @@ require 'spec_helper'
 
 module Pageflow
   describe SocialShareHelper do
+    describe '#social_share_entry_url' do
+      it 'returns share_url if present' do
+        entry = create(:entry, :published, published_revision_attributes: {
+                         share_url: 'http://example.com/my_entry'
+                       })
+        published_entry = PublishedEntry.new(entry)
+
+        result = helper.social_share_entry_url(published_entry)
+
+        expect(result).to eq('http://example.com/my_entry')
+      end
+
+      it 'falls back to pretty entry url' do
+        entry = create(:entry, :published, title: 'my_entry')
+        published_entry = PublishedEntry.new(entry)
+
+        result = helper.social_share_entry_url(published_entry)
+
+        expect(result).to eq('http://test.host/my_entry')
+      end
+    end
+
+    describe '#social_share_page_url' do
+      it 'appends page param to pretty entry url' do
+        entry = create(:entry, :published, title: 'my_entry')
+        storyline = create(:storyline, revision: entry.published_revision)
+        chapter = create(:chapter, storyline: storyline)
+        page = create(:page, chapter: chapter, configuration: {text: 'Page Text'}, position: 1)
+        published_entry = PublishedEntry.new(entry)
+
+        result = helper.social_share_page_url(published_entry, page)
+
+        expect(result).to eq("http://test.host/my_entry?page=#{page.perma_id}")
+      end
+
+      it 'supports string as page parameter' do
+        entry = create(:entry, :published, title: 'my_entry')
+        published_entry = PublishedEntry.new(entry)
+
+        result = helper.social_share_page_url(published_entry, 'some_placeholder')
+
+        expect(result).to eq('http://test.host/my_entry?page=some_placeholder')
+      end
+    end
+
     describe '#social_share_entry_description' do
       it 'returns entry summary if present' do
         entry = create(:entry, :published)
@@ -27,8 +72,8 @@ module Pageflow
         entry = create(:entry, :published)
         storyline = create(:storyline, revision: entry.published_revision)
         chapter = create(:chapter, storyline: storyline)
-        page = create(:page, chapter: chapter, configuration: { text: 'Page Text' }, position: 1)
-        create(:page, chapter: chapter, configuration: { text: 'Another Page Text' }, position: 2)
+        page = create(:page, chapter: chapter, configuration: {text: 'Page Text'}, position: 1)
+        create(:page, chapter: chapter, configuration: {text: 'Another Page Text'}, position: 2)
         published_entry = PublishedEntry.new(entry)
 
         result = helper.social_share_entry_description(published_entry)
@@ -51,10 +96,10 @@ module Pageflow
         entry = create(:entry, :published)
         storyline = create(:storyline, revision: entry.published_revision)
         chapter = create(:chapter, storyline: storyline)
-        page = create(:page, chapter: chapter, configuration: { text: 'Page Text' })
+        page = create(:page, chapter: chapter, configuration: {text: 'Page Text'})
         published_entry = PublishedEntry.new(entry)
 
-        result = helper.social_share_page_description(page, published_entry)
+        result = helper.social_share_page_description(published_entry, page)
 
         expect(result).to eq(page.configuration['text'])
       end
@@ -63,10 +108,10 @@ module Pageflow
         entry = create(:entry, :published)
         storyline = create(:storyline, revision: entry.published_revision)
         chapter = create(:chapter, storyline: storyline)
-        page = create(:page, chapter: chapter, configuration: { description: 'description' })
+        page = create(:page, chapter: chapter, configuration: {description: 'description'})
         published_entry = PublishedEntry.new(entry)
 
-        result = helper.social_share_page_description(page, published_entry)
+        result = helper.social_share_page_description(published_entry, page)
 
         expect(result).to eq(page.configuration['description'])
       end
@@ -79,7 +124,7 @@ module Pageflow
         page = create(:page, chapter: chapter)
         published_entry = PublishedEntry.new(entry)
 
-        result = helper.social_share_page_description(page, published_entry)
+        result = helper.social_share_page_description(published_entry, page)
 
         expect(result).to eq('social share description')
       end

--- a/spec/helpers/pageflow/social_share_links_helper_spec.rb
+++ b/spec/helpers/pageflow/social_share_links_helper_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+module Pageflow
+  describe SocialShareLinksHelper do
+    describe '#social_share_link' do
+      it 'add provider class to link' do
+        entry = create(:entry, :published)
+        published_entry = PublishedEntry.new(entry)
+
+        html = helper.social_share_link(:google, published_entry)
+
+        expect(html).to have_selector('a.share.google')
+      end
+
+      it 'has data-share-page attribute with page share link template' do
+        entry = create(:entry, :published)
+        published_entry = PublishedEntry.new(entry)
+
+        html = helper.social_share_link(:google, published_entry)
+
+        expect(html).to have_selector('a[data-share-page$="%3Fpage%3DpermaId"]')
+      end
+
+      it 'does not have data-share-page attribute if custom share url is present' do
+        entry = create(:entry, :published, published_revision_attributes: {
+                         share_url: 'http://example.com/my_entry'
+                       })
+        published_entry = PublishedEntry.new(entry)
+
+        html = helper.social_share_link(:google, published_entry)
+
+        expect(html).not_to have_selector('[data-share-page]')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is useful for:

* embedded entries that are actually viewed via a different domain

* entries that are part of a larger project whose landing page is
  supposed to be shared instead of the individual entry.

This change allows to set a custom share url via the social sharing
tab inside the editor. If it is set, the Twitter/Facebook/Google links
directly pass this url, instead of offering to either share the whole
entry or the current page.