### PR TITLE
Apply widget margin to mobile scroll indicator

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/indicators.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/indicators.scss
@@ -17,6 +17,7 @@ $indicator-icons: "icon_font" !default;
 @import "./indicators/icons/sprite";
 @import "./indicators/typography";
 @import "./indicators/colors";
+@import "./indicators/widget_margins";
 
 @if $indicator-icons == "sprite" {
   @include indicators-icons-sprite;

--- a/app/assets/stylesheets/pageflow/themes/default/indicators/widget_margins.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/indicators/widget_margins.scss
@@ -1,0 +1,3 @@
+.scroll_indicator {
+  @extend %pageflow_widget_margin_right !optional;
+}


### PR DESCRIPTION
On mobile the scroll indicator is aligned on the rigth. Apply widget
margin to prevent it being hidden behind navigation bars which are
also visible on mobile.