### PR TITLE
Fix memberships

### DIFF
--- a/admins/pageflow/membership.rb
+++ b/admins/pageflow/membership.rb
@@ -14,12 +14,6 @@ module Pageflow
       helper Pageflow::Admin::MembershipsHelper
       helper Pageflow::Admin::FormHelper
 
-      def permitted_params
-        result = params.permit(membership: [:user_id, :entity_id, :entity_type, :role])
-        restrict_attributes(result[:membership]) if result[:membership]
-        result
-      end
-
       def index
         if params[:user_id].present?
           redirect_to admin_user_url(params[:user_id])

--- a/app/views/admin/memberships/_form.html.erb
+++ b/app/views/admin/memberships/_form.html.erb
@@ -1,22 +1,25 @@
 <%= admin_form_for [:admin, parent, resource] do |f| %>
+  <% entity_type = resource.entity_type || params[:entity_type] %>
   <%= f.inputs do %>
     <%= f.input :user,
                 collection: membership_users_collection(parent, resource),
                 include_blank: false,
-                input_html: { disabled: !f.object.new_record? || parent_type == :user }%>
-    <% if params[:entity_type].to_sym == :entry %>
+                input_html: { disabled: !f.object.new_record? ||
+                                          parent_type == :user } %>
+    <% if entity_type == 'Pageflow::Entry' %>
       <%= render partial: 'admin/memberships/entity_entry_input', locals: {f: f} %>
     <% else %>
       <%= render partial: 'admin/memberships/entity_account_input', locals: {f: f} %>
     <% end %>
-    <%= f.hidden_field :entity_type, value: "Pageflow::#{params[:entity_type].capitalize}" %>
+    <%= f.hidden_field :entity_type, value: entity_type %>
   <% end %>
   <%= f.inputs do %>
-    <%= render partial: 'admin/memberships/role_hint' %>
+    <%= render partial: 'admin/memberships/role_hint',
+               locals: {entity_type: entity_type
+                                      .gsub('Pageflow::', '').downcase} %>
     <%= f.input :role,
-                collection: membership_roles_collection("Pageflow::#{params[:entity_type]
-                                                          .capitalize}"),
-                                                          include_blank: false %>
+                collection: membership_roles_collection(entity_type),
+                include_blank: false %>
   <% end %>
   <%= f.actions do %>
     <%= f.action(:submit) %>

--- a/app/views/admin/memberships/_role_hint.html.arb
+++ b/app/views/admin/memberships/_role_hint.html.arb
@@ -1,2 +1,2 @@
-li(para(t("pageflow.admin.memberships.on_#{params[:entity_type]}.role.hint_html")),
+li(para(t("pageflow.admin.memberships.on_#{entity_type}.role.hint_html")),
    class: 'side_hint')

--- a/app/views/components/pageflow/admin/add_membership_button_if_needed.rb
+++ b/app/views/components/pageflow/admin/add_membership_button_if_needed.rb
@@ -6,13 +6,19 @@ module Pageflow
       def build(user, parent, entity_type)
         if parent.is_a?(User)
           button_label = I18n.t("pageflow.admin.#{entity_type}.add")
-          path = new_admin_user_membership_path(parent, entity_type: entity_type.to_sym)
+          path = new_admin_user_membership_path(
+            parent, entity_type: to_class_name(entity_type)
+          )
           data_tooltip = I18n.t("pageflow.admin.#{entity_type}.none_addable_tooltip")
           rel = "add_#{entity_type}_membership"
         elsif parent.is_a?(Entry)
-          path = new_admin_entry_membership_path(parent, entity_type: entity_type.to_sym)
+          path = new_admin_entry_membership_path(
+            parent, entity_type: to_class_name(entity_type)
+          )
         else
-          path = new_admin_account_membership_path(parent, entity_type: entity_type.to_sym)
+          path = new_admin_account_membership_path(
+            parent, entity_type: to_class_name(entity_type)
+          )
         end
 
         unless parent.is_a?(User)
@@ -56,6 +62,14 @@ module Pageflow
             !membership_accounts_collection(user, Pageflow::Membership.new(user: user)).blank?) ||
            (parent.is_a?(Account) &&
             !membership_users_collection(parent, Membership.new(entity: parent)).blank?))
+      end
+
+      def to_class_name(entity_type)
+        if [:entry, 'entry'].include?(entity_type)
+          'Pageflow::Entry'
+        else
+          'Pageflow::Account'
+        end
       end
     end
   end

--- a/app/views/components/pageflow/admin/members_tab.rb
+++ b/app/views/components/pageflow/admin/members_tab.rb
@@ -22,9 +22,11 @@ module Pageflow
             column do |membership|
               if authorized?(:update, membership)
                 link_to(I18n.t('pageflow.admin.users.edit_role'),
-                        edit_admin_entry_membership_path(entry,
-                                                         membership,
-                                                         entity_type: :entry),
+                        edit_admin_entry_membership_path(
+                          entry,
+                          membership,
+                          entity_type: 'Pageflow::Entry'
+                        ),
                         data: {
                           rel: "edit_entry_membership_#{membership.role}"
                         })

--- a/app/views/components/pageflow/admin/user_accounts_tab.rb
+++ b/app/views/components/pageflow/admin/user_accounts_tab.rb
@@ -21,7 +21,11 @@ module Pageflow
             column do |membership|
               if authorized?(:update, membership)
                 link_to(t('pageflow.admin.users.edit_role'),
-                        edit_admin_user_membership_path(user, membership, entity_type: :account),
+                        edit_admin_user_membership_path(
+                          user,
+                          membership,
+                          entity_type: 'Pageflow::Account'
+                        ),
                         data: {
                           rel: "edit_account_role_#{membership.role}"
                         })

--- a/app/views/components/pageflow/admin/user_entries_tab.rb
+++ b/app/views/components/pageflow/admin/user_entries_tab.rb
@@ -25,7 +25,11 @@ module Pageflow
             column do |membership|
               if authorized?(:update, membership)
                 link_to(t('pageflow.admin.users.edit_role'),
-                        edit_admin_user_membership_path(user, membership, entity_type: :entry),
+                        edit_admin_user_membership_path(
+                          user,
+                          membership,
+                          entity_type: 'Pageflow::Entry'
+                        ),
                         data: {
                           rel: "edit_entry_role_#{membership.role}"
                         })

--- a/app/views/components/pageflow/admin/users_tab.rb
+++ b/app/views/components/pageflow/admin/users_tab.rb
@@ -18,9 +18,11 @@ module Pageflow
             column do |membership|
               if authorized?(:update, membership)
                 link_to(I18n.t('pageflow.admin.users.edit_role'),
-                        edit_admin_account_membership_path(membership.entity,
-                                                           membership,
-                                                           entity_type: :account),
+                        edit_admin_account_membership_path(
+                          membership.entity,
+                          membership,
+                          entity_type: 'Pageflow::Account'
+                        ),
                         data: {
                           rel: "edit_account_role_#{membership.role}"
                         })


### PR DESCRIPTION
- remove redundant `permitted_params`
- change form: entry/account for query params which are visible in URLs, 'Pageflow::Entry'/'Pageflow::Account' elsewhere to minimize confusion