### PR TITLE
Allow setting hide text related css classes on wrapper

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/hidden_text_indicator_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/hidden_text_indicator_widget.js
@@ -5,10 +5,12 @@
           that = this;
 
       parent.on('pageactivate', function(event) {
+        var pageOrPageWrapper = $(event.target).add('.content_and_background', event.target);
+
         that.element.toggleClass('invert', $(event.target).hasClass('invert'));
         that.element.toggleClass('hidden',
-                                 $(event.target).hasClass('hide_content_with_text') ||
-                                 $(event.target).hasClass('no_hidden_text_indicator'));
+                                 pageOrPageWrapper.hasClass('hide_content_with_text') ||
+                                 pageOrPageWrapper.hasClass('no_hidden_text_indicator'));
       });
 
       parent.on('hidetextactivate', function() {


### PR DESCRIPTION
So far the css classes `hide_content_with_text` and
`no_hidden_text_indicator` had to be present on the page's `section`
element. Allowing them also on the `.content_and_background` wrapper
element makes things much easer to control for page types since that
element is rendered by them.