### PR TITLE
Improve inline help for rights and alt text field

### DIFF
--- a/config/locales/new/alt.de.yml
+++ b/config/locales/new/alt.de.yml
@@ -5,4 +5,4 @@ de:
         common_attributes:
           alt:
             label: "Alt-Text"
-            inline_help: "Ein Hinweis darauf, was in dem dargestellten Element zum Ausdruck kommt."
+            inline_help: "Ein Hinweis darauf, was in dem dargestellten Element zum Ausdruck kommt. Der Text ist im Beitrag nicht sichtbar, kann aber von Screen-Readern verarbeitet werden und trägt somit zur barrierearmen Gestaltung der Inhalte bei."

--- a/config/locales/new/alt.en.yml
+++ b/config/locales/new/alt.en.yml
@@ -5,4 +5,4 @@ en:
         common_attributes:
           alt:
             label: "Alt-Text"
-            inline_help: "A hint describing the contents of the displayed element."
+            inline_help: "A hint describing the contents of the displayed element. Not displayed in the entry, but can be used by screen reader software. Improves accessibility of the content."

--- a/config/locales/new/background_types.de.yml
+++ b/config/locales/new/background_types.de.yml
@@ -5,4 +5,4 @@ de:
         label: Hintergrund-Typ
         values:
           image: Hintergrund-Bild
-          video: Hintergrund-Video
+          video: "Hintergrund-Video (Loop)"

--- a/config/locales/new/confirm_upload.de.yml
+++ b/config/locales/new/confirm_upload.de.yml
@@ -15,7 +15,7 @@ de:
             column_header: "Dateiname"
           rights:
             label: "Rechte"
-            inline_help: "Wird im Impressum des Beitrags angezeigt."
+            inline_help: "Wird im Copyright-Bereich des Beitrags angezeigt."
             column_header: "Rechte"
             cell_title:
               present: "Ausgefüllt: %{value}"


### PR DESCRIPTION
* Mention screen readers
* Say that file rights are displayed in the copyright section