### PR TITLE
Improve hls options fallback

### DIFF
--- a/config/initializers/zencoder.rb
+++ b/config/initializers/zencoder.rb
@@ -25,11 +25,13 @@ Paperclip.interpolates(:zencoder_host_alias) do |attachment, style|
 end
 
 Paperclip.interpolates(:zencoder_hls_host_alias) do |attachment, style|
-  Pageflow.config.zencoder_options.fetch(:hls_host_alias, Pageflow.config.zencoder_options.fetch(:s3_host_alias))
+  Pageflow.config.zencoder_options[:hls_host_alias] ||
+    Pageflow.config.zencoder_options.fetch(:s3_host_alias)
 end
 
 Paperclip.interpolates(:zencoder_hls_origin_host_alias) do |attachment, style|
-  Pageflow.config.zencoder_options.fetch(:hls_origin_host_alias, Pageflow.config.zencoder_options.fetch(:s3_host_alias))
+  Pageflow.config.zencoder_options[:hls_origin_host_alias] ||
+    Pageflow.config.zencoder_options.fetch(:s3_host_alias)
 end
 
 Paperclip.interpolates(:zencoder_protocol) do |attachment, style|


### PR DESCRIPTION
Also fall back to `s3_host_alias` when `hls_host_alias` or
`hls_origin_host_alias` is `nil`, not only when the key is not
present.

Otherwise, when reading the option from an environment variable, we
have to make sure not to set the key if the value is not present.