### PR TITLE
Add theme option to right align logo in desktop layout

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/logo/alignment.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/logo/alignment.scss
@@ -1,0 +1,27 @@
+/// Alignment of the logo in desktop layout. In phone layout, logos
+/// are always displayed left aligned.
+///
+/// - `"left"`: Left align logo.
+///
+/// - `"right"`: Right align logo in desktop layout.
+$logo-alignment: "left" !default;
+
+// Left position relative to page when logo is left aligned.
+$logo-left: 8% !default;
+
+// Right position relative to page when logo is right aligned.
+$logo-right: 14% !default;
+
+@mixin logo-alignment {
+  @include desktop {
+    @if $logo-alignment == "left" {
+      left: $logo-left;
+    } @else {
+      right: $logo-right;
+    }
+  }
+
+  @include phone {
+    left: $logo-left;
+  }
+}

--- a/app/assets/stylesheets/pageflow/themes/default/logo/variant/background_image.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/logo/variant/background_image.scss
@@ -1,3 +1,5 @@
+@import "../alignment";
+
 @mixin logo-variant-background-image(
   $first-page-only,
   $top,
@@ -14,7 +16,6 @@
     .content_and_background .scroller > div:after {
       content: "";
       position: absolute;
-      left: 8%;
       top: $top;
       z-index: 200;
       min-width: $min-width;
@@ -24,9 +25,10 @@
       background-image: image-url("pageflow/themes/#{$theme-name}/logo_header.png");
       background-repeat: no-repeat;
       background-size: contain;
-      background-position: left top;
+      background-position: #{$logo-alignment} top;
 
       @include mobile {
+        background-position: left top;
         padding-top: 1%;
         height: $mobile-height;
       }
@@ -34,6 +36,8 @@
       @include phone {
         top: $phone-top;
       }
+
+      @include logo-alignment;
     }
 
     &.invert .content_and_background .scroller > div:after {

--- a/app/assets/stylesheets/pageflow/themes/default/logo/variant/watermark.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/logo/variant/watermark.scss
@@ -1,3 +1,5 @@
+@import "../alignment";
+
 /// Fade in logo when scroller is near top
 ///
 /// - `"first-page"`: only on first page
@@ -25,7 +27,6 @@ $logo-watermark-variant-fade-in-with-header: false !default;
     width: $width;
     height: $height;
     top: $top;
-    left: 8%;
     z-index: 1;
 
     pointer-events: none;
@@ -37,6 +38,8 @@ $logo-watermark-variant-fade-in-with-header: false !default;
       height: $phone-height;
       top: 21px;
     }
+
+    @include logo-alignment;
 
     .js & {
       display: block;


### PR DESCRIPTION
In phone layout, the logo remains on left side to prevent conflict
with mobile navigation button.