### PR TITLE
Handle symbolized keys in mailer options

### DIFF
--- a/app/mailers/pageflow/user_mailer.rb
+++ b/app/mailers/pageflow/user_mailer.rb
@@ -3,8 +3,10 @@ module Pageflow
     include Resque::Mailer
 
     def invitation(options)
-      @user = User.find(options['user_id'])
-      @password_token = options['password_token']
+      options.symbolize_keys!
+
+      @user = User.find(options[:user_id])
+      @password_token = options[:password_token]
 
       I18n.with_locale(@user.locale) do
         headers('X-Language' => I18n.locale)

--- a/spec/mailers/pageflow/user_mailer_spec.rb
+++ b/spec/mailers/pageflow/user_mailer_spec.rb
@@ -7,6 +7,15 @@ module Pageflow
         user = create(:user)
         Pageflow.config.mailer_sender = 'test@example.com'
 
+        mail = UserMailer.invitation(user_id: user.id)
+
+        expect(mail.from).to eq(['test@example.com'])
+      end
+
+      it 'supports string keys passed by resque_mailer < 2.4.1' do
+        user = create(:user)
+        Pageflow.config.mailer_sender = 'test@example.com'
+
         mail = UserMailer.invitation('user_id' => user.id)
 
         expect(mail.from).to eq(['test@example.com'])
@@ -15,7 +24,7 @@ module Pageflow
       it 'uses locale of receiving user' do
         user = create(:user, locale: 'de')
 
-        mail = UserMailer.invitation('user_id' => user.id)
+        mail = UserMailer.invitation(user_id: user.id)
 
         expect(mail.header['X-Language'].value).to eq('de')
       end


### PR DESCRIPTION
Starting with version 2.4.1 `resque_mailer` symbolizes keys in
parameters passed to mailer methods. Symbolize keys to work with both
versions.

See also zapnap/resque_mailer#100