### PR TITLE
File filters

### DIFF
--- a/app/assets/javascripts/pageflow/editor/api.js
+++ b/app/assets/javascripts/pageflow/editor/api.js
@@ -9,7 +9,9 @@
 pageflow.EditorApi = pageflow.Object.extend(
 /** @lends module:pageflow/editor.pageflow.editor */{
 
-  initialize: function() {
+  initialize: function(options) {
+    this.router = options && options.router;
+
     this.sideBarRoutings = [];
     this.mainMenuItems = [];
     this.initializers = [];
@@ -104,7 +106,11 @@ pageflow.EditorApi = pageflow.Object.extend(
    * Navigate to the given path.
    */
   navigate: function(path, options) {
-    editor.navigate(path, options);
+    if (!this.router) {
+      throw 'Routing has not been initialized yet.';
+    }
+
+    this.router.navigate(path, options);
   },
 
   /**
@@ -154,12 +160,40 @@ pageflow.EditorApi = pageflow.Object.extend(
    * Trigger selection of the given file type with the given
    * handler. Payload hash is passed to selection handler as options.
    *
-   * Example:
+   * @param {string|{name: string, filter: string}} fileType
+   *   Either collection name of a file type or and object containing
+   *   the collection name a file type and a the name of a file type
+   *   filter.
    *
-   *     pageflow.editor.selectFile('image_files', 'my_file_selection_handler', {some: 'option for handler'});
+   * @param {string} handlerName
+   *   The name of a handler registered via {@link
+   *   module:pageflow/editor.pageflow.editor.registerFileSelectionHandler}.
+   *
+   * @param {Object} payload
+   *   Options passed to the file selection handler.
+   *
+   * @example
+   *
+   * pageflow.editor.selectFile('image_files',
+   *                            'my_file_selection_handler',
+   *                            {some: 'option for handler'});
+   *
+   * pageflow.editor.selectFile({name: 'image_files', filter: 'some_filter'},
+   *                            'my_file_selection_handler',
+   *                            {some: 'option for handler'});
    */
   selectFile: function(fileType, handlerName, payload) {
-    this.navigate('/files/' + fileType + '?handler=' + handlerName + '&payload=' + encodeURIComponent(JSON.stringify(payload)), {trigger: true});
+    if (typeof fileType === 'string') {
+      fileType = {
+        name: fileType
+      };
+    }
+
+    this.navigate('/files/' + fileType.name +
+                  '?handler=' + handlerName +
+                  '&payload=' + encodeURIComponent(JSON.stringify(payload)) +
+                  (fileType.filter ? '&filter=' + fileType.filter : ''),
+                  {trigger: true});
   },
 
   /**

--- a/app/assets/javascripts/pageflow/editor/api/file_type.js
+++ b/app/assets/javascripts/pageflow/editor/api/file_type.js
@@ -11,6 +11,7 @@ pageflow.FileType = pageflow.Object.extend({
     this.configurationEditorInputs = [].concat(options.configurationEditorInputs || []);
     this.configurationUpdaters = options.configurationUpdaters || [];
     this.metaDataAttributes = options.metaDataAttributes || [];
+    this.filters = options.filters || [];
 
     this.settingsDialogTabs = [
       {
@@ -38,5 +39,17 @@ pageflow.FileType = pageflow.Object.extend({
     this.model.prototype.modelName = this.model.prototype.modelName || this.paramKey;
     this.model.prototype.paramRoot = this.model.prototype.paramRoot || this.paramKey;
     this.model.prototype.i18nKey = this.model.prototype.i18nKey || this.i18nKey;
+  },
+
+  getFilter: function(name) {
+    var result =  _(this.filters).find(function(filter) {
+      return filter.name === name;
+    });
+
+    if (!result) {
+      throw new Error('Unknown filter "' + name + '" for file type "' + this.collectionName + '".');
+    }
+
+    return result;
   }
 });

--- a/app/assets/javascripts/pageflow/editor/api/file_types.js
+++ b/app/assets/javascripts/pageflow/editor/api/file_types.js
@@ -2,7 +2,8 @@ pageflow.FileTypes = pageflow.Object.extend({
   modifyableProperties: [
     'configurationEditorInputs',
     'configurationUpdaters',
-    'confirmUploadTableColumns'
+    'confirmUploadTableColumns',
+    'filters'
   ],
 
   initialize: function() {

--- a/app/assets/javascripts/pageflow/editor/collections/files_collection.js
+++ b/app/assets/javascripts/pageflow/editor/collections/files_collection.js
@@ -51,6 +51,15 @@ pageflow.FilesCollection = Backbone.Collection.extend({
       });
 
     return this._uploadableSubsetCollection;
+  },
+
+  withFilter: function(filterName) {
+    return new pageflow.SubsetCollection({
+      parent: this,
+      watchAttribute: 'configuration',
+
+      filter: this.fileType.getFilter(filterName).matches,
+    });
   }
 });
 

--- a/app/assets/javascripts/pageflow/editor/collections/subset_collection.js
+++ b/app/assets/javascripts/pageflow/editor/collections/subset_collection.js
@@ -55,5 +55,10 @@ pageflow.SubsetCollection = Backbone.Collection.extend({
 
   url: function() {
     return this.parentModel.url() + _.result(this.parent, 'url');
+  },
+
+  dispose: function() {
+    this.stopListening();
+    this.reset();
   }
 });

--- a/app/assets/javascripts/pageflow/editor/controllers/sidebar_controller.js
+++ b/app/assets/javascripts/pageflow/editor/controllers/sidebar_controller.js
@@ -11,11 +11,12 @@ pageflow.SidebarController = Backbone.Marionette.Controller.extend({
     }));
   },
 
-  files: function(collectionName, handler, payload) {
+  files: function(collectionName, handler, payload, filterName) {
     this.region.show(new pageflow.FilesView({
       model: this.entry,
       selectionHandler: handler && pageflow.editor.createFileSelectionHandler(handler, payload),
-      tabName: collectionName
+      tabName: collectionName,
+      filterName: filterName
     }));
 
     pageflow.editor.setDefaultHelpEntry('pageflow.help_entries.files');

--- a/app/assets/javascripts/pageflow/editor/initializers/routing.js
+++ b/app/assets/javascripts/pageflow/editor/initializers/routing.js
@@ -8,10 +8,12 @@ pageflow.app.addInitializer(function() {
     });
   });
 
-  window.editor = new pageflow.SidebarRouter({
+  pageflow.editor.router = new pageflow.SidebarRouter({
     controller: new pageflow.SidebarController({
       region: pageflow.app.sidebarRegion,
       entry: pageflow.entry
     })
   });
+
+  window.editor = pageflow.editor.router;
 });

--- a/app/assets/javascripts/pageflow/editor/routers/sidebar_router.js
+++ b/app/assets/javascripts/pageflow/editor/routers/sidebar_router.js
@@ -6,6 +6,7 @@ pageflow.SidebarRouter = Backbone.Marionette.AppRouter.extend({
     'chapters/:id': 'chapter',
     'storylines/:id': 'storyline',
 
+    'files/:collectionName?handler=:handler&payload=:payload&filter=:filter': 'files',
     'files/:collectionName?handler=:handler&payload=:payload': 'files',
     'files/:collectionName': 'files',
     'files': 'files',

--- a/app/assets/javascripts/pageflow/editor/templates/files_blank_slate.jst.ejs
+++ b/app/assets/javascripts/pageflow/editor/templates/files_blank_slate.jst.ejs
@@ -1,1 +1,1 @@
-<li class="blank_slate"><%= I18n.t('pageflow.editor.templates.files_blank_slate.no_files') %><li>
+<li class="blank_slate"><%= text %><li>

--- a/app/assets/javascripts/pageflow/editor/templates/filtered_files.jst.ejs
+++ b/app/assets/javascripts/pageflow/editor/templates/filtered_files.jst.ejs
@@ -1,0 +1,10 @@
+<div class="filtered_files-banner">
+  <span class="filtered_files-banner_prefix">
+    <%= I18n.t('pageflow.editor.views.filtered_files_view.banner_prefix') %>
+  </span>
+  <span class="filtered_files-filter_name"></span>
+  <a href=""
+     class="filtered_files-reset_filter"
+     title="<%= I18n.t('pageflow.editor.views.filtered_files_view.reset_filter') %>">
+  </a>
+</div>

--- a/app/assets/javascripts/pageflow/editor/views/file_item_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/file_item_view.js
@@ -70,6 +70,10 @@ pageflow.FileItemView = Backbone.Marionette.ItemView.extend({
   },
 
   update: function() {
+    if (this.isClosed) {
+      return;
+    }
+
     this.$el.attr('data-id', this.model.id);
     this.ui.fileName.text(this.model.get('file_name') || '(Unbekannt)');
 

--- a/app/assets/javascripts/pageflow/editor/views/files_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/files_view.js
@@ -43,19 +43,14 @@ pageflow.FilesView = Backbone.Marionette.ItemView.extend({
   },
 
   tab: function(fileType) {
+    var selectionMode = this.options.tabName === fileType.collectionName;
+
     this.tabsView.tab(fileType.collectionName, _.bind(function() {
-      return this.subview(new pageflow.CollectionView({
-        tagName: 'ul',
-        className: 'files expandable',
-        collection: pageflow.entry.getFileCollection(fileType),
-        itemViewConstructor: pageflow.FileItemView,
-        itemViewOptions: {
-          metaDataAttributes: fileType.metaDataAttributes,
-          selectionHandler: this.options.tabName === fileType.collectionName && this.options.selectionHandler
-        },
-        blankSlateViewConstructor: Backbone.Marionette.ItemView.extend({
-          template: 'templates/files_blank_slate'
-        })
+      return this.subview(new pageflow.FilteredFilesView({
+        entry: pageflow.entry,
+        fileType: fileType,
+        selectionHandler: selectionMode && this.options.selectionHandler,
+        filterName: selectionMode && this.options.filterName
       }));
     }, this));
 

--- a/app/assets/javascripts/pageflow/editor/views/filtered_files_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/filtered_files_view.js
@@ -18,6 +18,7 @@ pageflow.FilteredFilesView = Backbone.Marionette.ItemView.extend({
     var entry = this.options.entry;
     var fileType = this.options.fileType;
     var collection = entry.getFileCollection(fileType);
+    var blankSlateText = I18n.t('pageflow.editor.templates.files_blank_slate.no_files');
 
     if (this.options.filterName) {
       if (this.filteredCollection) {
@@ -25,6 +26,7 @@ pageflow.FilteredFilesView = Backbone.Marionette.ItemView.extend({
       }
 
       collection = this.filteredCollection = collection.withFilter(this.options.filterName);
+      blankSlateText = this.filterTranslation('blank_slate');
     }
 
     this.appendSubview(new pageflow.CollectionView({
@@ -37,22 +39,32 @@ pageflow.FilteredFilesView = Backbone.Marionette.ItemView.extend({
         selectionHandler: this.options.selectionHandler,
       },
       blankSlateViewConstructor: Backbone.Marionette.ItemView.extend({
-        template: 'templates/files_blank_slate'
+        template: 'templates/files_blank_slate',
+        serializeData: function(){
+          return {
+            text: blankSlateText
+          };
+        }
       })
     }));
 
     this.ui.banner.toggle(!!this.options.filterName);
 
     if (this.options.filterName) {
-      this.ui.filterName.text(this.filterDisplayName(this.options.filterName));
+      this.ui.filterName.text(this.filterTranslation('name'));
     }
   },
 
-  filterDisplayName: function(name) {
+  filterTranslation: function(keyName, options) {
+    var filterName = this.options.filterName;
+
     return pageflow.i18nUtils.findTranslation([
-      'pageflow.editor.files.filters.' + this.options.fileType.collectionName + '.' + name,
-      'pageflow.editor.files.common_filters.' + name,
-    ]);
+      'pageflow.editor.files.filters.' +
+        this.options.fileType.collectionName + '.' +
+        filterName + '.' +
+        keyName,
+      'pageflow.editor.files.common_filters.' + keyName
+    ], options);
   },
 
   onClose: function() {

--- a/app/assets/javascripts/pageflow/editor/views/filtered_files_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/filtered_files_view.js
@@ -1,0 +1,63 @@
+pageflow.FilteredFilesView = Backbone.Marionette.ItemView.extend({
+  template: 'templates/filtered_files',
+  className: 'filtered_files',
+
+  ui: {
+    banner: '.filtered_files-banner',
+    filterName: '.filtered_files-filter_name'
+  },
+
+  events: {
+    'click .filtered_files-reset_filter': function() {
+      pageflow.editor.navigate('/files/' + this.options.fileType.collectionName, {trigger: true});
+      return false;
+    }
+  },
+
+  onRender: function() {
+    var entry = this.options.entry;
+    var fileType = this.options.fileType;
+    var collection = entry.getFileCollection(fileType);
+
+    if (this.options.filterName) {
+      if (this.filteredCollection) {
+        this.filteredCollection.dispose();
+      }
+
+      collection = this.filteredCollection = collection.withFilter(this.options.filterName);
+    }
+
+    this.appendSubview(new pageflow.CollectionView({
+      tagName: 'ul',
+      className: 'files expandable',
+      collection: collection,
+      itemViewConstructor: pageflow.FileItemView,
+      itemViewOptions: {
+        metaDataAttributes: fileType.metaDataAttributes,
+        selectionHandler: this.options.selectionHandler,
+      },
+      blankSlateViewConstructor: Backbone.Marionette.ItemView.extend({
+        template: 'templates/files_blank_slate'
+      })
+    }));
+
+    this.ui.banner.toggle(!!this.options.filterName);
+
+    if (this.options.filterName) {
+      this.ui.filterName.text(this.filterDisplayName(this.options.filterName));
+    }
+  },
+
+  filterDisplayName: function(name) {
+    return pageflow.i18nUtils.findTranslation([
+      'pageflow.editor.files.filters.' + this.options.fileType.collectionName + '.' + name,
+      'pageflow.editor.files.common_filters.' + name,
+    ]);
+  },
+
+  onClose: function() {
+    if (this.filteredCollection) {
+      this.filteredCollection.dispose();
+    }
+  }
+});

--- a/app/assets/javascripts/pageflow/editor/views/inputs/file_input_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/inputs/file_input_view.js
@@ -20,7 +20,10 @@ pageflow.FileInputView = Backbone.Marionette.ItemView.extend({
   events: {
     'click .choose': function() {
       pageflow.editor.selectFile(
-        this.options.collection.name,
+        {
+          name: this.options.collection.name,
+          filter: this.options.filter
+        },
         this.options.fileSelectionHandler || 'pageConfiguration',
         _.extend({
           id: this.model.getRoutableId ? this.model.getRoutableId() : this.model.id,

--- a/app/assets/stylesheets/pageflow/editor/base.scss
+++ b/app/assets/stylesheets/pageflow/editor/base.scss
@@ -62,6 +62,7 @@
   @import "./files";
   @import "./confirm_encoding";
   @import "./files_gallery";
+  @import "./filtered_files";
   @import "./file_meta_data";
   @import "./file_stages";
   @import "./file_thumbnails";

--- a/app/assets/stylesheets/pageflow/editor/filtered_files.scss
+++ b/app/assets/stylesheets/pageflow/editor/filtered_files.scss
@@ -1,0 +1,25 @@
+.filtered_files {
+  position: relative;
+
+  &-banner {
+    display: block;
+    padding: 7px 10px;
+    margin: 0 -10px;
+    background-color: #f9f1b7;
+    border-top: solid 1px #e4dc9d;
+    border-bottom: solid 1px #e4dc9d;
+  }
+
+  &-filter_name {
+    font-weight: bold;
+  }
+
+  &-reset_filter {
+    @include background-icon-center;
+    @include cancel-icon;
+
+    position: absolute;
+    right: 7px;
+    top: 15px;
+  }
+}

--- a/config/locales/new/file_filters.de.yml
+++ b/config/locales/new/file_filters.de.yml
@@ -1,0 +1,6 @@
+de:
+  pageflow:
+    editor:
+      views:
+        filtered_files_view:
+          banner_prefix: "Aktiver Filter:"

--- a/spec/javascripts/api_spec.js
+++ b/spec/javascripts/api_spec.js
@@ -1,0 +1,42 @@
+describe('pageflow.EditorApi', function() {
+  describe('#selectFile', function() {
+    it('navigates to files route for file type given as string', function() {
+      var router = fakeRouter();
+      var api = new pageflow.EditorApi({router: router});
+
+      api.selectFile('image_files', 'some_handler');
+
+      expect(router.navigate).to.have.been.calledWith(
+        sinon.match('/files/image_files').and(sinon.match('handler=some_handler'))
+      );
+    });
+
+    it('navigates to files route for file type given as object', function() {
+      var router = fakeRouter();
+      var api = new pageflow.EditorApi({router: router});
+
+      api.selectFile({name: 'image_files', filter: 'large'}, 'some_handler');
+
+      expect(router.navigate).to.have.been.calledWith(
+        sinon.match('/files/image_files')
+          .and(sinon.match('handler=some_handler'))
+          .and(sinon.match('filter=large'))
+      );
+    });
+
+    it('passes payload as serialized string', function() {
+      var router = fakeRouter();
+      var api = new pageflow.EditorApi({router: router});
+
+      api.selectFile('image_files', 'some_handler', {some: 'payload'});
+
+      expect(router.navigate).to.have.been.calledWith(
+        sinon.match('payload=%7B%22some%22%3A%22payload%22%7D')
+      );
+    });
+
+    function fakeRouter() {
+      return {navigate: sinon.spy()};
+    }
+  });
+});

--- a/spec/javascripts/collections/files_collection_spec.js
+++ b/spec/javascripts/collections/files_collection_spec.js
@@ -52,6 +52,36 @@ describe('FileCollection', function() {
     });
   });
 
+  describe('#withFilter', function() {
+    it('always contains subset of files matching given filter', function() {
+      var fileType = f.fileType({
+        filters: [
+          {
+            name: 'with_custom_field',
+            matches: function(file) {
+              return !!file.configuration.get('custom');
+            }
+          }
+        ]
+      });
+      var files = [
+        {
+          file_name: 'image.png'
+        },
+        {
+          file_name: 'other.png'
+        }
+      ];
+      var entry = {};
+      var collection = pageflow.FilesCollection.createForFileType(fileType, files, {entry: entry});
+
+      var uploadableFiles = collection.withFilter('with_custom_field');
+      collection.first().configuration.set('custom', 'some value');
+
+      expect(uploadableFiles.length).to.eq(1);
+    });
+  });
+
   describe('#fetch', function() {
     it('sets file type on fetched file models', function() {
       var fileType = f.fileType();


### PR DESCRIPTION
* Let file types define named filter functions that can be applied to
  the list of files.

* Extend `selectFile` API function to accept options object which
  contains file selection handler name and filter name.

* Extract `FilteredFilesView` from `FilesView` which applies the
  specified filter to the list and displays a banner with a link to
  display the complete list again.

* Add options `FileInputView` to specify a filter name for file
  selection.

* Allow displaying a custom text when no files match the active filter.