### PR TITLE
Continue prebuffer on media tag init

### DIFF
--- a/node_package/src/media/components/createFilePlayer/handlePlayerState.js
+++ b/node_package/src/media/components/createFilePlayer/handlePlayerState.js
@@ -1,10 +1,14 @@
-export function initPlayer(player, getPlayerState, prevFileId, fileId) {
+export function initPlayer(player, getPlayerState, playerActions, prevFileId, fileId) {
   const playerState = getPlayerState();
 
   if (fileId === prevFileId) {
     if (playerState.currentTime > 0) {
       player.currentTime(playerState.currentTime);
     }
+  }
+
+  if (playerState.shouldPrebuffer) {
+    player.prebuffer().then(playerActions.prebuffered);
   }
 
   if (playerState.isPlaying) {

--- a/node_package/src/media/components/createFilePlayer/index.jsx
+++ b/node_package/src/media/components/createFilePlayer/index.jsx
@@ -49,6 +49,7 @@ export default function({
 
         initPlayerFromPlayerState(this.player,
                                   () => this.props.playerState,
+                                  this.props.playerActions,
                                   this.prevFileId,
                                   this.props.file.id);
 


### PR DESCRIPTION
Prevent getting stuck in prebuffering state when it has been triggered
before a file has been assigned.