### PR TITLE
Improve pageflow-support gem

### DIFF
--- a/spec/support/Rakefile
+++ b/spec/support/Rakefile
@@ -1,0 +1,7 @@
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+Bundler::GemHelper.install_tasks

--- a/spec/support/pageflow-support.gemspec
+++ b/spec/support/pageflow-support.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['.']
 
-  s.add_runtime_dependency 'mysql2'
+  s.add_runtime_dependency 'pageflow', Pageflow::VERSION
+  s.add_runtime_dependency 'mysql2', '~> 0.3.16'
 end

--- a/spec/support/pageflow/dummy/app.rb
+++ b/spec/support/pageflow/dummy/app.rb
@@ -1,3 +1,5 @@
+require 'pageflow/version'
+
 module Pageflow
   module Dummy
     class App
@@ -17,7 +19,7 @@ module Pageflow
 
       def directory
         require 'rails/version'
-        File.join('spec', 'dummy', "rails-#{Rails::VERSION::STRING}")
+        File.join('spec', 'dummy', "rails-#{Rails::VERSION::STRING}-pageflow-#{Pageflow::VERSION}")
       end
 
       def template_path

--- a/spec/support/pageflow/dummy/rails_template.rb
+++ b/spec/support/pageflow/dummy/rails_template.rb
@@ -25,6 +25,11 @@ append_to_file('config/application.rb', <<-END)
   end
 END
 
+# Ensure pageflow is required even if it is not listed in plugin Gemfile does
+inject_into_file('config/application.rb',
+                 "require 'pageflow'\n",
+                 after: "Bundler.require(*Rails.groups)\n")
+
 # Remove requires to missing gems (i.e. turbolinks)
 gsub_file('app/assets/javascripts/application.js', %r'//=.*', '')
 


### PR DESCRIPTION
* Prevent install generators from failing when generating dummy app in
  plugin engine by requiring Pageflow from dummy app. In a real app
  Pageflow would be required by Bundler since it would be listed in
  the app's Gemfile. This need not be the case in plugin engines.

* Include pageflow version in dummy app directory name to ensure
  regeneration when running specs with other Pageflow version.

* Ensure `pageflow-support` gem version matches `pageflow` gem
  version.

* Restrict `mysql` dependency version.

* Allow using bundler gem tasks for `pageflow-support`.