### PR TITLE
rename the section ID to "page-nnnn"

### DIFF
--- a/app/views/pageflow/pages/_page.html.erb
+++ b/app/views/pageflow/pages/_page.html.erb
@@ -1,5 +1,10 @@
 <%= cache page do %>
-  <%= content_tag :section, :id => page.perma_id, :class => page_css_class(page), :data => {:template => page.template, :id => page.id, :chapter_id => page.chapter_id} do %>
+  <%= content_tag :section, id: "page-#{page.perma_id}", class: page_css_class(page),
+    data: {
+      template: page.template,
+      id: page.id,
+      chapter_id: page.chapter_id
+    } do %>
     <%= render_page_template(page, entry: entry) %>
     <a class="to_top" href="#content"><%= t('pageflow.public.goto_top') %></a>
   <% end %>


### PR DESCRIPTION
In CSS, selectors cannot begin with a numeric ID.

There are [workarounds](https://benfrain.com/when-and-where-you-can-use-numbers-in-id-and-class-names/) but following the spec seems better.