### PR TITLE
Prevent 404 when share image has been deleted

### DIFF
--- a/app/helpers/pageflow/social_share_helper.rb
+++ b/app/helpers/pageflow/social_share_helper.rb
@@ -53,9 +53,10 @@ module Pageflow
 
     def social_share_entry_image_tags(entry)
       image_urls = []
+      image_file = ImageFile.find_by_id(entry.share_image_id)
 
-      if entry.share_image_id.present?
-        image_urls << ImageFile.find(entry.share_image_id).thumbnail_url(:medium)
+      if image_file
+        image_urls << image_file.thumbnail_url(:medium)
       else
         entry.pages.each do |page|
           if image_urls.size >= 4

--- a/spec/helpers/pageflow/social_share_helper_spec.rb
+++ b/spec/helpers/pageflow/social_share_helper_spec.rb
@@ -176,6 +176,21 @@ module Pageflow
         expect(html).to have_css("meta[content=\"#{@image1.thumbnail_url(:medium)}\"][name=\"twitter:image:src\"]", visible: false)
         expect(html).to have_css('meta[name="twitter:image:src"]', visible: false, count: 1)
       end
+
+      it 'falls back to page thumbnails if share image references missing image' do
+        @entry.published_revision.share_image_id = @image1.id
+        published_entry = PublishedEntry.new(@entry)
+        storyline = create(:storyline, revision: @entry.published_revision)
+        chapter = create(:chapter, storyline: storyline)
+        create(:page, configuration: {thumbnail_image_id: @image2.id}, chapter: chapter)
+
+        @image1.destroy
+        html = helper.social_share_entry_image_tags(published_entry)
+
+        expect(html).to have_css(<<-END.strip, visible: false, count: 1)
+          meta[content="#{@image2.thumbnail_url(:medium)}"][property="og:image"]
+        END
+      end
     end
   end
 end


### PR DESCRIPTION
Fallback to page thumbnails if configured share image no longer
exists.