### PR TITLE
replace simple jQuery with native JavaScript

### DIFF
--- a/app/views/layouts/pageflow/application.html.erb
+++ b/app/views/layouts/pageflow/application.html.erb
@@ -23,8 +23,8 @@
 
 <body class="load_all_images has_no_mobile_platform non_js">
   <script>
-    jQuery('body').removeClass('load_all_images');
-    jQuery("body").removeClass('non_js').addClass('js');
+    document.body.classList.remove('load_all_images', 'non_js');
+    document.body.classList.add('js');
   </script>
   <%= yield %>
 </body>


### PR DESCRIPTION
element.classList is quite widely supported:
http://caniuse.com/#search=classlist

Legacy IE does not support multiple parameters for the add() and
remove() methods. I could solve this by using two lines for the removal.

I know there is a solid dependence on jQuery but for these simple class
manipulations we shouldn't need to load all of jQuery?