### PR TITLE
Ensure facebook app does not crop viewport

### DIFF
--- a/app/assets/javascripts/pageflow/browser/agent.js
+++ b/app/assets/javascripts/pageflow/browser/agent.js
@@ -49,5 +49,13 @@ pageflow.browser.agent = {
    */
   matchesIEUpTo11: function() {
     return navigator.userAgent.match(/Trident\//);
+  },
+
+  /**
+   * Returns true in InApp browser of Facebook app.
+   * @return {boolean}
+   */
+  matchesFacebookInAppBrowser: function() {
+    return navigator.userAgent.match(/FBAN/) && navigator.userAgent.match(/FBAV/);
   }
 };

--- a/app/assets/javascripts/pageflow/browser/facebook.js
+++ b/app/assets/javascripts/pageflow/browser/facebook.js
@@ -1,0 +1,10 @@
+// Facebook app displays a toolbar at the bottom of the screen on iOS
+// phone which hides parts of the browser viewport. Normally this is
+// hidden once the user scrolls, but since there is no native
+// scrolling in Pageflow, the bar stays and hides page elements like
+// the slim player controls.
+pageflow.browser.feature('facebook toolbar', function(has) {
+  return has.all(has('ios platform'),
+                 has('phone platform'),
+                 pageflow.browser.agent.matchesFacebookInAppBrowser());
+});

--- a/app/assets/javascripts/pageflow/widgets/loading_spinner.js
+++ b/app/assets/javascripts/pageflow/widgets/loading_spinner.js
@@ -3,6 +3,8 @@
     _create: function() {
       var element = this.element;
 
+      pageflow.nativeScrolling.preventScrollBouncing(element);
+
       setTimeout(function() {
         pageflow.ready.then(function() {
           element.addClass('fade');

--- a/app/assets/stylesheets/pageflow/base.scss
+++ b/app/assets/stylesheets/pageflow/base.scss
@@ -8,6 +8,19 @@ html, body, #outer_wrapper {
   -webkit-tap-highlight-color: transparent; /* we need this for some Android browsers */
 }
 
+// Facebook app displays a toolbar at the bottom of the screen on iOS
+// phone which hides parts of the browser viewport. Normally this is
+// hidden once the user scrolls, but since there is no native
+// scrolling in Pageflow, the bar stays and hides page elements like
+// the slim player controls. Setting the wrapper to fixed, makes it
+// work for some reason.
+.has_facebook_toolbar #outer_wrapper {
+  height: auto;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+}
+
 html {
   background-color: black;
 }


### PR DESCRIPTION
On iOS Facebook displays a toolbar at the bottom of the screen hiding
parts of the play controls. Detect Facebook browser via user agent and
apply fixed position to wrapper.