### PR TITLE
Hide audio page content when text tracks are displayed

### DIFF
--- a/app/assets/stylesheets/pageflow/page_types/video/content_hiding.scss
+++ b/app/assets/stylesheets/pageflow/page_types/video/content_hiding.scss
@@ -1,3 +1,4 @@
+.js .audioPage.has_text_tracks,
 .js .videoPage {
   .scroller {
     @include transition(opacity 0.2s linear);


### PR DESCRIPTION
Otherwise shadow and text hide the text tracks.