### PR TITLE
Change Roles.high to not expect account membership

### DIFF
--- a/app/models/pageflow/roles.rb
+++ b/app/models/pageflow/roles.rb
@@ -19,7 +19,10 @@ module Pageflow
 
     def high(user, entry)
       roles = [:none, :member, :previewer, :editor, :publisher, :manager]
-      account_role = Membership.where(user: user, entity: entry.account).first.role || :none
+
+      account_membership = Membership.where(user: user, entity: entry.account).first
+      account_role = account_membership ? account_membership.role : :none
+
       if user.entries.include?(entry)
         entry_role = Membership.where(user: user, entity: entry).first.role
       else

--- a/spec/models/pageflow/roles_spec.rb
+++ b/spec/models/pageflow/roles_spec.rb
@@ -42,6 +42,16 @@ module Pageflow
 
         expect(Roles.high(user, entry)).to eq(:member)
       end
+
+      it 'returns correct role when only entry role exists after entry changed accounts' do
+        user = create(:user)
+        account = create(:account)
+        entry = create(:entry, with_editor: user)
+
+        entry.update!(account: account)
+
+        expect(Roles.high(user, entry)).to eq(:editor)
+      end
     end
   end
 end


### PR DESCRIPTION
Normally when a user that is member of entry is also member of the
entry's account. Still this can be false when an entry has been moved
between accounts.

Prevent exception on entry admin page when trying to find the highest
role of a user.