### PR TITLE
Use correct matcher to expect destroyed record

### DIFF
--- a/spec/models/pageflow/edit_lock_spec.rb
+++ b/spec/models/pageflow/edit_lock_spec.rb
@@ -202,7 +202,7 @@ module Pageflow
 
           edit_lock.release(current_user)
 
-          expect(edit_lock).to be_new_record
+          expect(edit_lock).to be_destroyed
         end
       end
 

--- a/spec/models/pageflow/user_spec.rb
+++ b/spec/models/pageflow/user_spec.rb
@@ -35,7 +35,7 @@ module Pageflow
 
         user.destroy_with_password('@qwert123')
 
-        expect(user).to be_new_record
+        expect(user).to be_destroyed
       end
 
       context 'without correct password' do


### PR DESCRIPTION
RSpec < 3.6 used to rely on `record.persisted?` in `be_new_record`
matcher. Now it used `record.new_record?` which is false for destroyed
records. Use correct `be_destroyed` matcher which simply delegates to
`record.destroyed?`.