### PR TITLE
Introduce conditional thumbnail candidates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,7 @@ Style/SpaceInsideHashLiteralBraces:
 # Do not warn about missing magic comment
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+# Allow `json.(:attribute)`
+Style/LambdaCall:
+  Enabled: false

--- a/app/assets/javascripts/pageflow/editor/models/page.js
+++ b/app/assets/javascripts/pageflow/editor/models/page.js
@@ -55,6 +55,10 @@ pageflow.Page = Backbone.Model.extend({
     var configuration = this.configuration;
 
     return _.reduce(this.pageType().thumbnailCandidates(), function(result, candidate) {
+      if (candidate.condition && !conditionMet(candidate.condition, configuration)) {
+        return result;
+      }
+
       return result || configuration.getReference(candidate.attribute, candidate.file_collection);
     }, null);
   },
@@ -77,6 +81,15 @@ pageflow.Page = Backbone.Model.extend({
     this.destroyWithDelay();
   }
 });
+
+function conditionMet(condition, configuration) {
+  if (condition.negated) {
+    return configuration.get(condition.attribute) != condition.value;
+  }
+  else {
+    return configuration.get(condition.attribute) == condition.value;
+  }
+}
 
 pageflow.Page.linkedPagesLayouts = ['default', 'hero_top_left', 'hero_top_right'];
 pageflow.Page.textPositions = ['left', 'right'];

--- a/app/helpers/pageflow/common_entry_seed_helper.rb
+++ b/app/helpers/pageflow/common_entry_seed_helper.rb
@@ -57,7 +57,8 @@ module Pageflow
           {
             attribute: candidate[:attribute],
             collection_name: candidate[:file_collection],
-            css_class_prefix: thumbnail_candidate_css_class_prefix(candidate)
+            css_class_prefix: thumbnail_candidate_css_class_prefix(candidate),
+            condition: condition(candidate)
           }
         end
       end
@@ -65,6 +66,16 @@ module Pageflow
       def thumbnail_candidate_css_class_prefix(candidate)
         file_type = config.file_types.find_by_collection_name!(candidate[:file_collection])
         file_type.model.model_name.singular
+      end
+
+      def condition(candidate)
+        result = candidate[:unless] || candidate[:if]
+
+        if result
+          result[:negated] = !!candidate[:unless]
+        end
+
+        result
       end
     end
   end

--- a/app/views/pageflow/page_types/_page_type.json.jbuilder
+++ b/app/views/pageflow/page_types/_page_type.json.jbuilder
@@ -8,6 +8,13 @@ json.(page_type,
 
 json.thumbnail_candidates(page_type.thumbnail_candidates) do |candidate|
   json.(candidate, :attribute, :file_collection)
+
+  if (condition = candidate[:unless] || candidate[:if])
+    json.condition do
+      json.(condition, :attribute, :value)
+      json.negated(!!candidate[:unless])
+    end
+  end
 end
 
 if page_type.json_seed_template

--- a/lib/pageflow/page_type.rb
+++ b/lib/pageflow/page_type.rb
@@ -104,18 +104,67 @@ module Pageflow
     # a registered {FileType}. The first file found is used as
     # thumbnail.
     #
-    # @example Default return value
-    #
     #     [
     #       {attribute: 'thumbnail_image_id', file_collection: 'image_files'},
     #       {attribute: 'background_image_id', file_collection: 'image_files'}
     #     ]
     #
+    # It is possible to specify further conditions under which the
+    # candidate may be used via `if` or `unless` keys:
+    #
+    #     [
+    #       {
+    #         attribute: 'video_id',
+    #         file_collection: 'video_files',
+    #         if: {
+    #           attribute: 'background_type',
+    #           value: 'video',
+    #         }
+    #       },
+    #       {
+    #         attribute: 'image_id',
+    #         file_collection: 'image_files',
+    #         unless: {
+    #           attribute: 'background_type',
+    #           value: 'video',
+    #         }
+    #       }
+    #     ]
+    #
+    # The candidate will only be used if the given attribute has the
+    # given value.
+    #
     # @returns {Array<Hash>}
     def thumbnail_candidates
       [
-        {attribute: 'thumbnail_image_id', file_collection: 'image_files'},
-        {attribute: 'background_image_id', file_collection: 'image_files'}
+        {
+          file_collection: 'image_files',
+          attribute: 'thumbnail_image_id'
+        },
+        {
+          file_collection: 'image_files',
+          attribute: 'background_image_id',
+          unless: {
+            attribute: 'background_type',
+            value: 'video'
+          }
+        },
+        {
+          file_collection: 'image_files',
+          attribute: 'poster_image_id',
+          if: {
+            attribute: 'background_type',
+            value: 'video'
+          }
+        },
+        {
+          file_collection: 'video_files',
+          attribute: 'video_file_id',
+          if: {
+            attribute: 'background_type',
+            value: 'video'
+          }
+        }
       ]
     end
 

--- a/spec/helpers/pageflow/common_entry_seed_helper_spec.rb
+++ b/spec/helpers/pageflow/common_entry_seed_helper_spec.rb
@@ -20,7 +20,22 @@ module Pageflow
         it 'includes thumbnail candidates of page types registered for entry' do
           thumbnail_candidates = [
             {attribute: 'thumbnail_image_id', file_collection: 'image_files'},
-            {attribute: 'video_id', file_collection: 'video_files'}
+            {
+              attribute: 'image_id',
+              file_collection: 'image_files',
+              if: {
+                attribute: 'background_type',
+                value: 'image'
+              }
+            },
+            {
+              attribute: 'video_id',
+              file_collection: 'video_files',
+              unless: {
+                attribute: 'background_type',
+                value: 'image'
+              }
+            }
           ]
 
           pageflow_configure do |config|
@@ -38,12 +53,28 @@ module Pageflow
             {
               attribute: 'thumbnail_image_id',
               collection_name: 'image_files',
-              css_class_prefix: 'pageflow_image_file'
+              css_class_prefix: 'pageflow_image_file',
+              condition: nil
+            },
+            {
+              attribute: 'image_id',
+              collection_name: 'image_files',
+              css_class_prefix: 'pageflow_image_file',
+              condition: {
+                attribute: 'background_type',
+                value: 'image',
+                negated: false
+              }
             },
             {
               attribute: 'video_id',
               collection_name: 'video_files',
-              css_class_prefix: 'pageflow_video_file'
+              css_class_prefix: 'pageflow_video_file',
+              condition: {
+                attribute: 'background_type',
+                value: 'image',
+                negated: true
+              }
             }
           ])
         end

