### PR TITLE
Improve boundary events

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/scroller_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/scroller_widget.js
@@ -52,6 +52,8 @@
       else {
         this.iscroll.scrollTo(0, 0, 0);
       }
+
+      this._triggerBoundaryEvents();
     },
 
     scrollBy: function(deltaX, deltaY, time, easing) {
@@ -78,7 +80,7 @@
     },
 
     afterAnimationHook: function() {
-      this._triggerNearBottomEvents();
+      this._triggerBoundaryEvents();
     },
 
     disable: function() {
@@ -130,6 +132,11 @@
       this.iscroll.on('scroll', _.bind(this._triggerNearTopEvents, this));
       this.iscroll.on('scrollEnd', _.bind(this._triggerNearTopEvents, this));
       this.iscroll.on('afterkeyboard', _.bind(this._triggerNearTopEvents, this));
+    },
+
+    _triggerBoundaryEvents: function() {
+      this._triggerNearTopEvents();
+      this._triggerNearBottomEvents();
     },
 
     _triggerNearBottomEvents: function() {

--- a/app/assets/javascripts/pageflow/widgets/header.js
+++ b/app/assets/javascripts/pageflow/widgets/header.js
@@ -4,32 +4,36 @@ jQuery(function($) {
       var slideshow = this.options.slideshow,
           that = this;
 
-    slideshow.on('pageactivate', function(event) {
-        updateClasses($(event.target));
+      slideshow.on('pageactivate', function(event, options) {
+        updateClasses(slideshow.currentPage(), options);
       });
 
       slideshow.on('scrollerneartop', function(event) {
-        that.element.addClass('near_top');
+        var page = $(event.target).parents('section');
+
+        if (page.is(slideshow.currentPage())) {
+          that.element.addClass('near_top');
+        }
       });
 
       slideshow.on('scrollernotneartop', function(event) {
         var page = $(event.target).parents('section');
 
-        if (page.hasClass('active')) {
+        if (page.is(slideshow.currentPage())) {
           that.element.removeClass('near_top');
         }
       });
 
-      if (slideshow.currentPage()) {
-        updateClasses(slideshow.currentPage());
+      if (slideshow.currentPage().length) {
+        updateClasses(slideshow.currentPage(), {});
       }
 
+      this.element.addClass('near_top');
       this.element.find('.header input').placeholder();
 
       function updateClasses(page) {
         that.element.toggleClass('invert', page.hasClass('invert'));
         that.element.toggleClass('first_page', page.index() === 0);
-        that.element.addClass('near_top');
       }
     }
   });


### PR DESCRIPTION
* 	Improve scroller widget boundary events

  Ensure boundary events trigger when the position is reset. This
  ensures that header logos can be faded out correctly when scrolling
  back to a page with position bottom.		

* 	Improve setting of near_bottom class in header

  When scrolling back to a page the class may not be set since we are at
  the bottom of the page. Rely completely on the scroller events of the
  current page.