### PR TITLE
Trigger event when seed data is available

### DIFF
--- a/app/assets/javascripts/pageflow/editor/initializers/setup_collections.js
+++ b/app/assets/javascripts/pageflow/editor/initializers/setup_collections.js
@@ -38,4 +38,6 @@ pageflow.app.addInitializer(function(options) {
   pageflow.savingRecords = new pageflow.SavingRecordsCollection();
   pageflow.savingRecords.watch(pageflow.pages);
   pageflow.savingRecords.watch(pageflow.chapters);
+
+  pageflow.events.trigger('seed:loaded');
 });

--- a/app/assets/javascripts/pageflow/ready.js
+++ b/app/assets/javascripts/pageflow/ready.js
@@ -9,6 +9,8 @@ pageflow.ready = new $.Deferred(function(readyDeferred) {
       });
 
       slideshow.each(function() {
+        pageflow.events.trigger('seed:loaded');
+
         pageflow.entryData = new pageflow.SeedEntryData(
           pageflow.seed
         );


### PR DESCRIPTION
Create a uniform end point for libraries to subscribe to, which need
to load data either from the JSON seed or the Backbone collections.