### PR TITLE
Backport: Fix sharing menu in mobile navigation

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/navigation_mobile.js
+++ b/app/assets/javascripts/pageflow/widgets/navigation_mobile.js
@@ -43,6 +43,7 @@
         var sharingMobile = $(this).parents('.sharing_mobile');
 
         scroller = new IScroll(this, {
+          preventDefault: false,
           mouseWheel: true,
           bounce: false,
           probeType: 3


### PR DESCRIPTION
Scroller in mobile should not prevent default. Preventing default on
`touchstart` causes `click` events not to be fired which made it
impossible to expand sharing menu items.

Since native scrolling is prevented for the mobile navigation anyway,
the option can be disabled.

Backport of #661