### PR TITLE
Fix exception when sorting user accounts table by role

### DIFF
--- a/app/views/components/pageflow/admin/user_accounts_tab.rb
+++ b/app/views/components/pageflow/admin/user_accounts_tab.rb
@@ -2,15 +2,16 @@ module Pageflow
   module Admin
     class UserAccountsTab < ViewComponent
       def build(user)
-        embedded_index_table(user.memberships.on_accounts.includes(:account)
-                              .accessible_by(current_ability, :index),
+        embedded_index_table(user.memberships.on_accounts
+                               .includes(:account).references(:pageflow_accounts)
+                               .accessible_by(current_ability, :index),
                              blank_slate_text: t('pageflow.admin.users.no_accounts')) do
           table_for_collection class: 'memberships', sortable: true, i18n: Pageflow::Membership do
             column :account, sortable: 'pageflow_accounts.name' do |membership|
-              if authorized?(:read, membership.entity)
-                link_to(membership.entity.name, admin_account_path(membership.entity))
+              if authorized?(:read, membership.account)
+                link_to(membership.account.name, admin_account_path(membership.account))
               else
-                membership.entity.name
+                membership.account.name
               end
             end
             column :role, sortable: 'pageflow_memberships.role' do |membership|

--- a/app/views/components/pageflow/admin/user_entries_tab.rb
+++ b/app/views/components/pageflow/admin/user_entries_tab.rb
@@ -2,22 +2,23 @@ module Pageflow
   module Admin
     class UserEntriesTab < ViewComponent
       def build(user)
-        embedded_index_table(user.memberships.on_entries.includes(:entry, entry: :account)
-                              .accessible_by(current_ability, :index),
+        embedded_index_table(user.memberships.on_entries
+                               .includes(:entry, entry: :account).references(:pageflow_entries)
+                               .accessible_by(current_ability, :index),
                              blank_slate_text: t('pageflow.admin.users.no_entries')) do
           table_for_collection class: 'memberships', sortable: true, i18n: Pageflow::Membership do
             column :entry, sortable: 'pageflow_entries.title' do |membership|
-              link_to(membership.entity.title, admin_entry_path(membership.entity))
+              link_to(membership.entry.title, admin_entry_path(membership.entry))
             end
             column :role, sortable: 'pageflow_memberships.role' do |membership|
               membership_role_with_tooltip(membership.role, scope: 'entries')
             end
             column :account, sortable: 'pageflow_accounts.name' do |membership|
-              if authorized?(:read, membership.entity.account)
-                link_to(membership.entity.account.name,
-                        admin_account_path(membership.entity.account))
+              if authorized?(:read, membership.entry.account)
+                link_to(membership.entry.account.name,
+                        admin_account_path(membership.entry.account))
               else
-                membership.entity.account.name
+                membership.entry.account.name
               end
             end
             column :created_at, sortable: 'pageflow_memberships.created_at'

--- a/lib/pageflow/view_component.rb
+++ b/lib/pageflow/view_component.rb
@@ -1,14 +1,5 @@
 module Pageflow
-  # Base class for Arbre components defined by Pageflow. Store the
-  # builder method name to facilitate calling it in specs.
+  # Base class for Arbre components defined by Pageflow.
   class ViewComponent < Arbre::Component
-    class << self
-      attr_reader :builder_method_name
-    end
-
-    def self.builder_method(name)
-      @builder_method_name = name
-      super
-    end
   end
 end

--- a/spec/support/config/devise.rb
+++ b/spec/support/config/devise.rb
@@ -1,5 +1,6 @@
 RSpec.configure do |config|
-  config.include Devise::TestHelpers, :type => :controller
+  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::TestHelpers, type: :view_component
 
   module DeviseTestHelpersWithScope
     def sign_in(user)
@@ -7,5 +8,6 @@ RSpec.configure do |config|
     end
   end
 
-  config.include DeviseTestHelpersWithScope, :type => :controller
+  config.include DeviseTestHelpersWithScope, type: :controller
+  config.include DeviseTestHelpersWithScope, type: :view_component
 end

--- a/spec/support/helpers/view_component_example_group.rb
+++ b/spec/support/helpers/view_component_example_group.rb
@@ -21,7 +21,11 @@ module ViewComponentExampleGroup
       if block_given?
         arbre(&block).to_s
       else
-        arbre.send(described_class.builder_method_name, *args, &block)
+        component = described_class
+
+        arbre do
+          insert_tag(component, *args, &block)
+        end
       end
   end
 end

--- a/spec/views/components/pageflow/admin/user_accounts_tab_spec.rb
+++ b/spec/views/components/pageflow/admin/user_accounts_tab_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Pageflow
+  describe Admin::UserAccountsTab, type: :view_component do
+    before do
+      helper.extend(ActiveAdmin::ViewHelpers)
+      helper.extend(Pageflow::Admin::MembershipsHelper)
+      helper.extend(Rails.application.routes.url_helpers)
+
+      allow(helper).to receive(:url_for)
+      allow(helper).to receive(:authorized?).and_return(true)
+    end
+
+    %w[
+      pageflow_accounts.name_desc
+      pageflow_memberships.role_desc
+      pageflow_memberships.created_at desc
+    ].each do |order|
+      it "can be sorted by #{order}" do
+        user = create(:user)
+        create(:account, with_member: user, name: 'Account 1')
+        create(:account, with_publisher: user, name: 'Account 2')
+
+        sign_in(user)
+        params[:order] = order
+
+        render(user)
+
+        expect(rendered).to have_selector('table tr td', text: 'Account 1')
+        expect(rendered).to have_selector('table tr td', text: 'Account 2')
+      end
+    end
+  end
+end

--- a/spec/views/components/pageflow/admin/user_entries_tab_spec.rb
+++ b/spec/views/components/pageflow/admin/user_entries_tab_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+module Pageflow
+  describe Admin::UserEntriesTab, type: :view_component do
+    before do
+      helper.extend(ActiveAdmin::ViewHelpers)
+      helper.extend(Pageflow::Admin::MembershipsHelper)
+      helper.extend(Rails.application.routes.url_helpers)
+
+      allow(helper).to receive(:url_for)
+      allow(helper).to receive(:authorized?).and_return(true)
+    end
+
+    %w[
+      pageflow_entries.title_desc
+      pageflow_accounts.name_desc
+      pageflow_memberships.role_desc
+      pageflow_memberships.created_at desc
+    ].each do |order|
+      it "can be sorted by #{order}" do
+        user = create(:user)
+        create(:entry, with_editor: user, title: 'Entry 1')
+        create(:entry, with_publisher: user, title: 'Entry 2')
+
+        sign_in(user)
+        params[:order] = order
+
+        render(user)
+
+        expect(rendered).to have_selector('table tr td', text: 'Entry 1')
+        expect(rendered).to have_selector('table tr td', text: 'Entry 2')
+      end
+    end
+  end
+end


### PR DESCRIPTION
When eager loading memberships entities, we need to ensure (using
`references`) that ActiveRecord always does a join instead of separate
query. Otherwise the conidition inside the `account`/`entry`
associations references a missing column.

Before the table only worked when sorting by entity name since the
order requires a join.

Also make sure to actually use the preloaded association to prevent
N+1 queries.