### PR TITLE
extract h2 in various places into a partial

### DIFF
--- a/app/views/pageflow/pages/_page_headers.html.erb
+++ b/app/views/pageflow/pages/_page_headers.html.erb
@@ -1,0 +1,5 @@
+<h2>
+  <span class="tagline"><%= tagline %></span>
+  <span class="title"><%= title %></span>
+  <span class="subtitle"><%= subtitle %></span>
+</h2>

--- a/app/views/pageflow/pages/templates/_audio.html.erb
+++ b/app/views/pageflow/pages/templates/_audio.html.erb
@@ -6,11 +6,10 @@
   </div>
 
   <div class="page_header">
-    <h2>
-      <span class="tagline"><%= configuration['tagline'] %></span>
-      <span class="title"><%= configuration['title'] %></span>
-      <span class="subtitle"><%= configuration['subtitle'] %></span>
-    </h2>
+    <%= render partial: "page_headers", locals: {
+      tagline: configuration['tagline'],
+      title: configuration['title'],
+      subtitle: configuration['subtitle']} %>
     <%= background_image_tag(configuration['background_image_id'], {"class" => "print_image"}) %>
   </div>
 

--- a/app/views/pageflow/pages/templates/_audio_loop.html.erb
+++ b/app/views/pageflow/pages/templates/_audio_loop.html.erb
@@ -7,11 +7,10 @@
   </div>
 
   <div class="page_header">
-    <h2>
-      <span class="tagline"><%= configuration['tagline'] %></span>
-      <span class="title"><%= configuration['title'] %></span>
-      <span class="subtitle"><%= configuration['subtitle'] %></span>
-    </h2>
+    <%= render partial: "page_headers", locals: {
+      tagline: configuration['tagline'],
+      title: configuration['title'],
+      subtitle: configuration['subtitle']} %>
     <%= background_image_tag(configuration['background_image_id'], {:class => "print_image"}) %>
   </div>
 

--- a/app/views/pageflow/pages/templates/_background_image.html.erb
+++ b/app/views/pageflow/pages/templates/_background_image.html.erb
@@ -8,11 +8,10 @@
     <div>
       <div class="contentWrapper">
         <div class="page_header">
-          <h2>
-            <span class="tagline"><%= configuration['tagline'] %></span>
-            <span class="title"><%= configuration['title'] %></span>
-            <span class="subtitle"><%= configuration['subtitle'] %></span>
-          </h2>
+          <%= render partial: "page_headers", locals: {
+            tagline: configuration['tagline'],
+            title: configuration['title'],
+            subtitle: configuration['subtitle']} %>
           <%= background_image_tag(configuration['background_image_id'], {"class" => "print_image"}) %>
         </div>
         <div class="contentText">

--- a/app/views/pageflow/pages/templates/_background_video.html.erb
+++ b/app/views/pageflow/pages/templates/_background_video.html.erb
@@ -16,11 +16,10 @@
     <div>
       <div class="contentWrapper">
         <div class="page_header">
-          <h2>
-            <span class="tagline"><%= configuration['tagline'] %></span>
-            <span class="title"><%= configuration['title'] %></span>
-            <span class="subtitle"><%= configuration['subtitle'] %></span>
-          </h2>
+          <%= render partial: "page_headers", locals: {
+            tagline: configuration['tagline'],
+            title: configuration['title'],
+            subtitle: configuration['subtitle']} %>
           <%= poster_image_tag(configuration['video_file_id'], configuration['poster_image_id'], {:class => "print_image"}) %>
         </div>
         <div class="contentText">

--- a/app/views/pageflow/pages/templates/_video.html.erb
+++ b/app/views/pageflow/pages/templates/_video.html.erb
@@ -1,11 +1,10 @@
 <div class="blackLayer"></div>
 <div class="content_and_background videoPage">
   <div class="page_header">
-    <h2>
-      <span class="tagline"><%= configuration['tagline'] %></span>
-      <span class="title"><%= configuration['title'] %></span>
-      <span class="subtitle"><%= configuration['subtitle'] %></span>
-    </h2>
+    <%= render partial: "page_headers", locals: {
+      tagline: configuration['tagline'],
+      title: configuration['title'],
+      subtitle: configuration['subtitle']} %>
     <%= poster_image_tag(configuration['video_file_id'], configuration['poster_image_id'], {:class => "print_image"}) %>
   </div>
   <div class="backgroundArea">


### PR DESCRIPTION
We've been having some pain in styling the separate elements in this h2.

Ideally we would like to change the markup into:

```
h3.tagline
h1.title
h2.subtitle
```

which would be more semantically correct and easier to style as block elements.

Extracting the duplicated code into a partial would give us a way to easily override just this partial. But implementing more semantic markup instead of the one big `h2` would be cool with me too.
