### PR TITLE
Add feature detection for mobile video features

### DIFF
--- a/app/assets/javascripts/pageflow/browser/autoplay_support.js
+++ b/app/assets/javascripts/pageflow/browser/autoplay_support.js
@@ -1,0 +1,3 @@
+pageflow.browser.feature('autoplay support', function(has) {
+  return has.not('mobile platform');
+});

--- a/app/assets/javascripts/pageflow/browser/facebook.js
+++ b/app/assets/javascripts/pageflow/browser/facebook.js
@@ -4,7 +4,6 @@
 // scrolling in Pageflow, the bar stays and hides page elements like
 // the slim player controls.
 pageflow.browser.feature('facebook toolbar', function(has) {
-  return has.all(has('ios platform'),
-                 has('phone platform'),
+  return has.all(has('iphone platform'),
                  pageflow.browser.agent.matchesFacebookInAppBrowser());
 });

--- a/app/assets/javascripts/pageflow/browser/ios_platform.js
+++ b/app/assets/javascripts/pageflow/browser/ios_platform.js
@@ -1,3 +1,8 @@
 pageflow.browser.feature('ios platform', function() {
   return pageflow.browser.agent.matchesMobileSafari();
 });
+
+pageflow.browser.feature('iphone platform', function(has) {
+  return has.all(has('ios platform'),
+                 has('phone platform'));
+});

--- a/app/assets/javascripts/pageflow/browser/video.js
+++ b/app/assets/javascripts/pageflow/browser/video.js
@@ -24,3 +24,7 @@ pageflow.browser.feature('mp4 support only', function(has) {
     pageflow.browser.agent.matchesDesktopSafari9() ||
     pageflow.browser.agent.matchesDesktopSafari10();
 });
+
+pageflow.browser.feature('native video player', function(has) {
+  return has('iphone platform');
+});

--- a/app/assets/javascripts/pageflow/media_player/volume_fading.js
+++ b/app/assets/javascripts/pageflow/media_player/volume_fading.js
@@ -12,6 +12,10 @@ pageflow.mediaPlayer.volumeFading = function(player) {
   };
 
   player.fadeVolume = function(value, duration) {
+    if (!pageflow.browser.has('volume control support')) {
+      return new jQuery.Deferred().resolve().promise();
+    }
+
     cancelFadeVolume();
 
     return new $.Deferred(function(deferred) {

--- a/node_package/src/media/components/PageBackgroundVideo.jsx
+++ b/node_package/src/media/components/PageBackgroundVideo.jsx
@@ -8,7 +8,7 @@ import {has} from 'utils/selectors';
 import {connect} from 'react-redux';
 
 export function PageBackgroundVideo(props) {
-  if (props.hasMobilePlatform && (mobilePosterExists(props) || !props.hasMuteVideoAutoplaySupport)) {
+  if (props.hasMobilePlatform && mobilePosterExists(props)) {
     return (
       <MobilePageVideoPoster page={props.page}
                              propertyNamePrefix={props.propertyNamePrefix} />
@@ -33,6 +33,5 @@ function mobilePosterExists(props) {
 
 export default connect(combine({
   fileExists: fileExists(),
-  hasMobilePlatform: has('mobile platform'),
-  hasMuteVideoAutoplaySupport: has('mute video autoplay support')
+  hasMobilePlatform: has('mobile platform')
 }))(PageBackgroundVideo);

--- a/node_package/src/media/components/__spec__/PageBackgroundVideo-spec.jsx
+++ b/node_package/src/media/components/__spec__/PageBackgroundVideo-spec.jsx
@@ -14,7 +14,6 @@ describe('PageBackgroundVideo', () => {
           mobilePosterImageId: 5
         },
         hasMobilePlatform: true,
-        hasMuteVideoAutoplaySupport: true,
         fileExists: fileExistsFn({
           imageFiles: [5]
         })
@@ -25,30 +24,10 @@ describe('PageBackgroundVideo', () => {
       expect(wrapper).to.have.descendants(MobilePageVideoPoster);
     });
 
-    it('renders mobile poster if mute autoplay is not supported', () => {
+    it('renders muted video player on mobile if no mobile poster is present', () => {
       const props = {
         page: {},
-
         hasMobilePlatform: true,
-        hasMuteVideoAutoplaySupport: false,
-
-        fileExists: fileExistsFn({
-          imageFiles: []
-        })
-      };
-
-      const wrapper = shallow(<PageBackgroundVideo {...props} />);
-
-      expect(wrapper).to.have.descendants(MobilePageVideoPoster);
-    });
-
-    it('renders muted video player if mute autoplay is supported and no mobile poster is present', () => {
-      const props = {
-        page: {},
-
-        hasMobilePlatform: true,
-        hasMuteVideoAutoplaySupport: true,
-
         fileExists: fileExistsFn({
           imageFiles: []
         })


### PR DESCRIPTION
* Autoplay
* Native video player

Add iphone platform and native video player features

Show video poster if mute autoplay is not supported

There is no easy way to feature detect autoplay. Since eventually all
devices will support it and a custom mobile poster can always be
specified, we can drop the special case.