### PR TITLE
read the attribute instead of super

### DIFF
--- a/app/models/concerns/pageflow/feature_target.rb
+++ b/app/models/concerns/pageflow/feature_target.rb
@@ -49,7 +49,7 @@ module Pageflow
     end
 
     def features_configuration
-      super || {}
+      self[:features_configuration] || {}
     end
   end
 end

--- a/app/models/concerns/pageflow/output_source.rb
+++ b/app/models/concerns/pageflow/output_source.rb
@@ -40,7 +40,8 @@ module Pageflow
     end
 
     def output_presences
-      (super || {}).merge(externally_generated_output_presences)
+      output_presences = self[:output_presences] || {}
+      output_presences.merge(externally_generated_output_presences)
     end
 
     def externally_generated_outputs

--- a/app/models/concerns/pageflow/serialized_configuration.rb
+++ b/app/models/concerns/pageflow/serialized_configuration.rb
@@ -11,7 +11,7 @@ module Pageflow
     end
 
     def configuration
-      super || {}
+      self[:configuration] || {}
     end
   end
 end


### PR DESCRIPTION
super is a bit counter-intuitive since the method might not exist on the superclass, but we're just relying on the message being picked up anyway. By reading the attribute the intent is made more clear.

We are not using `read_attribute` but the brackets, because the latter raises an exception when the attribute cannot be found. The rails style guide recommends so. https://github.com/bbatsov/rails-style-guide#read-attribute