### PR TITLE
[WIP] Paperclip :pageflow_filesystem_root interpolation

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,8 +1,9 @@
 require 'socket'
+require 'rails'
 
 Pageflow.configure do |config|
   config.paperclip_attachments_version = 'v1'
-  config.paperclip_filesystem_root = Rails.root.join('tmp/attachments/production/')
+  config.paperclip_filesystem_root = Rails.root.join("tmp/attachments/#{Rails.env}/")
 
   if Rails.env.test?
     config.paperclip_s3_default_options.merge!({
@@ -71,35 +72,22 @@ Pageflow.configure do |config|
   }
 end
 
-if Rails.env.development?
-  Paperclip.interpolates(:pageflow_filesystem_root) do |attachment, style|
-    Rails.root.join('tmp/attachments/development/filesystem')
-  end
-
-  Paperclip.interpolates(:host) do |attachment, style|
-    ENV.fetch('PAGEFLOW_ATTACHMENTS_SCOPE_NAME') { Socket.gethostname }
-  end
+Paperclip.interpolates(:pageflow_filesystem_root) do |attachment, style|
+  Pageflow.config.paperclip_filesystem_root
 end
 
-if Rails.env.production?
-  Paperclip.interpolates(:pageflow_filesystem_root) do |attachment, style|
-    Pageflow.config.paperclip_filesystem_root
-  end
-
-  Paperclip.interpolates(:host) do |attachment, style|
+Paperclip.interpolates(:host) do |attachment, style|
+  case Rails.env
+  when "development"
+    ENV.fetch('PAGEFLOW_ATTACHMENTS_SCOPE_NAME') { Socket.gethostname }
+  when "test"
+    'test-host'
+  else
     'main'
   end
 end
 
 if Rails.env.test?
-  Paperclip.interpolates(:pageflow_filesystem_root) do |attachment, style|
-    Rails.root.join('tmp/attachments/test/filesystem')
-  end
-
-  Paperclip.interpolates(:host) do |attachment, style|
-    'test-host'
-  end
-
   class Paperclip::Attachment
     def bucket_name
       'test'

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -5,28 +5,21 @@ Pageflow.configure do |config|
   config.paperclip_attachments_version = 'v1'
   config.paperclip_filesystem_root = Rails.root.join("tmp/attachments/#{Rails.env}/")
 
-  if Rails.env.test?
-    config.paperclip_s3_default_options.merge!({
-      storage: :filesystem,
-      path: ':rails_root/tmp/attachments/test/s3/:class/:attachment/:id_partition/:style/:filename'
-    })
-  else
-    config.paperclip_s3_default_options.merge!({
-      storage: :s3,
-      s3_headers: {'Cache-Control' => "public, max-age=31536000"},
-      s3_options: {max_retries: 10},
+  config.paperclip_s3_default_options.merge!({
+    storage: :s3,
+    s3_headers: {'Cache-Control' => "public, max-age=31536000"},
+    s3_options: {max_retries: 10},
 
-      url: ':s3_alias_url',
-      path: ':host/:class_basename/:attachment/:id_partition/:pageflow_attachments_version:style/:filename',
+    url: ':s3_alias_url',
+    path: ':host/:class_basename/:attachment/:id_partition/:pageflow_attachments_version:style/:filename',
 
-      # Paperclip deletes and reuploads the original on
-      # reprocess. Sometimes S3 seems to change the order of commands
-      # causing the image to be deleted. This is fixed on paperclip
-      # master, but for us not deleting old files is good enough. They
-      # might be in the CDN anyway.
-      keep_old_files: true
-    })
-  end
+    # Paperclip deletes and reuploads the original on
+    # reprocess. Sometimes S3 seems to change the order of commands
+    # causing the image to be deleted. This is fixed on paperclip
+    # master, but for us not deleting old files is good enough. They
+    # might be in the CDN anyway.
+    keep_old_files: true
+  })
 
   config.paperclip_filesystem_default_options.merge!({
     storage: :filesystem,
@@ -84,14 +77,6 @@ Paperclip.interpolates(:host) do |attachment, style|
     'test-host'
   else
     'main'
-  end
-end
-
-if Rails.env.test?
-  class Paperclip::Attachment
-    def bucket_name
-      'test'
-    end
   end
 end
 

--- a/spec/support/config/pageflow.rb
+++ b/spec/support/config/pageflow.rb
@@ -1,0 +1,6 @@
+Pageflow.configure do |config|
+  config.paperclip_s3_default_options.merge!({
+    storage: :filesystem,
+    path: ':rails_root/tmp/attachments/test/s3/:class/:attachment/:id_partition/:style/:filename'
+  })
+end

--- a/spec/support/config/paperclip.rb
+++ b/spec/support/config/paperclip.rb
@@ -10,3 +10,9 @@ RSpec.configure do |config|
     allow(Paperclip).to receive(:run).and_return('100x100')
   end
 end
+
+class Paperclip::Attachment
+  def bucket_name
+    'test'
+  end
+end


### PR DESCRIPTION
Previously, this interpolation would only be defined in development, test and production environments. A staging environment did not have this interpolation which would lead to an error. Changed the existing code to a switch inside the definition, so that an interpolation value always exists.

The special cases for Rails.env.test should probably move into a support file under spec.