### PR TITLE
Use correct Backbone sync parameter to trigger retry

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/mixins/retryable.js
+++ b/app/assets/javascripts/pageflow/editor/models/mixins/retryable.js
@@ -11,6 +11,6 @@ pageflow.retryable = {
       model.trigger('error', model, resp, options);
     };
     options.url = this.url() + '/retry';
-    return this.sync('post', this, options);
+    return this.sync('create', this, options);
   }
 };


### PR DESCRIPTION
Former parameter caused a get request, which lead to a 404.