### PR TITLE
[WIP] Allow HTTP caching based on Last-Modified

### DIFF
--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -39,6 +39,8 @@ module Pageflow
           else
             @entry.share_target = @entry
           end
+
+          fresh_when(@entry, public: true)
         end
         format.json do
           authenticate_user!

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -25,6 +25,7 @@ module Pageflow
              :author, :publisher, :keywords,
              :theme,
              :password_protected?,
+             :created_at, :updated_at,
              :to => :revision)
 
     def initialize(entry, revision = nil)


### PR DESCRIPTION
Uses `fresh_when` to both set `Last-Modified` on a client's initial request, and respond with `304 Not Modified` if the content hasn't changed. For this, we added delegation of the ActiveRecord timestamps on Entry to Revision.

This change speeds up browsers. By adding `public: true` we also allow caching proxies to store the response. This setup even prevents the application server being hit at all. It can be accomplished using a simple cache like rack-cache, but also works great with cdn-based reverse proxy servers, nginx, Varnish, CloudFlare, etc.