### PR TITLE
add Cache-Control header for S3 uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@
 
 [Compare changes](https://github.com/codevise/pageflow/compare/12-0-stable...master)
 
-None so far.
+Media stack:
+
+- Switch from `Expires` to `Cache-Control` header for media uploads.
+  ([#753](https://github.com/codevise/pageflow/pull/753))
+
+It’s recommended you update the files currently stored on S3:
+
+```
+s3cmd --recursive modify --add-header="Cache-Control: public, max-age=31536000" s3://yourbucket/
+s3cmd --recursive modify --remove-header=Expires s3://yourbucket/
+```
+
+Tread carefully when you do this! As noted in [this StackExchange answer](http://stackoverflow.com/questions/22501465/how-to-add-cache-control-in-aws-s3), we have experienced that some public read permissions were lost after running this script. Test first using just a single object. In the AWS Management Console, you might want to grant public read access on the entire bucket again to be safe.
 
 See
 [12-0-stable](https://github.com/codevise/pageflow/blob/12-0-stable/CHANGELOG.md)

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -6,31 +6,31 @@ Pageflow.configure do |config|
 
   if Rails.env.test?
     config.paperclip_s3_default_options.merge!({
-      :storage => :filesystem,
-      :path => ':rails_root/tmp/attachments/test/s3/:class/:attachment/:id_partition/:style/:filename'
+      storage: :filesystem,
+      path: ':rails_root/tmp/attachments/test/s3/:class/:attachment/:id_partition/:style/:filename'
     })
   else
     config.paperclip_s3_default_options.merge!({
-      :storage => :s3,
-      :s3_headers => {'Expires' => 1.year.from_now.httpdate},
-      :s3_options => {:max_retries => 10},
+      storage: :s3,
+      s3_headers: {'Cache-Control' => "public, max-age=31536000"},
+      s3_options: {max_retries: 10},
 
-      :url => ':s3_alias_url',
-      :path => ':host/:class_basename/:attachment/:id_partition/:pageflow_attachments_version:style/:filename',
+      url: ':s3_alias_url',
+      path: ':host/:class_basename/:attachment/:id_partition/:pageflow_attachments_version:style/:filename',
 
       # Paperclip deletes and reuploads the original on
       # reprocess. Sometimes S3 seems to change the order of commands
       # causing the image to be deleted. This is fixed on paperclip
       # master, but for us not deleting old files is good enough. They
       # might be in the CDN anyway.
-      :keep_old_files => true
+      keep_old_files: true
     })
   end
 
   config.paperclip_filesystem_default_options.merge!({
-    :storage => :filesystem,
-    :path => ':pageflow_filesystem_root/:class/:attachment/:id_partition/:style/:filename',
-    :url => 'not_uploaded_yet'
+    storage: :filesystem,
+    path: ':pageflow_filesystem_root/:class/:attachment/:id_partition/:style/:filename',
+    url: 'not_uploaded_yet'
   })
 
   config.thumbnail_styles = {


### PR DESCRIPTION
In addition to the existing Expires header _for now_. I am actually proposing we get rid of the Expires header completely. I'll write this in a comment on the pull request.

Expires is HTTP/1.0 (!)
Cache-Control is HTTP/1.1 and supersedes Expires.
Cache-Control offers everything from Expires and a lot more.

In our case, it's important to mark the files public, so that they will
be cached by proxies. Also give them the same high expiry time (1 year), because they
have timestamps in the URL, which invalidates the cache.