### PR TITLE
Allow overriding logic to determine highlightes page

### DIFF
--- a/app/assets/javascripts/pageflow/highlighted_page.js
+++ b/app/assets/javascripts/pageflow/highlighted_page.js
@@ -1,5 +1,6 @@
 pageflow.HighlightedPage = pageflow.Object.extend({
-  initialize: function(entryData) {
+  initialize: function(entryData, options) {
+    this.customNavigationBarMode = options && options.customNavigationBarMode;
     this.entry = entryData;
   },
 
@@ -28,7 +29,12 @@ pageflow.HighlightedPage = pageflow.Object.extend({
   },
 
   getNavigationBarMode: function(storylineId) {
-    return this.entry.getStorylineConfiguration(storylineId).navigation_bar_mode;
+    if (this.customNavigationBarMode) {
+      return this.customNavigationBarMode(storylineId, this.entry);
+    }
+    else {
+      return this.entry.getStorylineConfiguration(storylineId).navigation_bar_mode;
+    }
   },
 
   getChapterPagesUntil: function(pagePermaId) {
@@ -43,6 +49,6 @@ pageflow.HighlightedPage = pageflow.Object.extend({
   }
 });
 
-pageflow.HighlightedPage.create = function() {
-  return new pageflow.HighlightedPage(pageflow.entryData);
+pageflow.HighlightedPage.create = function(options) {
+  return new pageflow.HighlightedPage(pageflow.entryData, options);
 };

--- a/app/assets/javascripts/pageflow/widgets/page_navigation_list.js
+++ b/app/assets/javascripts/pageflow/widgets/page_navigation_list.js
@@ -9,8 +9,8 @@
       var links = element.find('a[href]');
 
       var chapterFilter = pageflow.ChapterFilter.create();
-      var highlightedPage = pageflow.HighlightedPage.create();
-      var animation = pageflow.PageNavigationListAnimation.create()
+      var highlightedPage = pageflow.HighlightedPage.create(options.highlightedPage);
+      var animation = pageflow.PageNavigationListAnimation.create();
 
       pageflow.ready.then(function() {
         highlightUnvisitedPages(pageflow.visited.getUnvisitedPages());

--- a/spec/javascripts/pageflow/highlighted_page_spec.js
+++ b/spec/javascripts/pageflow/highlighted_page_spec.js
@@ -118,5 +118,44 @@ describe('pageflow.HighlightedPage', function() {
         expect(result).to.eq(102);
       });
     });
+
+    describe('with customNavigationBarMode option', function() {
+      it('uses navigation bar modes returned by option', function() {
+        var entryData = new p.SeedEntryData({
+          storyline_configurations: {
+            10: {
+              parent_page_perma_id: 101
+            },
+            20: {
+              parent_page_perma_id: 102,
+            },
+            30: {
+              main: true
+            }
+          },
+          chapters: [
+            {id: 1, storyline_id: 10},
+            {id: 2, storyline_id: 20},
+            {id: 3, storyline_id: 30}
+          ],
+          pages: [
+            {perma_id: 100, chapter_id: 1},
+            {perma_id: 101, chapter_id: 2},
+            {perma_id: 102, chapter_id: 3}
+          ]
+        });
+        var outline = new p.HighlightedPage(entryData, {
+          customNavigationBarMode: function(storylineId, entryData) {
+            if (!entryData.getStorylineConfiguration(storylineId).main) {
+              return 'inherit_from_parent';
+            }
+          }
+        });
+
+        var result = outline.getPagePermaId(100);
+
+        expect(result).to.eq(102);
+      });
+    });
   });
 });


### PR DESCRIPTION
Add option to `pageNavigationList` which is passed to
`HighlightedPage` to allow overriding the navigation bar mode. This
can be used in navigation bars which always only display the main
storyline.