### PR TITLE
Allow specifying opacity of image variant logo

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/logo/variant/background_image.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/logo/variant/background_image.scss
@@ -1,3 +1,9 @@
+// Opacity of the logo
+$logo-background-image-variant-opacity: null !default;
+
+/// Opacity of the logo on the first page
+$logo-background-image-variant-first-page-opacity: null !default;
+
 @mixin logo-variant-background-image(
   $first-page-only,
   $top,
@@ -39,5 +45,13 @@
     &.invert .content_and_background .scroller > div:after {
       background-image: image-url("pageflow/themes/#{$theme-name}/logo_header_invert.png");
     }
+  }
+
+  .page .scroller > div:after {
+    opacity: $logo-background-image-variant-opacity;
+  }
+
+  .page:first-child .scroller > div:after {
+    opacity: $logo-background-image-variant-first-page-opacity;
   }
 }


### PR DESCRIPTION
Provide a separate variable for the logo on the first page, to allow
e.g. having a transparent logo on all but the first page.