### PR TITLE
Use entry locale in CloseButton translations

### DIFF
--- a/node_package/spec/support/index.js
+++ b/node_package/spec/support/index.js
@@ -1,0 +1,9 @@
+import {expect} from './chai';
+import stubI18n from './stubI18n';
+import mockContext from './mockContext';
+
+export {
+  expect,
+  stubI18n,
+  mockContext
+}

--- a/node_package/spec/support/mockContext.js
+++ b/node_package/spec/support/mockContext.js
@@ -1,0 +1,18 @@
+import createStore from 'createStore';
+
+import i18n from 'i18n';
+
+const reduxModules = {
+  i18n
+};
+
+const defaultOptions = {
+  locale: 'en'
+};
+
+export default function mockContext(reduxModuleNames, options) {
+  return {
+    store: createStore(reduxModuleNames.map(name => reduxModules[name]),
+                       {...defaultOptions, ...options})
+  };
+}

--- a/node_package/spec/support/stubI18n.js
+++ b/node_package/spec/support/stubI18n.js
@@ -1,0 +1,13 @@
+import sinon from 'sinon';
+
+export default function stubI18n() {
+  beforeEach(() => {
+    window.I18n = {
+      t: sinon.stub().returns('translation')
+    };
+  });
+
+  afterEach(() => {
+    delete window.I18n;
+  });
+};

--- a/node_package/src/__spec__/i18n-spec.js
+++ b/node_package/src/__spec__/i18n-spec.js
@@ -3,18 +3,10 @@ import {t, locale} from 'i18n/selectors';
 import createStore from 'createStore';
 
 import {expect} from 'support/chai';
-import sinon from 'sinon';
+import stubI18n from 'support/stubI18n';
 
 describe('i18n', () => {
-  beforeEach(() => {
-    window.I18n = {
-      t: sinon.spy()
-    };
-  });
-
-  afterEach(() => {
-    delete window.I18n;
-  });
+  stubI18n();
 
   it('provides t selector to fetch translations', () => {
     const store = createStore([i18nModule], {locale: 'fr'});

--- a/node_package/src/components/CloseButton.jsx
+++ b/node_package/src/components/CloseButton.jsx
@@ -1,13 +1,21 @@
-export default function(props) {
+import {t} from 'i18n/selectors';
+import {combineSelectors} from 'utils';
+import {connect} from 'react-redux';
+
+function CloseButton(props) {
   return (
     <div className="close_button text_hidden_only"
          tabIndex="4"
-         title={I18n.t('pageflow.public.close')}
+         title={props.t('pageflow.public.close')}
          onClick={props.onClick}>
 
       <div className="label">
-        {I18n.t('pageflow.public.close')}
+        {props.t('pageflow.public.close')}
       </div>
     </div>
   );
 }
+
+export default connect(combineSelectors({
+  t
+}))(CloseButton);

--- a/node_package/src/components/__spec__/CloseButton-spec.jsx
+++ b/node_package/src/components/__spec__/CloseButton-spec.jsx
@@ -1,0 +1,14 @@
+import CloseButton from '../CloseButton';
+
+import {expect, stubI18n, mockContext} from 'support';
+import {mount} from 'enzyme';
+
+describe('CloseButton', () => {
+  stubI18n();
+
+  it('renders ok', () => {
+    const wrapper = mount(<CloseButton />, {context: mockContext(['i18n'])});
+
+    expect(wrapper).to.have.className('close_button');
+  });
+});


### PR DESCRIPTION
Use the `t` function which is given via `connect`, rather than
accessing the global `I18n` object which uses the   default locale.