### PR TITLE
Improve revisions table on entry admin page

### DIFF
--- a/app/assets/stylesheets/pageflow/admin/entries.scss
+++ b/app/assets/stylesheets/pageflow/admin/entries.scss
@@ -11,7 +11,10 @@
     }
 
     .published td {
-      background-color: $published-color;
+      // scss-lint:disable ImportantRule
+      // Win against overly specific Active Admin rule
+      background-color: $published-color !important;
+      // scss-lint:enable ImportantRule
       color: #000;
     }
   }

--- a/app/views/components/pageflow/admin/embedded_index_table.rb
+++ b/app/views/components/pageflow/admin/embedded_index_table.rb
@@ -8,6 +8,7 @@ module Pageflow
       def build(base_collection, options = {})
         @base_collection = base_collection
         @scopes = []
+        @sort_columns = []
         @blank_slate_text = options[:blank_slate_text]
         super()
       end
@@ -16,15 +17,15 @@ module Pageflow
         scopes << ActiveAdmin::Scope.new(*args)
       end
 
-      def table_for_collection(*args, &block)
+      def table_for_collection(options = {}, &block)
         if scopes.any?
           custom_scopes_renderer(scopes, default_scope: scopes.first.id)
         end
 
-        record_sort_columns(&block)
+        record_sort_columns(&block) if options[:sortable]
 
         if scoped_collection.any?
-          build_table(*args, &block)
+          build_table(options, &block)
         else
           build_blank_slate
         end
@@ -32,10 +33,10 @@ module Pageflow
 
       private
 
-      def build_table(*args, &block)
+      def build_table(options, &block)
         paginated_collection(paginate(apply_sorting(scoped_collection)),
                              download_links: false) do
-          table_for(collection, *args, &block)
+          table_for(collection, options, &block)
         end
       end
 

--- a/spec/views/components/pageflow/admin/embedded_index_table_spec.rb
+++ b/spec/views/components/pageflow/admin/embedded_index_table_spec.rb
@@ -52,7 +52,7 @@ module Pageflow
 
       render do
         embedded_index_table(Entry) do
-          table_for_collection do
+          table_for_collection sortable: true do
             column :id, sortable: true
             column :title, sortable: true
           end
@@ -71,8 +71,8 @@ module Pageflow
 
       render do
         embedded_index_table(Entry) do
-          table_for_collection do
-            column :id, stortable: true
+          table_for_collection sortable: true do
+            column :id, sortable: true
             column :title, sortable: true
           end
         end
@@ -83,12 +83,12 @@ module Pageflow
     end
 
     it 'sorts by first sortable column by default' do
-      create(:entry, title: 'Bbb')
       create(:entry, title: 'Aaa')
+      create(:entry, title: 'Bbb')
 
       render do
-        embedded_index_table(Entry) do
-          table_for_collection do
+        embedded_index_table(Entry.order('title DESC')) do
+          table_for_collection sortable: true do
             column :id, sortable: false
             column :title, sortable: true
           end
@@ -99,22 +99,39 @@ module Pageflow
       expect(titles).to eq(['Aaa', 'Bbb'])
     end
 
+    it 'does not reorder if table is not sortable' do
+      create(:entry, title: 'Bbb')
+      create(:entry, title: 'Aaa')
+
+      render do
+        embedded_index_table(Entry.order('title DESC')) do
+          table_for_collection do
+            column :id, sortable: false
+            column :title, sortable: true
+          end
+        end
+      end
+      titles = Capybara.string(rendered).all('td:last-child').map(&:text)
+
+      expect(titles).to eq(['Bbb', 'Aaa'])
+    end
+
     it 'ignores order parameter not matching sortable column' do
-      create(:user, last_name: 'Bbb')
       create(:user, last_name: 'Aaa')
+      create(:user, last_name: 'Bbb')
 
       params[:order] = 'last_name_desc'
 
       render do
         embedded_index_table(User) do
-          table_for_collection do
-            column :last_name
+          table_for_collection sortable: true do
+            column :last_name, sortable: false
           end
         end
       end
       titles = Capybara.string(rendered).all('td').map(&:text)
 
-      expect(titles).to eq(['Bbb', 'Aaa'])
+      expect(titles).to eq(['Aaa', 'Bbb'])
     end
 
     it 'ignores invalid order parameter' do
@@ -125,7 +142,7 @@ module Pageflow
 
       render do
         embedded_index_table(User) do
-          table_for_collection do
+          table_for_collection sortable: true do
             column :last_name
           end
         end
@@ -143,7 +160,7 @@ module Pageflow
 
       render do
         embedded_index_table(User) do
-          table_for_collection do
+          table_for_collection sortable: true do
             column :id, sortable: true
             column :formal_name, sortable: 'last_name'
           end


### PR DESCRIPTION
* Ensure newest revision is at the top, by preventing embedded index
  table from reordering if table is not sortable
* Highlight published revision