### PR TITLE
mark %pageflow_widget_margin_right optional

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/player_controls/widget_margins.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/player_controls/widget_margins.scss
@@ -11,5 +11,5 @@
 }
 
 .player_controls-menu_bar-stand_alone {
-  @extend %pageflow_widget_margin_right;
+  @extend %pageflow_widget_margin_right !optional;
 }


### PR DESCRIPTION
widgets don't _have_ to provide it.
it will raise an error in the default player otherwise.

continuation of #771