### PR TITLE
Fix page widget index for analytics adapters

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/lazy_page_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/lazy_page_widget.js
@@ -5,6 +5,7 @@
   var prototype = {
     _create: function() {
       this.configuration = this.element.data('configuration') || this.options.configuration;
+      this.index = this.options.index;
     },
 
     _ensureCreated: function() {


### PR DESCRIPTION
The page widget sets an index property during initialization. This is
used by analytics adapters to create page names of the form
"<index>-<page_title>". While creating the lazy loading page widget
wrapper, this property must have been forgotten. Ensure it is also set
on the wrapper widget.