--- a/spec/helpers/pageflow/page_types_helper_spec.rb
+++ b/spec/helpers/pageflow/page_types_helper_spec.rb
@@ -42,7 +42,12 @@ module Pageflow
           name 'test'
 
           def thumbnail_candidates
-            [{attribute: 'thumbnail_image_id', file_collection: 'image_files'}]
+            [
+              {
+                attribute: 'thumbnail_image_id',
+                file_collection: 'image_files'
+              }
+            ]
           end
         end
 
@@ -50,8 +55,62 @@ module Pageflow
         config.page_types.register(page_type_class.new)
 
         result = JSON.parse(helper.page_type_json_seeds(config))
+        candidate = result[0]['thumbnail_candidates'][0]
 
-        expect(result[0]['thumbnail_candidates']).to eq([{'attribute' => 'thumbnail_image_id', 'file_collection' => 'image_files'}])
+        expect(candidate['attribute']).to eq('thumbnail_image_id')
+        expect(candidate['file_collection']).to eq('image_files')
+      end
+
+      it 'includes thumbnail_candidates with condition' do
+        page_type_class = Class.new(Pageflow::PageType) do
+          name 'test'
+
+          def thumbnail_candidates
+            [
+              {
+                attribute: 'background_image_id',
+                file_collection: 'image_files',
+                if: {attribute: 'background_type', value: 'image'}
+              }
+            ]
+          end
+        end
+
+        config = Configuration.new
+        config.page_types.register(page_type_class.new)
+
+        result = JSON.parse(helper.page_type_json_seeds(config))
+        candidate = result[0]['thumbnail_candidates'][0]
+
+        expect(candidate['condition']['attribute']).to eq('background_type')
+        expect(candidate['condition']['value']).to eq('image')
+        expect(candidate['condition']['negated']).to eq(false)
+      end
+
+      it 'includes thumbnail_candidates with negated condition' do
+        page_type_class = Class.new(Pageflow::PageType) do
+          name 'test'
+
+          def thumbnail_candidates
+            [
+              {
+                attribute: 'background_image_id',
+                file_collection: 'image_files',
+                unless: {attribute: 'background_type', value: 'image'}
+              }
+            ]
+          end
+        end
+
+        config = Configuration.new
+        config.page_types.register(page_type_class.new)
+
+        result = JSON.parse(helper.page_type_json_seeds(config))
+        candidate = result[0]['thumbnail_candidates'][0]
+
+        expect(candidate['condition']['attribute']).to eq('background_type')
+        expect(candidate['condition']['value']).to eq('image')
+        expect(candidate['condition']['negated']).to eq(true)
       end
     end
 

