### PR TITLE
Fix ensureValueDefined option of SelectInputView

### DIFF
--- a/app/assets/javascripts/pageflow/ui/views/inputs/select_input_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/inputs/select_input_view.js
@@ -138,8 +138,7 @@ pageflow.SelectInputView = Backbone.Marionette.ItemView.extend({
     this.load();
     this.listenTo(this.model, 'change:' + this.options.propertyName, this.load);
 
-    if (this.options.ensureValueDefined && !this.ui.select.val()) {
-      this.ui.select.val(this.options.values[0]);
+    if (this.options.ensureValueDefined && !this.model.has(this.options.propertyName)) {
       this.save();
     }
   },

--- a/spec/javascripts/pageflow/ui/views/inputs/select_input_view_spec.js
+++ b/spec/javascripts/pageflow/ui/views/inputs/select_input_view_spec.js
@@ -144,6 +144,37 @@ describe('pageflow.SelectInputView', function() {
     });
   });
 
+  describe('without ensureValueDefined option', function() {
+    it('does not assign value when rendered', function() {
+      var model = new Model();
+      var selectInputView = new pageflow.SelectInputView({
+        model: model,
+        propertyName: 'value',
+        values: ['one', 'two']
+      });
+
+      selectInputView.render();
+
+      expect(model.has('value')).to.eq(false);
+    });
+  });
+
+  describe('with ensureValueDefined option', function() {
+    it('assigns value of first option when rendered', function() {
+      var model = new Model();
+      var selectInputView = new pageflow.SelectInputView({
+        model: model,
+        propertyName: 'value',
+        values: ['one', 'two'],
+        ensureValueDefined: true
+      });
+
+      selectInputView.render();
+
+      expect(model.get('value')).to.eq('one');
+    });
+  });
+
   function optionTexts(view) {
     view.render();
 


### PR DESCRIPTION
The change in #725 made sure that the first option is always displayed
as a default value in a select box without blank item. This broke the
`ensureValueDefined' option: A value would only be defined if the
select box did not have selected item.

Instead explicitly check that if the model has a value defined for the
property. If not, calling `save` is enough now since the first item
has already been selected.