### PR TITLE
Call hook on entry publication

### DIFF
--- a/app/models/pageflow/entry_publication.rb
+++ b/app/models/pageflow/entry_publication.rb
@@ -16,6 +16,8 @@ module Pageflow
     def save!
       assumed_quota.verify_not_exceeded!
       entry.publish(attributes.merge(creator: user))
+
+      Pageflow.config.hooks.invoke(:entry_published, entry: entry)
     end
 
     private

--- a/spec/models/pageflow/entry_publication_spec.rb
+++ b/spec/models/pageflow/entry_publication_spec.rb
@@ -87,7 +87,7 @@ module Pageflow
 
       it 'invokes entry_published hooks' do
         entry = create(:entry)
-        user = create(:user, account: entry.account)
+        user = create(:user, :previewer, on: entry)
         quota = QuotaDouble.available.new(:published_entries, entry.account)
         entry_publication = EntryPublication.new(entry, {}, quota, user)
         subscriber = double('subscriber', call: nil)

--- a/spec/models/pageflow/entry_publication_spec.rb
+++ b/spec/models/pageflow/entry_publication_spec.rb
@@ -84,6 +84,19 @@ module Pageflow
 
         entry_publication.save!
       end
+
+      it 'invokes entry_published hooks' do
+        entry = create(:entry)
+        user = create(:user, account: entry.account)
+        quota = QuotaDouble.available.new(:published_entries, entry.account)
+        entry_publication = EntryPublication.new(entry, {}, quota, user)
+        subscriber = double('subscriber', call: nil)
+
+        Pageflow.config.hooks.on(:entry_published, subscriber)
+        entry_publication.save!
+
+        expect(subscriber).to have_received(:call).with(entry: entry)
+      end
     end
   end
 end


### PR DESCRIPTION
Allow plugins to register custom functionality to be performed when an
entry has been published.