### PR TITLE
Use create instead of build_stubbed in EditLock tests

### DIFF
--- a/spec/models/pageflow/edit_lock_spec.rb
+++ b/spec/models/pageflow/edit_lock_spec.rb
@@ -14,7 +14,7 @@ module Pageflow
         it 'raises HeldByOtherUserError' do
           current_user = build(:user)
           other_user = build(:user)
-          edit_lock = build(:edit_lock, :user => other_user)
+          edit_lock = build(:edit_lock, user: other_user)
 
           expect {
             edit_lock.acquire(current_user)
@@ -25,9 +25,9 @@ module Pageflow
           current_user = build(:user)
           other_user = build(:user)
           entry = build(:entry)
-          edit_lock = build(:edit_lock, :user => other_user, :entry => entry)
+          edit_lock = build(:edit_lock, user: other_user, entry: entry)
 
-          edit_lock.acquire(current_user, :force => true)
+          edit_lock.acquire(current_user, force: true)
 
           expect(entry.edit_lock).to be_held_by(current_user)
         end
@@ -36,7 +36,7 @@ module Pageflow
           current_user = build(:user)
           other_user = build(:user)
           entry = build(:entry)
-          edit_lock = build(:edit_lock, :user => other_user, :entry => entry)
+          edit_lock = build(:edit_lock, user: other_user, entry: entry)
 
           Timecop.freeze(Time.now + EditLock::TIME_TO_LIVE + 1.minute)
           edit_lock.acquire(current_user)
@@ -48,7 +48,7 @@ module Pageflow
       context 'when held by other session' do
         it 'raises HeldByOtherSessionError' do
           current_user = build(:user)
-          edit_lock = build(:edit_lock, :user => current_user)
+          edit_lock = build(:edit_lock, user: current_user)
 
           expect {
             edit_lock.acquire(current_user)
@@ -57,19 +57,19 @@ module Pageflow
 
         it 'raises HeldByOtherSessionError for non matching id' do
           current_user = build(:user)
-          edit_lock = build(:edit_lock, :user => current_user)
+          edit_lock = build(:edit_lock, user: current_user)
 
           expect {
-            edit_lock.acquire(current_user, :id => 'other_id')
+            edit_lock.acquire(current_user, id: 'other_id')
           }.to raise_error(EditLock::HeldByOtherSessionError)
         end
 
         it 'can be acquired with force option' do
           current_user = build(:user)
           entry = build(:entry)
-          edit_lock = build(:edit_lock, :user => current_user, :entry => entry)
+          edit_lock = build(:edit_lock, user: current_user, entry: entry)
 
-          edit_lock.acquire(current_user, :id => 'other_id', :force => true)
+          edit_lock.acquire(current_user, id: 'other_id', force: true)
 
           expect(entry.edit_lock).to be_held_by(current_user)
         end
@@ -77,10 +77,10 @@ module Pageflow
         it 'can be acquired if timed out' do
           current_user = build(:user)
           entry = build(:entry)
-          edit_lock = build(:edit_lock, :user => current_user, :entry => entry)
+          edit_lock = build(:edit_lock, user: current_user, entry: entry)
 
           Timecop.freeze(Time.now + EditLock::TIME_TO_LIVE + 1.minute)
-          edit_lock.acquire(current_user, :id => 'other_id')
+          edit_lock.acquire(current_user, id: 'other_id')
 
           expect(entry.edit_lock).to be_held_by(current_user)
         end
@@ -90,19 +90,19 @@ module Pageflow
         it 'returns quietly' do
           current_user = build(:user)
           entry = build(:entry)
-          edit_lock = create(:edit_lock, :user => current_user, :entry => entry)
+          edit_lock = create(:edit_lock, user: current_user, entry: entry)
 
           expect {
-            edit_lock.acquire(current_user, :id => edit_lock.id)
+            edit_lock.acquire(current_user, id: edit_lock.id)
           }.not_to raise_error
         end
 
         it 'does not create new lock even with force option' do
           current_user = build(:user)
           entry = build(:entry)
-          edit_lock = create(:edit_lock, :user => current_user, :entry => entry)
+          edit_lock = create(:edit_lock, user: current_user, entry: entry)
 
-          edit_lock.acquire(current_user, :id => edit_lock.id, :force => true)
+          edit_lock.acquire(current_user, id: edit_lock.id, force: true)
 
           expect(entry.edit_lock).to be(edit_lock)
         end
@@ -110,13 +110,13 @@ module Pageflow
         it 'deferres time out' do
           current_user = build(:user)
           entry = build(:entry)
-          edit_lock = create(:edit_lock, :user => current_user, :entry => entry)
+          edit_lock = create(:edit_lock, user: current_user, entry: entry)
 
           Timecop.freeze(Time.now + EditLock::TIME_TO_LIVE + 1.minute)
-          edit_lock.acquire(current_user, :id => edit_lock.id)
+          edit_lock.acquire(current_user, id: edit_lock.id)
 
           expect {
-            edit_lock.acquire(current_user, :id => 'other_id')
+            edit_lock.acquire(current_user, id: 'other_id')
           }.to raise_error(EditLock::HeldByOtherSessionError)
         end
       end
@@ -127,22 +127,22 @@ module Pageflow
         it 'raises HeldByOtherUserError' do
           current_user = build(:user)
           other_user = build(:user)
-          edit_lock = build(:edit_lock, :user => other_user)
+          edit_lock = build(:edit_lock, user: other_user)
 
           expect {
-            edit_lock.verify!(current_user, :id => 'other_id')
+            edit_lock.verify!(current_user, id: 'other_id')
           }.to raise_error(EditLock::HeldByOtherUserError)
         end
 
         it 'raises HeldByOtherUserError even if timed out' do
           current_user = build(:user)
           other_user = build(:user)
-          edit_lock = build(:edit_lock, :user => other_user)
+          edit_lock = build(:edit_lock, user: other_user)
 
           Timecop.freeze(Time.now + EditLock::TIME_TO_LIVE + 1.minutes)
 
           expect {
-            edit_lock.verify!(current_user, :id => 'other_id')
+            edit_lock.verify!(current_user, id: 'other_id')
           }.to raise_error(EditLock::HeldByOtherUserError)
         end
       end
@@ -150,21 +150,21 @@ module Pageflow
       context 'when held by other session' do
         it 'raises HeldByOtherSessionError' do
           current_user = build(:user)
-          edit_lock = build(:edit_lock, :user => current_user)
+          edit_lock = build(:edit_lock, user: current_user)
 
           expect {
-            edit_lock.verify!(current_user, :id => 'other_id')
+            edit_lock.verify!(current_user, id: 'other_id')
           }.to raise_error(EditLock::HeldByOtherSessionError)
         end
 
         it 'raises HeldByOtherSessionError even if timed out' do
           current_user = build(:user)
-          edit_lock = build(:edit_lock, :user => current_user)
+          edit_lock = build(:edit_lock, user: current_user)
 
           Timecop.freeze(Time.now + EditLock::TIME_TO_LIVE + 1.minutes)
 
           expect {
-            edit_lock.verify!(current_user, :id => 'other_id')
+            edit_lock.verify!(current_user, id: 'other_id')
           }.to raise_error(EditLock::HeldByOtherSessionError)
         end
       end
@@ -173,22 +173,22 @@ module Pageflow
         it 'returns quietly' do
           current_user = build(:user)
           entry = build(:entry)
-          edit_lock = create(:edit_lock, :user => current_user, :entry => entry)
+          edit_lock = create(:edit_lock, user: current_user, entry: entry)
 
           expect {
-            edit_lock.verify!(current_user, :id => edit_lock.id)
+            edit_lock.verify!(current_user, id: edit_lock.id)
           }.not_to raise_error
         end
 
         it 'deferres timeout if timed out' do
           current_user = build(:user)
-          edit_lock = create(:edit_lock, :user => current_user)
+          edit_lock = create(:edit_lock, user: current_user)
 
           Timecop.freeze(Time.now + EditLock::TIME_TO_LIVE + 1.minutes)
-          edit_lock.verify!(current_user, :id => edit_lock.id)
+          edit_lock.verify!(current_user, id: edit_lock.id)
 
           expect {
-            edit_lock.verify!(current_user, :id => 'other_id')
+            edit_lock.verify!(current_user, id: 'other_id')
           }.to raise_error(EditLock::HeldByOtherSessionError)
         end
       end
@@ -198,7 +198,7 @@ module Pageflow
       context 'when held by current user' do
         it 'destroys edit lock' do
           current_user = build(:user)
-          edit_lock = create(:edit_lock, :user => current_user)
+          edit_lock = create(:edit_lock, user: current_user)
 
           edit_lock.release(current_user)
 
@@ -210,7 +210,7 @@ module Pageflow
         it 'does not destroy edit lock' do
           current_user = build(:user)
           other_user = build(:user)
-          edit_lock = create(:edit_lock, :user => current_user)
+          edit_lock = create(:edit_lock, user: current_user)
 
           edit_lock.release(other_user)
 
@@ -239,7 +239,7 @@ module Pageflow
           edit_lock = EditLock::Null.new(entry)
 
           expect {
-            edit_lock.verify!(current_user, :id => 1)
+            edit_lock.verify!(current_user, id: 1)
           }.to raise_error(EditLock::NotHeldError)
         end
       end

--- a/spec/models/pageflow/edit_lock_spec.rb
+++ b/spec/models/pageflow/edit_lock_spec.rb
@@ -48,7 +48,7 @@ module Pageflow
       context 'when held by other session' do
         it 'raises HeldByOtherSessionError' do
           current_user = build(:user)
-          edit_lock = build_stubbed(:edit_lock, :user => current_user)
+          edit_lock = build(:edit_lock, :user => current_user)
 
           expect {
             edit_lock.acquire(current_user)
@@ -57,7 +57,7 @@ module Pageflow
 
         it 'raises HeldByOtherSessionError for non matching id' do
           current_user = build(:user)
-          edit_lock = build_stubbed(:edit_lock, :user => current_user)
+          edit_lock = build(:edit_lock, :user => current_user)
 
           expect {
             edit_lock.acquire(current_user, :id => 'other_id')
@@ -90,7 +90,7 @@ module Pageflow
         it 'returns quietly' do
           current_user = build(:user)
           entry = build(:entry)
-          edit_lock = build_stubbed(:edit_lock, :user => current_user, :entry => entry)
+          edit_lock = create(:edit_lock, :user => current_user, :entry => entry)
 
           expect {
             edit_lock.acquire(current_user, :id => edit_lock.id)
@@ -100,7 +100,7 @@ module Pageflow
         it 'does not create new lock even with force option' do
           current_user = build(:user)
           entry = build(:entry)
-          edit_lock = build_stubbed(:edit_lock, :user => current_user, :entry => entry)
+          edit_lock = create(:edit_lock, :user => current_user, :entry => entry)
 
           edit_lock.acquire(current_user, :id => edit_lock.id, :force => true)
 
@@ -150,7 +150,7 @@ module Pageflow
       context 'when held by other session' do
         it 'raises HeldByOtherSessionError' do
           current_user = build(:user)
-          edit_lock = build_stubbed(:edit_lock, :user => current_user)
+          edit_lock = build(:edit_lock, :user => current_user)
 
           expect {
             edit_lock.verify!(current_user, :id => 'other_id')
@@ -159,7 +159,7 @@ module Pageflow
 
         it 'raises HeldByOtherSessionError even if timed out' do
           current_user = build(:user)
-          edit_lock = build_stubbed(:edit_lock, :user => current_user)
+          edit_lock = build(:edit_lock, :user => current_user)
 
           Timecop.freeze(Time.now + EditLock::TIME_TO_LIVE + 1.minutes)
 
@@ -173,7 +173,7 @@ module Pageflow
         it 'returns quietly' do
           current_user = build(:user)
           entry = build(:entry)
-          edit_lock = build_stubbed(:edit_lock, :user => current_user, :entry => entry)
+          edit_lock = create(:edit_lock, :user => current_user, :entry => entry)
 
           expect {
             edit_lock.verify!(current_user, :id => edit_lock.id)
@@ -182,7 +182,7 @@ module Pageflow
 
         it 'deferres timeout if timed out' do
           current_user = build(:user)
-          edit_lock = build_stubbed(:edit_lock, :user => current_user)
+          edit_lock = create(:edit_lock, :user => current_user)
 
           Timecop.freeze(Time.now + EditLock::TIME_TO_LIVE + 1.minutes)
           edit_lock.verify!(current_user, :id => edit_lock.id)


### PR DESCRIPTION
FactoryGirl no longer allows models created by `build_stubbed` to
access database methods, which some of `EditLock`'s methods do. Use
`create` strategy instead if a database id is required for the test.