### PR TITLE
Update ActiveAdmin to 1.0.pre4

### DIFF
--- a/app/views/pageflow/admin/widgets/_fields.html.erb
+++ b/app/views/pageflow/admin/widgets/_fields.html.erb
@@ -1,5 +1,5 @@
 <% widgets.each do |widget| %>
-  <%= form.semantic_fields_for(widget) do |fields| %>
+  <%= form.semantic_fields_for(widget, builder: ActiveAdmin::FormBuilder) do |fields| %>
     <%= fields.input(:type_name,
                      label: t(widget.role, scope: 'pageflow.widgets.roles'),
                      input_html: {name: "widgets[#{widget.role}]"},

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 4.2.6'
 
   # Framework for admin interface
-  s.add_dependency 'activeadmin', '1.0.0.pre2'
+  s.add_dependency 'activeadmin', '1.0.0.pre4'
 
   # Make devise mailers use resque. (Needs to be below active admin entry!)
   s.add_dependency 'devise-async', '~> 0.9.0'


### PR DESCRIPTION
Fixes most of the remaining deprecation warnings.