### PR TITLE
destroy widgets when parent subject is destroyed

### DIFF
--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -12,7 +12,7 @@ module Pageflow
     belongs_to :creator, :class_name => 'User'
     belongs_to :restored_from, :class_name => 'Pageflow::Revision'
 
-    has_many :widgets, :as => :subject
+    has_many :widgets, as: :subject, dependent: :destroy
     has_many :storylines, -> { order('pageflow_storylines.position ASC') }
     has_many :chapters, -> { order('position ASC') }, through: :storylines
     has_many :pages, -> { reorder(PAGE_ORDER) }, through: :storylines

--- a/app/models/pageflow/theming.rb
+++ b/app/models/pageflow/theming.rb
@@ -3,7 +3,7 @@ module Pageflow
     include ThemeReferencer
 
     belongs_to :account
-    has_many :widgets, as: :subject
+    has_many :widgets, as: :subject, dependent: :destroy
 
     has_many :entries
 


### PR DESCRIPTION
leaves invalid rows in the database otherwise.