### PR TITLE
Preload page background images

### DIFF
--- a/node_package/src/components/BackgroundImage.jsx
+++ b/node_package/src/components/BackgroundImage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import {preloadBackgroundImage} from 'utils';
 
 /**
  * Display an element with a background image referenced by
@@ -23,9 +24,15 @@ import classNames from 'classnames';
 export default class BackgroundImage extends React.Component {
   render() {
     return (
-      <div className={this.cssClass()} style={this.style()}>
+      <div className={this.cssClass()} style={this.style()} ref={element => this.element = element}>
       </div>
     );
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.loaded && !prevProps.loaded) {
+      preloadBackgroundImage(this.element);
+    }
   }
 
   cssClass() {

--- a/node_package/src/utils/index.js
+++ b/node_package/src/utils/index.js
@@ -2,6 +2,7 @@ import camelize from './camelize';
 import combine from './combine';
 import memoizedSelector, {combine as combineSelectors} from './memoizedSelector';
 import has from './has';
+import preloadBackgroundImage from './preloadBackgroundImage';
 
 export {
   camelize,
@@ -10,5 +11,7 @@ export {
   combineSelectors,
   memoizedSelector,
 
-  has
+  has,
+
+  preloadBackgroundImage
 };

--- a/node_package/src/utils/preloadBackgroundImage.js
+++ b/node_package/src/utils/preloadBackgroundImage.js
@@ -1,0 +1,7 @@
+export default function preloadBackgroundImage(element) {
+  const propertyValue = window.getComputedStyle(element).getPropertyValue('background-image');
+
+  if (propertyValue.match(/^url/)) {
+    new Image().src = propertyValue.replace(/^url\(['"]?/, '').replace(/['"]?\)$/, '');
+  }
+}


### PR DESCRIPTION
Setting the `load_image` css class to make sure the `background-image`
rule applies does not trigger image loading (e.g. in Chrome). Detect
image url via computed styles to account for media queries and ensure
image is loaded via `new Image()`.

Originally similar functionality was part of most page types'
`preload` hooks, but has not been ported to React based page types so
far.