### PR TITLE
Add option to skip smil output

### DIFF
--- a/config/initializers/zencoder.rb
+++ b/config/initializers/zencoder.rb
@@ -12,6 +12,7 @@ Pageflow.after_global_configure do |config|
   Pageflow::ZencoderOutputDefinition.default_akamai_host = zencoder_options[:akamai_host]
   Pageflow::ZencoderOutputDefinition.default_akamai_credentials = zencoder_options[:akamai_credentials]
   Pageflow::ZencoderVideoOutputDefinition.skip_hls = zencoder_options.fetch(:skip_hls, false)
+  Pageflow::ZencoderVideoOutputDefinition.skip_smil = zencoder_options.fetch(:skip_hls, false)
 
   raise "Missing s3_host_alias option in Pageflow.config.zencoder_options." unless zencoder_options.has_key?(:s3_host_alias)
   raise "Missing s3_protocol option in Pageflow.config.zencoder_options." unless zencoder_options.has_key?(:s3_protocol)

--- a/lib/pageflow/zencoder_video_output_definition.rb
+++ b/lib/pageflow/zencoder_video_output_definition.rb
@@ -1,6 +1,6 @@
 module Pageflow
   class ZencoderVideoOutputDefinition < ZencoderOutputDefinition
-    cattr_accessor :skip_hls
+    cattr_accessor :skip_hls, :skip_smil
 
     attr_reader :video_file
 
@@ -22,7 +22,7 @@ module Pageflow
         transferable(mp4_low_definition),
 
         hls_definitions,
-        non_transferable(smil_definition),
+        smil_definition,
 
         thumbnails_definitions
       ].flatten
@@ -184,13 +184,14 @@ module Pageflow
     end
 
     def smil_definition
-      {
-        :streams => smil_stream_definitions,
-        :type => 'playlist',
-        :format => 'highwinds',
-        :path =>  video_file.smil.path,
-        :public => true
-      }
+      return [] if skip_smil
+      non_transferable(
+        streams: smil_stream_definitions,
+        type: 'playlist',
+        format: 'highwinds',
+        path: video_file.smil.path,
+        public: true
+      )
     end
 
     def smil_stream_definitions
@@ -204,8 +205,8 @@ module Pageflow
           :bandwidth => 256
         },
         {
-          :path => video_file.mp4_high.url(host: :hls_origin, default_protocol: 'http'),
-          :bandwidth => 3750
+          path: video_file.mp4_high.url(host: :hls_origin, default_protocol: 'http'),
+          bandwidth: 3750
         }
       ]
     end

--- a/spec/pageflow/zencoder_video_output_definition_spec.rb
+++ b/spec/pageflow/zencoder_video_output_definition_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+module Pageflow
+  describe ZencoderVideoOutputDefinition do
+    describe '#outputs' do
+      it 'contains all definitions per default' do
+        video_file = build(:video_file)
+        definition = ZencoderVideoOutputDefinition.new(video_file)
+
+        expect(definition).to have_output.to_s3(video_file.webm_high.path)
+        expect(definition).to have_output.to_s3(video_file.webm_medium.path)
+        expect(definition).to have_output.to_s3(video_file.mp4_high.path)
+        expect(definition).to have_output.to_s3(video_file.mp4_medium.path)
+        expect(definition).to have_output.to_s3(video_file.mp4_low.path)
+        expect(definition).to have_output.to_s3(video_file.hls_low.path)
+        expect(definition).to have_output.to_s3(video_file.hls_medium.path)
+        expect(definition).to have_output.to_s3(video_file.hls_high.path)
+        expect(definition).to have_output.to_s3(video_file.hls_playlist.path)
+        expect(definition).to have_output.to_s3(video_file.smil.path)
+      end
+
+      it 'skips hls definitions if set to do so' do
+        video_file = build(:video_file)
+        definition = ZencoderVideoOutputDefinition.new(video_file)
+        definition.skip_hls = true
+
+        expect(definition).to have_output.to_s3(video_file.webm_high.path)
+        expect(definition).to have_output.to_s3(video_file.webm_medium.path)
+        expect(definition).to have_output.to_s3(video_file.mp4_high.path)
+        expect(definition).to have_output.to_s3(video_file.mp4_medium.path)
+        expect(definition).to have_output.to_s3(video_file.mp4_low.path)
+        expect(definition).not_to have_output.to_s3(video_file.hls_low.path)
+        expect(definition).not_to have_output.to_s3(video_file.hls_medium.path)
+        expect(definition).not_to have_output.to_s3(video_file.hls_high.path)
+        expect(definition).not_to have_output.to_s3(video_file.hls_playlist.path)
+        expect(definition).to have_output.to_s3(video_file.smil.path)
+      end
+
+      it 'skips smil definitions if set to do so' do
+        video_file = build(:video_file)
+        definition = ZencoderVideoOutputDefinition.new(video_file)
+        definition.skip_smil = true
+
+        expect(definition).to have_output.to_s3(video_file.webm_high.path)
+        expect(definition).to have_output.to_s3(video_file.webm_medium.path)
+        expect(definition).to have_output.to_s3(video_file.mp4_high.path)
+        expect(definition).to have_output.to_s3(video_file.mp4_medium.path)
+        expect(definition).to have_output.to_s3(video_file.mp4_low.path)
+        expect(definition).to have_output.to_s3(video_file.hls_low.path)
+        expect(definition).to have_output.to_s3(video_file.hls_medium.path)
+        expect(definition).to have_output.to_s3(video_file.hls_high.path)
+        expect(definition).to have_output.to_s3(video_file.hls_playlist.path)
+        expect(definition).not_to have_output.to_s3(video_file.smil.path)
+      end
+    end
+  end
+end

--- a/spec/support/matchers/have_output.rb
+++ b/spec/support/matchers/have_output.rb
@@ -1,0 +1,15 @@
+RSpec::Matchers.define :have_output do
+  chain :to_s3 do |path|
+    @s3_url = path.prepend('s3://com-example-pageflow-out')
+  end
+  match do |definition|
+    definition.outputs.detect { |output| output[:url] == @s3_url }.try(:any?)
+  end
+  failure_message do
+    urls = definition.outputs.map { |output| output[:url] }
+    "expected to find URL #{@s3_url} in output URLs #{urls}."
+  end
+  failure_message_when_negated do
+    "expected to not find URL #{@s3_url} in output URLs, but found it."
+  end
+end


### PR DESCRIPTION
Additionally, test for all generated outputs, depending on flags
skip_hls and skip_smil.

fixes #536