### PR TITLE
Remove cargo-culted @body_class

### DIFF
--- a/app/views/layouts/pageflow/application.html.erb
+++ b/app/views/layouts/pageflow/application.html.erb
@@ -20,11 +20,12 @@
 
   <%= render 'layouts/pageflow/ie_include_tags' %>
 </head>
-<%= content_tag :body, :class => [@body_class, 'load_all_images has_no_mobile_platform non_js'].compact.flatten.join(' ') do %>
+
+<body class="load_all_images has_no_mobile_platform non_js">
   <script>
     jQuery('body').removeClass('load_all_images');
     jQuery("body").removeClass('non_js').addClass('js');
   </script>
   <%= yield %>
-<% end %>
+</body>
 <% end %>


### PR DESCRIPTION
content_tag with a nested yield does not work completely, because the
end of the tag is swallowed unless you use `capture` inside the block.

This change replaces the content_tag helper with the regular HTML tag.
Now the </body></html> appears in the page.