### PR TITLE
Do not record history when changing pages via scrolling

### DIFF
--- a/app/assets/javascripts/pageflow/history.js
+++ b/app/assets/javascripts/pageflow/history.js
@@ -8,6 +8,9 @@ pageflow.History = function(slideshow, adapter) {
     if (options.back) {
       adapter.replaceState(null, '', adapter.hash());
     }
+    else if (options.ignoreInHistory) {
+      adapter.replaceState(null, '', hash);
+    }
     else {
       adapter.replaceState(options, '', adapter.hash());
       adapter.pushState(null, '', hash);

--- a/app/assets/javascripts/pageflow/slideshow/dom_order_scroll_navigator.js
+++ b/app/assets/javascripts/pageflow/slideshow/dom_order_scroll_navigator.js
@@ -12,12 +12,15 @@ pageflow.DomOrderScrollNavigator = function(slideshow, entryData) {
     }
 
     slideshow.goTo(previousPage, {
-      position: position
+      position: position,
+      ignoreInHistory: true
     });
   };
 
   this.next = function(currentPage, pages) {
-    slideshow.goTo(this.getNextPage(currentPage, pages));
+    slideshow.goTo(this.getNextPage(currentPage, pages), {
+      ignoreInHistory: true
+    });
   };
 
   this.nextPageExists = function(currentPage, pages) {


### PR DESCRIPTION
When looking at an entry each visited page used to be recorded as an
individual history entry. This can make it quite hard to leave a
Pageflow when coming from some external site since you have to trace
your whole path through the entry backwards.

Now instead, we only record history entries when changing pages via
links or buttons and ignore page changes that are caused by back/next
scroll navigation.

This allows to use the back button to return from a sub storyline or
go back to a page with internal links. The overall behavior should
resemble interaction with a normal website much more closely.