### PR TITLE
Improve HTML translation support in I18nUtils

### DIFF
--- a/app/assets/javascripts/pageflow/ui/utils/i18n_utils.js
+++ b/app/assets/javascripts/pageflow/ui/utils/i18n_utils.js
@@ -12,15 +12,30 @@ pageflow.i18nUtils = {
    *   Translation key candidates.
    *
    * @param {string} [options.defaultValue]
-   *   Value to return if non of the keys has a translation.
+   *   Value to return if none of the keys has a translation. Is
+   *   treated like an HTML translation if html flag is set.
+   *
+   * @param {boolean} [options.html]
+   *   If true, also search for keys ending in '_html' and HTML-escape
+   *   keys that do not end in 'html'
    *
    * @return {string}
    */
   findTranslation: function(keys, options) {
     options = options || {};
 
+    if (options.html) {
+      keys = this.translationKeysWithSuffix(keys, 'html');
+    }
+
     return _.chain(keys).reverse().reduce(function(result, key) {
-      return I18n.t(key, _.extend({}, options, {defaultValue: result}));
+      var unescapedTranslation = I18n.t(key, _.extend({}, options, {defaultValue: result}));
+      if (!options.html || key.match(/_html$/) || result == unescapedTranslation) {
+        return unescapedTranslation;
+      }
+      else {
+        return $('<div />').text(unescapedTranslation).html();
+      }
     }, options.defaultValue).value();
   },
 

--- a/spec/javascripts/pageflow/ui/utils/i18n_utils_spec.js
+++ b/spec/javascripts/pageflow/ui/utils/i18n_utils_spec.js
@@ -2,7 +2,9 @@ describe('pageflow.i18nUtils', function() {
   support.useFakeTranslations({
     'some.key': 'Some text',
     'fallback': 'Fallback',
-    'with.interpolation': 'Value %{value}'
+    'with.interpolation': 'Value %{value}',
+    'html.key.without.suffix': '<div />',
+    'html.key.with.suffix_html': '<div />'
   });
 
   describe('.findTranslation', function() {
@@ -30,6 +32,51 @@ describe('pageflow.i18nUtils', function() {
       );
 
       expect(result).to.eq('Value interpolated');
+    });
+
+    it('does not escape html if html flag is not set', function() {
+      var result = pageflow.i18nUtils.findTranslation(
+        ['html.key.without.suffix']
+      );
+
+      expect(result).to.eq('<div />');
+    });
+
+    it('searches for keys ending in _html if flag is set', function() {
+      var result = pageflow.i18nUtils.findTranslation(
+        ['html.key.with.suffix'],
+        {html: true}
+      );
+
+      expect(result).to.eq('<div />');
+    });
+
+    it('HTML-escapes translations the key of which does not end in _html, if html flag '+
+       'is set', function() {
+         var result = pageflow.i18nUtils.findTranslation(
+           ['html.key.without.suffix'],
+           {html: true}
+         );
+
+         expect(result).to.eq('&lt;div /&gt;');
+       });
+
+    it('does not escape default value if html flag is not set', function() {
+      var result = pageflow.i18nUtils.findTranslation(
+        ['not.there'],
+        {defaultValue: '<div />'}
+      );
+
+      expect(result).to.eq('<div />');
+    });
+
+    it('does not escape default value if html flag is set', function() {
+      var result = pageflow.i18nUtils.findTranslation(
+        ['not.there'],
+        {defaultValue: '<div />', html: true}
+      );
+
+      expect(result).to.eq('<div />');
     });
   });
 


### PR DESCRIPTION
- add html option to findTranslation, which will expand searches to also
  look for keys with _html suffix
- HTML-escape translations whose keys do not end in _html