### PR TITLE
Use parallel Coverall builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 cache: bundler
 
 env:
-  - PAGEFLOW_RAILS_VERSION=4.2.6 PUBLISH_THEME_DOC=true
+  - PAGEFLOW_RAILS_VERSION=4.2.6 PUBLISH_THEME_DOC=true COVERALLS_PARALLEL=true
 
 services:
   - redis-server
@@ -23,3 +23,6 @@ script:
   - bin/rspec
   - bin/teaspoon
   - bundle exec publish-pageflow-theme-doc
+
+notifications:
+  webhooks: https://coveralls.io/webhook?service_name=travis-ci


### PR DESCRIPTION
Prevent Coveralls from submitting duplicate comments.