### PR TITLE
[WIP] Provide consistent interface for entry and account policies

### DIFF
--- a/app/policies/pageflow/account_policy.rb
+++ b/app/policies/pageflow/account_policy.rb
@@ -84,6 +84,21 @@ module Pageflow
       @account = account
     end
 
+    def be_member_on?
+      @user.admin? ||
+        allows?(%w(member previewer editor publisher manager))
+    end
+
+    def preview?
+      @user.admin? ||
+        allows?(%w(previewer editor publisher manager))
+    end
+
+    def edit?
+      @user.admin? ||
+        allows?(%w(editor publisher manager))
+    end
+
     def publish?
       @user.admin? ||
         allows?(%w(publisher manager))

--- a/app/policies/pageflow/entry_policy.rb
+++ b/app/policies/pageflow/entry_policy.rb
@@ -47,7 +47,8 @@ module Pageflow
     end
 
     def preview?
-      query.has_at_least_role?(:previewer)
+      user.admin? ||
+        query.has_at_least_role?(:previewer)
     end
 
     def read?
@@ -59,7 +60,8 @@ module Pageflow
     end
 
     def edit?
-      query.has_at_least_role?(:editor)
+      user.admin? ||
+        query.has_at_least_role?(:editor)
     end
 
     def confirm_encoding?
@@ -83,7 +85,8 @@ module Pageflow
     end
 
     def publish?
-      query.has_at_least_role?(:publisher)
+      user.admin? ||
+        query.has_at_least_role?(:publisher)
     end
 
     def create?


### PR DESCRIPTION
Since we did not need some of the account policies, we did not provide them up to this point. To provide a more consistent policy interface, this commit adds three methods that were undefined so far.

Also, the standard entry and account policies now always include admin. This was also inconsistent.