### PR TITLE
move player controls to host pageflow initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 #### Breaking Changes
 
-- Move player controls initialization to the generated Pageflow initializer. Add these lines to `config/initializers/pageflow.rb` in your host application:
+- The built-in widget types must now be registered in the host application. To keep existing functionality from previous Pageflow versions, add these lines to `config/initializers/pageflow.rb` in your host application:
 
 ```
-# Configure the classic or slim player controls.
+# Register the built-in widget types.
+# You can remove these or add different versions with the same name.
+config.widget_types.register(Pageflow::BuiltInWidgetType.navigation, default: true)
+config.widget_types.register(Pageflow::BuiltInWidgetType.mobile_navigation, default: true)
 config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls, default: true)
 config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls)
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 [Compare changes](https://github.com/codevise/pageflow/compare/12-0-stable...master)
 
+#### Breaking Changes
+
+- Move player controls initialization to the generated Pageflow initializer. Add these lines to `config/initializers/pageflow.rb` in your host application:
+
+```
+# Configure the classic or slim player controls.
+config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls, default: true)
+config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls)
+```
+
 Media stack:
 
 - Switch from `Expires` to `Cache-Control` header for media uploads.

--- a/config/initializers/widget_types.rb
+++ b/config/initializers/widget_types.rb
@@ -1,4 +1,0 @@
-Pageflow.configure do |config|
-  config.widget_types.register(Pageflow::BuiltInWidgetType.navigation, default: true)
-  config.widget_types.register(Pageflow::BuiltInWidgetType.mobile_navigation, default: true)
-end

--- a/config/initializers/widget_types.rb
+++ b/config/initializers/widget_types.rb
@@ -1,7 +1,4 @@
 Pageflow.configure do |config|
   config.widget_types.register(Pageflow::BuiltInWidgetType.navigation, default: true)
   config.widget_types.register(Pageflow::BuiltInWidgetType.mobile_navigation, default: true)
-
-  config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls, default: true)
-  config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls)
 end

--- a/lib/generators/pageflow/initializer/templates/pageflow.rb
+++ b/lib/generators/pageflow/initializer/templates/pageflow.rb
@@ -3,9 +3,12 @@ Pageflow.configure do |config|
   # users.
   config.mailer_sender = 'change-me-at-config-initializers-pageflow@example.com'
 
-  # Configure the classic or slim player controls.
-  config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls, default: true)
+  # Register the built-in widget types.
+  # You can remove these or add different versions with the same name.
+  config.widget_types.register(Pageflow::BuiltInWidgetType.navigation, default: true)
+  config.widget_types.register(Pageflow::BuiltInWidgetType.mobile_navigation, default: true)
   config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls)
+  config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls, default: true)
 
   # Plugins provide page types and widget types.
   config.plugin(Pageflow.built_in_page_types_plugin)

--- a/lib/generators/pageflow/initializer/templates/pageflow.rb
+++ b/lib/generators/pageflow/initializer/templates/pageflow.rb
@@ -3,6 +3,10 @@ Pageflow.configure do |config|
   # users.
   config.mailer_sender = 'change-me-at-config-initializers-pageflow@example.com'
 
+  # Configure the classic or slim player controls.
+  config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls, default: true)
+  config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls)
+
   # Plugins provide page types and widget types.
   config.plugin(Pageflow.built_in_page_types_plugin)
   # config.plugin(Pageflow::Rainbow.plugin)

--- a/spec/generators/pageflow/initializer/initializer_generator_spec.rb
+++ b/spec/generators/pageflow/initializer/initializer_generator_spec.rb
@@ -15,14 +15,24 @@ module Pageflow
         expect(initializer).to exist
       end
 
-      it 'registers classic player controls' do
+      it 'registers the built-in classic player controls' do
         expect(initializer)
           .to contain('config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls')
       end
 
-      it 'registers slim player controls' do
+      it 'registers the built-in slim player controls' do
         expect(initializer)
           .to contain('config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls')
+      end
+
+      it 'registers the built-in navigation widget type' do
+        expect(initializer)
+          .to contain('config.widget_types.register(Pageflow::BuiltInWidgetType.navigation')
+      end
+
+      it 'registers the built-in mobile_navigation widget type' do
+        expect(initializer)
+          .to contain('config.widget_types.register(Pageflow::BuiltInWidgetType.mobile_navigation')
       end
     end
   end

--- a/spec/generators/pageflow/initializer/initializer_generator_spec.rb
+++ b/spec/generators/pageflow/initializer/initializer_generator_spec.rb
@@ -5,9 +5,24 @@ require 'generators/pageflow/initializer/initializer_generator'
 module Pageflow
   module Generators
     describe InitializerGenerator, type: :generator do
-      it "generates 'config/initializers/pageflow.rb'" do
+      let(:initializer) { file('config/initializers/pageflow.rb') }
+
+      before do
         run_generator
-        expect(file('config/initializers/pageflow.rb')).to exist
+      end
+
+      it "generates 'config/initializers/pageflow.rb'" do
+        expect(initializer).to exist
+      end
+
+      it "registers classic player controls" do
+        expect(initializer)
+          .to contain("config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls")
+      end
+
+      it "registers slim player controls" do
+        expect(initializer)
+          .to contain("config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls")
       end
     end
   end

--- a/spec/generators/pageflow/initializer/initializer_generator_spec.rb
+++ b/spec/generators/pageflow/initializer/initializer_generator_spec.rb
@@ -15,14 +15,14 @@ module Pageflow
         expect(initializer).to exist
       end
 
-      it "registers classic player controls" do
+      it 'registers classic player controls' do
         expect(initializer)
-          .to contain("config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls")
+          .to contain('config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls')
       end
 
-      it "registers slim player controls" do
+      it 'registers slim player controls' do
         expect(initializer)
-          .to contain("config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls")
+          .to contain('config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls')
       end
     end
   end


### PR DESCRIPTION
This exposes the player controls, making them configurable from the host
application. It's possible to do this already, directly in the pageflow
initializer:

```
config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls,
default: true)
```

The classic controls would still be available, though. To allow removing
them altogether, I see different options:

- The simplest thing would be to move the registration calls for the
  widget types [1] to the host application initializer. This would be a
  breaking change, but maybe even more aligned with the way things work
  for built in page types already.