### PR TITLE
Fix video loop on Safari 10 on El Capitan.

### DIFF
--- a/app/assets/javascripts/pageflow/browser/agent.js
+++ b/app/assets/javascripts/pageflow/browser/agent.js
@@ -11,8 +11,20 @@ pageflow.browser.agent = {
     return this.matchesSafari9() && !this.matchesMobilePlatform();
   },
 
+  matchesDesktopSafari10: function() {
+    return this.matchesSafari10() && !this.matchesMobilePlatform();
+  },
+
   matchesSafari9: function() {
     var matchers = [/Safari\//i, /Version\/9/i];
+
+    return _.all(matchers, function(matcher) {
+      return navigator.userAgent.match(matcher);
+    });
+  },
+
+  matchesSafari10: function() {
+    var matchers = [/Safari\//i, /Version\/10/i];
 
     return _.all(matchers, function(matcher) {
       return navigator.userAgent.match(matcher);

--- a/app/assets/javascripts/pageflow/browser/video.js
+++ b/app/assets/javascripts/pageflow/browser/video.js
@@ -18,6 +18,9 @@ pageflow.browser.feature('prebuffering support', function(has) {
 pageflow.browser.feature('mp4 support only', function(has) {
   // - Silk does not play videos with hls source
   // - Desktop Safari 9.1 does not loop hls videos
+  // - Desktop Safari 10 does not loop hls videos on El
+  //   Capitan. Appears to be fixed on Sierra
   return pageflow.browser.agent.matchesSilk() ||
-    pageflow.browser.agent.matchesDesktopSafari9();
+    pageflow.browser.agent.matchesDesktopSafari9() ||
+    pageflow.browser.agent.matchesDesktopSafari10();
 });


### PR DESCRIPTION
Already Safari 9 failed to loop hls videos. While Safari 10 on Sierra
appears to be fixed, Safari 10 on El Capitan still has the
problem. Since there is no obvious way to detect El Capitan/Sierra,
apply the fix to both browser versions.

Backport of #663 