### PR TITLE
Fix page title hysteresis

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/page.js
+++ b/app/assets/javascripts/pageflow/editor/models/page.js
@@ -48,7 +48,9 @@ pageflow.Page = Backbone.Model.extend({
   },
 
   title: function() {
-    return this.configuration.get('title') || this.configuration.get('additional_title');
+    return this.configuration.get('title') ||
+      this.configuration.get('additional_title') ||
+      '';
   },
 
   thumbnailFile: function() {


### PR DESCRIPTION
On choosing a page link, properly update title when it should be an
empty string. Without this, e.g. in ReferenceInputView, `title` will
not update in certain situations, because page#title() returns
`'undefined'` due to `''` falsiness in Javascript.

To reproduce:
```
this.configuration.get('title') === ''
this.configuration.get('additional_title') === undefined
```