### PR TITLE
Move register calls for built-in widget types to plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,10 @@
 
 #### Breaking Changes
 
-- The built-in widget types must now be registered in the host application. To keep existing functionality from previous Pageflow versions, add these lines to `config/initializers/pageflow.rb` in your host application:
+- The built-in widget types must now be registered in the host application. To keep existing functionality from previous Pageflow versions, add this line to `config/initializers/pageflow.rb` in your host application:
 
 ```
-# Register the built-in widget types.
-# You can remove these or add different versions with the same name.
-config.widget_types.register(Pageflow::BuiltInWidgetType.navigation, default: true)
-config.widget_types.register(Pageflow::BuiltInWidgetType.mobile_navigation, default: true)
-config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls, default: true)
-config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls)
+config.plugin(Pageflow.built_in_widget_types_plugin)
 ```
 
 Media stack:

--- a/lib/generators/pageflow/initializer/templates/pageflow.rb
+++ b/lib/generators/pageflow/initializer/templates/pageflow.rb
@@ -3,15 +3,9 @@ Pageflow.configure do |config|
   # users.
   config.mailer_sender = 'change-me-at-config-initializers-pageflow@example.com'
 
-  # Register the built-in widget types.
-  # You can remove these or add different versions with the same name.
-  config.widget_types.register(Pageflow::BuiltInWidgetType.navigation, default: true)
-  config.widget_types.register(Pageflow::BuiltInWidgetType.mobile_navigation, default: true)
-  config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls)
-  config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls, default: true)
-
   # Plugins provide page types and widget types.
   config.plugin(Pageflow.built_in_page_types_plugin)
+  config.plugin(Pageflow.built_in_widget_types_plugin)
   # config.plugin(Pageflow::Rainbow.plugin)
 
   # Add custom themes by invoking the pageflow:theme generator and

--- a/lib/pageflow.rb
+++ b/lib/pageflow.rb
@@ -37,4 +37,8 @@ module Pageflow
   def self.built_in_page_types_plugin
     BuiltInPageTypesPlugin.new
   end
+
+  def self.built_in_widget_types_plugin
+    BuiltInWidgetTypesPlugin.new
+  end
 end

--- a/lib/pageflow/built_in_widget_types_plugin.rb
+++ b/lib/pageflow/built_in_widget_types_plugin.rb
@@ -1,0 +1,10 @@
+module Pageflow
+  class BuiltInWidgetTypesPlugin < Plugin
+    def configure(config)
+      config.widget_types.register(Pageflow::BuiltInWidgetType.navigation, default: true)
+      config.widget_types.register(Pageflow::BuiltInWidgetType.mobile_navigation, default: true)
+      config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls)
+      config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls, default: true)
+    end
+  end
+end

--- a/spec/generators/pageflow/initializer/initializer_generator_spec.rb
+++ b/spec/generators/pageflow/initializer/initializer_generator_spec.rb
@@ -15,24 +15,9 @@ module Pageflow
         expect(initializer).to exist
       end
 
-      it 'registers the built-in classic player controls' do
+      it 'registers the built-in widget types plugin' do
         expect(initializer)
-          .to contain('config.widget_types.register(Pageflow::BuiltInWidgetType.classic_player_controls')
-      end
-
-      it 'registers the built-in slim player controls' do
-        expect(initializer)
-          .to contain('config.widget_types.register(Pageflow::BuiltInWidgetType.slim_player_controls')
-      end
-
-      it 'registers the built-in navigation widget type' do
-        expect(initializer)
-          .to contain('config.widget_types.register(Pageflow::BuiltInWidgetType.navigation')
-      end
-
-      it 'registers the built-in mobile_navigation widget type' do
-        expect(initializer)
-          .to contain('config.widget_types.register(Pageflow::BuiltInWidgetType.mobile_navigation')
+          .to contain('config.plugin(Pageflow.built_in_widget_types_plugin')
       end
     end
   end


### PR DESCRIPTION
In #774, widget type registrations have been moved to the host application, to
allow disabling built in widget types.

Extracting the register calls into a plugin has a couple of
advantages:

* Should there ever be a need to add a built-in widget type, host
  applications which follow the default setup need not be modified.

* More in line with the way built in page types are registered.

* Same flexibility: If you do not wish to use the default set of built
  in widget types, simply replace the plugin with a bunch of custom
  register calls.