--- a/spec/javascripts/models/page_spec.js
+++ b/spec/javascripts/models/page_spec.js
@@ -1,0 +1,140 @@
+describe('Page', function() {
+  describe('#thumbnailFile', function() {
+    support.setupGlobals({
+      editor: function() {
+        var api = new pageflow.EditorApi();
+
+        api.pageTypes.register('audio', {});
+        api.pageTypes.setup([
+          {
+            name: 'video',
+            thumbnail_candidates: [
+              {
+                attribute: 'thumbnail_id',
+                file_collection: 'image_files',
+              },
+              {
+                attribute: 'image_id',
+                file_collection: 'image_files',
+                condition: {
+                  attribute: 'background_type',
+                  value: 'image'
+                }
+              },
+              {
+                attribute: 'poster_id',
+                file_collection: 'image_files',
+                condition: {
+                  attribute: 'background_type',
+                  value: 'image',
+                  negated: true
+                }
+              }
+            ]
+          }
+        ]);
+
+        return api;
+      },
+
+      entry: function() {
+        pageflow.editor.fileTypes = support.factories.fileTypes(function() {
+          this.withImageFileType();
+        });
+
+        return support.factories.entry({}, {
+          fileTypes: pageflow.editor.fileTypes,
+          files: pageflow.FilesCollection.createForFileTypes(
+            pageflow.editor.fileTypes,
+            {
+              image_files: [
+                {id: 5},
+                {id: 6}
+              ]
+            }
+          )
+        });
+      }
+    });
+
+    it('returns first present file', function() {
+      var page = new pageflow.Page({
+        template: 'video',
+        configuration: {
+          thumbnail_id: 5
+        }
+      });
+
+      var thumbnailFile = page.thumbnailFile();
+
+      expect(thumbnailFile.id).to.eq(5);
+    });
+
+    it('returns undefined if no candidate matches', function() {
+      var page = new pageflow.Page({
+        template: 'video',
+        configuration: {}
+      });
+
+      var thumbnailFile = page.thumbnailFile();
+
+      expect(thumbnailFile).to.eq(undefined);
+    });
+
+    it('returns undefined if candidate condition is not met', function() {
+      var page = new pageflow.Page({
+        template: 'video',
+        configuration: {
+          image_id: 5,
+          background_type: 'video'
+        }
+      });
+
+      var thumbnailFile = page.thumbnailFile();
+
+      expect(thumbnailFile).to.eq(undefined);
+    });
+
+    it('returns undefined if negated candidate condition is met', function() {
+      var page = new pageflow.Page({
+        template: 'video',
+        configuration: {
+          poster_id: 5,
+          background_type: 'image'
+        }
+      });
+
+      var thumbnailFile = page.thumbnailFile();
+
+      expect(thumbnailFile).to.eq(undefined);
+    });
+
+    it('returns present file if candidate condition is met', function() {
+      var page = new pageflow.Page({
+        template: 'video',
+        configuration: {
+          image_id: 5,
+          background_type: 'image'
+        }
+      });
+
+      var thumbnailFile = page.thumbnailFile();
+
+      expect(thumbnailFile.id).to.eq(5);
+    });
+
+    it('returns present file if negated candidate condition is not met', function() {
+      var page = new pageflow.Page({
+        template: 'video',
+        configuration: {
+          poster_id: 5,
+          background_type: 'video'
+        }
+      });
+
+      var thumbnailFile = page.thumbnailFile();
+
+      expect(thumbnailFile.id).to.eq(5);
+    });
+  });
+});

--- a/spec/models/pageflow/thumbnail_file_resolver_spec.rb
+++ b/spec/models/pageflow/thumbnail_file_resolver_spec.rb
@@ -85,6 +85,78 @@ module Pageflow
         expect(file.position_x).to eq(50)
         expect(file.position_y).to eq(50)
       end
+
+      context 'with conditions' do
+        it 'skips candidate if condition is not met' do
+          image_file = create(:image_file)
+          panorama_image_file = create(:image_file)
+          candidates = [
+            {
+              attribute: 'panorama_id',
+              file_collection: 'image_files',
+              if: {attribute: 'background_type', value: 'panorama'}
+            },
+            {
+              attribute: 'image_id',
+              file_collection: 'image_files',
+              if: {attribute: 'background_type', value: 'image'}
+            }
+          ]
+          configuration = {
+            'background_type' => 'image',
+            'panorama_id' => panorama_image_file.id,
+            'image_id' => image_file.id
+          }
+          resolver = ThumbnailFileResolver.new(candidates, configuration)
+
+          file = resolver.find
+
+          expect(file).to eq(image_file)
+        end
+
+        it 'skips candidate if condition given via unless is met' do
+          image_file = create(:image_file)
+          panorama_image_file = create(:image_file)
+          candidates = [
+            {
+              attribute: 'panorama_id',
+              file_collection: 'image_files',
+              unless: {attribute: 'background_type', value: 'panorama'}
+            },
+            {
+              attribute: 'image_id',
+              file_collection: 'image_files',
+              unless: {attribute: 'background_type', value: 'image'}
+            }
+          ]
+          configuration = {
+            'background_type' => 'panorama',
+            'panorama_id' => panorama_image_file.id,
+            'image_id' => image_file.id
+          }
+          resolver = ThumbnailFileResolver.new(candidates, configuration)
+
+          file = resolver.find
+
+          expect(file).to eq(image_file)
+        end
+
+        it 'raises helpful error when condition does not have attribute and value keys' do
+          candidates = [
+            {
+              attribute: 'panorama_id',
+              file_collection: 'image_files',
+              if: {value: 'panorama'}
+            }
+          ]
+          configuration = {}
+          resolver = ThumbnailFileResolver.new(candidates, configuration)
+
+          expect {
+            resolver.find
+          }.to raise_error(/Expected thumbnail candidate condition to have keys/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Allow restricting when a thumbnail candidate may be used by giving an
attribute and a desired value. This makes it possible, for example, to
use different thumbnail candidates based on a `background_type`
configuration attribute.