### PR TITLE
Let file selection handler abort navigation

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/file_item_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/file_item_view.js
@@ -24,8 +24,13 @@ pageflow.FileItemView = Backbone.Marionette.ItemView.extend({
 
   events: {
     'click .select': function() {
-      this.options.selectionHandler.call(this.model);
-      pageflow.editor.navigate(this.options.selectionHandler.getReferer(), {trigger: true});
+      var result = this.options.selectionHandler.call(this.model);
+
+      if (result !== false) {
+        pageflow.editor.navigate(this.options.selectionHandler.getReferer(),
+                                 {trigger: true});
+      }
+
       return false;
     },
 


### PR DESCRIPTION
Allow file selection handler to return `false` to prevent redirection
back to referer. This can be used if the made selection was invalid or
if navigation was already triggered by the `call` method.