### PR TITLE
Update Travis Ruby version to 2.1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.1
+  - 2.1.7
   - 2.3.1
 
 # User container based travis infrastructure which allows caching


### PR DESCRIPTION
`has_scope 0.7`, which is now allowed by newer versions of `inherited_resources`, requires Ruby 2.1.7.