### PR TITLE
prevent account with entries being deleted

### DIFF
--- a/app/models/pageflow/account.rb
+++ b/app/models/pageflow/account.rb
@@ -2,8 +2,8 @@ module Pageflow
   class Account < ActiveRecord::Base
     include FeatureTarget
 
-    has_many :users
-    has_many :entries
+    has_many :users, dependent: :restrict_with_exception
+    has_many :entries, dependent: :restrict_with_exception
     has_many :folders, dependent: :destroy
 
     has_many :themings, dependent: :destroy

--- a/spec/models/pageflow/account_spec.rb
+++ b/spec/models/pageflow/account_spec.rb
@@ -2,6 +2,24 @@ require 'spec_helper'
 
 module Pageflow
   describe Account do
+    describe 'with entries' do
+      it 'cannot be deleted' do
+        account = create(:account)
+        create(:entry, account: account)
+
+        expect { account.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
+      end
+    end
+
+    describe 'with users' do
+      it 'cannot be deleted' do
+        account = create(:account)
+        create(:user, account: account)
+
+        expect { account.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError)
+      end
+    end
+
     describe '#build_default_theming' do
       it 'sets default theming to new theming' do
         account = create(:account)


### PR DESCRIPTION
Instead, ActiveRecord::DeleteRestrictionError will be raised. Entries
without accounts leave the system in an unstable state, so it must be
prevented.

Fixes #562 