### PR TITLE
Fix css class collision in widget scroll indicators

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/navigation.js
+++ b/app/assets/javascripts/pageflow/widgets/navigation.js
@@ -23,7 +23,7 @@
         $('li.mute', element).hide();
         $('.navigation_bar_bottom', element).css('height', '224px');
         $('.scroller', element).css('bottom', '224px');
-        $('.scroll_indicator.bottom', element).css('bottom', '190px');
+        $('.navigation_scroll_indicator.bottom', element).css('bottom', '190px');
       }
 
       /* header button */
@@ -105,14 +105,14 @@
 
       var initiateIndicators = function() {
         setTimeout(function() {
-          $('.scroll_indicator', element).show();
+          $('.navigation_scroll_indicator', element).show();
           toggleIndicators();
         }, 500);
       };
 
       $('.scroller', element).each(function () {
-        var bottomIndicator = $('.scroll_indicator.bottom', element),
-          topIndicator = $('.scroll_indicator.top', element),
+        var bottomIndicator = $('.navigation_scroll_indicator.bottom', element),
+          topIndicator = $('.navigation_scroll_indicator.top', element),
           scrollUpIntervalID, scrollDownIntervalID,
           hideOverlay = function () {
             overlays.addClass('hidden').removeClass('visible');
@@ -255,7 +255,7 @@
       /* fullscreen button */
       $('.navigation_bar_bottom .fullscreen a', element).fullscreenButton();
 
-      $('.button, .navigation_mute, .scroll_indicator', element).on({
+      $('.button, .navigation_mute, .navigation_scroll_indicator', element).on({
         'touchstart mousedown': function() {
           $(this).addClass('pressed');
         },

--- a/app/assets/javascripts/pageflow/widgets/overview.js
+++ b/app/assets/javascripts/pageflow/widgets/overview.js
@@ -66,13 +66,13 @@ jQuery(function($) {
           scrollToActive: '.ov_chapter'
         });
 
-        this.element.find('.scroll_indicator.left').scrollButton({
+        this.element.find('.overview_scroll_indicator.left').scrollButton({
           scroller: scroller,
           page: true,
           direction: 'left'
         });
 
-        this.element.find('.scroll_indicator.right').scrollButton({
+        this.element.find('.overview_scroll_indicator.right').scrollButton({
           scroller: scroller,
           page: true,
           direction: 'right'

--- a/app/assets/stylesheets/pageflow/navigation_bar.scss
+++ b/app/assets/stylesheets/pageflow/navigation_bar.scss
@@ -218,7 +218,7 @@
       width: auto;
     }
 
-    a.scroll_indicator {
+    a.navigation_scroll_indicator {
       opacity: 0;
       visibility: hidden;
       @include transition(opacity 0.2s linear, visibility 0.2s);

--- a/app/assets/stylesheets/pageflow/overview.scss
+++ b/app/assets/stylesheets/pageflow/overview.scss
@@ -33,7 +33,7 @@
     @include transform(translate(0, 0));
   }
 
-  .scroll_indicator {
+  .overview_scroll_indicator {
     position: absolute;
     bottom: 0;
     z-index: 1;

--- a/app/assets/stylesheets/pageflow/themes/default/navigation/dimensions.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/navigation/dimensions.scss
@@ -52,7 +52,7 @@ $scroll-indicator-offset: 35px;
     bottom: $bottom-height;
   }
 
-  .scroll_indicator {
+  .navigation_scroll_indicator {
     height: $scroll-indicator-height;
 
     &.bottom {
@@ -69,7 +69,7 @@ $scroll-indicator-offset: 35px;
       top: $top-height + $item-height;
     }
 
-    .scroll_indicator.top {
+    .navigation_scroll_indicator.top {
       top: $top-height + $item-height - $scroll-indicator-offset;
     }
   }

--- a/app/assets/stylesheets/pageflow/themes/default/navigation/icons/icon_font.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/navigation/icons/icon_font.scss
@@ -101,7 +101,7 @@
       height: auto;
     }
 
-    .scroll_indicator {
+    .navigation_scroll_indicator {
       @include background-icon-center($font-size: 25px, $color: $scroll-indicator-color);
       font-weight: bold;
       position: absolute;

--- a/app/assets/stylesheets/pageflow/themes/default/navigation/icons/sprite.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/navigation/icons/sprite.scss
@@ -10,17 +10,17 @@
     height: 42px;
   }
 
-  .scroll_indicator {
+  .navigation_scroll_indicator {
     @extend %pageflow_sprite_icon;
     width: 45px;
     right: 20px;
   }
 
-  .scroll_indicator.top {
+  .navigation_scroll_indicator.top {
     @include pageflow-sprite-icon-arrow-up($offset: -5px);
   }
 
-  .scroll_indicator.bottom {
+  .navigation_scroll_indicator.bottom {
     @include pageflow-sprite-icon-arrow-down($offset: -5px);
   }
 

--- a/app/assets/stylesheets/pageflow/themes/default/overview/icons/icon_font.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/overview/icons/icon_font.scss
@@ -29,7 +29,7 @@
     }
   }
 
-  .scroll_indicator {
+  .overview_scroll_indicator {
     &:before {
       font-weight: bold;
       font-size: 29px;

--- a/app/assets/stylesheets/pageflow/themes/default/overview/icons/sprite.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/overview/icons/sprite.scss
@@ -13,7 +13,7 @@
     }
   }
 
-  .scroll_indicator {
+  .overview_scroll_indicator {
     &.left {
       @include pageflow-sprite-icon-arrow-left;
     }

--- a/app/assets/stylesheets/pageflow/themes/legacy/navigation.scss
+++ b/app/assets/stylesheets/pageflow/themes/legacy/navigation.scss
@@ -161,12 +161,12 @@ $nav-color: #9c9c9c;
       top: 224px;
     }
 
-    .scroll_indicator.top {
+    .navigation_scroll_indicator.top {
       top: 189px;
     }
   }
 
-  a.scroll_indicator {
+  a.navigation_scroll_indicator {
     $normal-offset: -14px;
     $hover-offset: -115px;
     $pressed-offset: -64px;

--- a/app/views/pageflow/entries/navigation/_bar_bottom.html.erb
+++ b/app/views/pageflow/entries/navigation/_bar_bottom.html.erb
@@ -1,4 +1,4 @@
-<a class="scroll_indicator bottom" tabindex="2">
+<a class="navigation_scroll_indicator bottom" tabindex="2">
   <span class="hint"><%= t('pageflow.public.scroll_down') %></span>
 </a>
 <ul class="navigation_bar_bottom">

--- a/app/views/pageflow/entries/navigation/_bar_top.html.erb
+++ b/app/views/pageflow/entries/navigation/_bar_top.html.erb
@@ -38,6 +38,6 @@
     </a>
   </li>
 </ul>
-<a class="scroll_indicator top" tabindex="2">
+<a class="navigation_scroll_indicator top" tabindex="2">
   <span class="hint"><%= t('pageflow.public.scroll_up') %></span>
 </a>

--- a/app/views/pageflow/entries/overview/_entry.html.erb
+++ b/app/views/pageflow/entries/overview/_entry.html.erb
@@ -5,7 +5,11 @@
     </a>
     <h2><%= t('pageflow.public.overview') %></h2>
 
-    <a class="scroll_indicator left button" tabindex="1" title="<%= t('pageflow.public.scroll_left') %>"><span class="hint"><%= t('pageflow.public.scroll_left') %></span></a>
+    <a class="overview_scroll_indicator left button"
+       tabindex="1"
+       title="<%= t('pageflow.public.scroll_left') %>">
+      <span class="hint"><%= t('pageflow.public.scroll_left') %></span>
+    </a>
 
     <div class="wrapper">
       <div class="scroller">
@@ -15,6 +19,10 @@
       </div>
     </div>
 
-    <a class="scroll_indicator right button" tabindex="1" title="<%= t('pageflow.public.scroll_right') %>"><span class="hint"><%= t('pageflow.public.scroll_right') %></span></a>
+    <a class="overview_scroll_indicator right button"
+       tabindex="1"
+       title="<%= t('pageflow.public.scroll_right') %>">
+      <span class="hint"><%= t('pageflow.public.scroll_right') %></span>
+    </a>
   </div>
 </section>


### PR DESCRIPTION
Styles meant for the main scroll indicator applied to the scroll
indicators inside the navigation and overview widgets.

Prefix classes with widget name to prevent collision.