### PR TITLE
Use relative URLs inside dash and hls playlists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@
 # checks locally.
 inherit_from: ./.rubocop_hound.yml
 
+AllCops:
+  TargetRubyVersion: 2.1
+
 # Use double quotes only for interpolation.
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/app/models/pageflow/video_file.rb
+++ b/app/models/pageflow/video_file.rb
@@ -43,6 +43,10 @@ module Pageflow
       "s3://#{File.join(attachment_on_s3.bucket_name, attachment_on_s3.path)}"
     end
 
+    def encode_highdef?
+      entry.feature_state('highdef_video_encoding')
+    end
+
     def mp4_4k
       ZencoderAttachment.new(self, '4k.mp4')
     end

--- a/app/models/pageflow/zencoder_attachment.rb
+++ b/app/models/pageflow/zencoder_attachment.rb
@@ -43,6 +43,14 @@ module Pageflow
                               url_options)
     end
 
+    def url_relative_to(attachment)
+      result = url
+      result.gsub!("#{File.dirname(attachment.url)}/", '') ||
+        raise("Could not generate relative url for #{result} based on #{attachment.url}.")
+
+      result
+    end
+
     private
 
     def ensure_default_protocol(url, url_options)

--- a/app/models/pageflow/zencoder_attachment.rb
+++ b/app/models/pageflow/zencoder_attachment.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module Pageflow
   class ZencoderAttachment
     cattr_accessor :default_options
@@ -44,11 +46,13 @@ module Pageflow
     end
 
     def url_relative_to(attachment)
-      result = url
-      result.gsub!("#{File.dirname(attachment.url)}/", '') ||
-        raise("Could not generate relative url for #{result} based on #{attachment.url}.")
+      dir_path = File.dirname(URI.parse(attachment.url).path)
 
-      result
+      unless URI.parse(url).path.start_with?(dir_path)
+        raise("Could not generate relative url for #{url} based on #{attachment.url}.")
+      end
+
+      url.split("#{dir_path}/", 2).last
     end
 
     private

--- a/app/models/pageflow/zencoder_attachment.rb
+++ b/app/models/pageflow/zencoder_attachment.rb
@@ -1,12 +1,11 @@
 module Pageflow
   class ZencoderAttachment
-
     cattr_accessor :default_options
     self.default_options = {
-      path: "/:zencoder_asset_version/:host/:class/:id_partition/:filename",
-      url: ":zencoder_protocol//:zencoder_host_alias:zencoder_path",
-      hls_url: ":zencoder_protocol//:zencoder_hls_host_alias:zencoder_path",
-      hls_origin_url: ":zencoder_protocol//:zencoder_hls_origin_host_alias:zencoder_path"
+      path: '/:zencoder_asset_version/:host/:class/:id_partition/:filename',
+      url: ':zencoder_protocol//:zencoder_host_alias:zencoder_path',
+      hls_url: ':zencoder_protocol//:zencoder_hls_host_alias:zencoder_path',
+      hls_origin_url: ':zencoder_protocol//:zencoder_hls_origin_host_alias:zencoder_path'
     }
 
     attr_reader :file_name_pattern, :instance, :options, :styles

--- a/lib/pageflow/zencoder_video_output_definition.rb
+++ b/lib/pageflow/zencoder_video_output_definition.rb
@@ -34,7 +34,7 @@ module Pageflow
     private
 
     def mp4_highdef_definitions
-      return [] unless video_file.entry.feature_state('highdef_video_encoding')
+      return [] unless video_file.encode_highdef?
       [transferable(mp4_4k_definition), transferable(mp4_fullhd_definition)]
     end
 
@@ -128,7 +128,7 @@ module Pageflow
     end
 
     def dash_highdef_definitions
-      return [] unless video_file.entry.feature_state('highdef_video_encoding')
+      return [] unless video_file.encode_highdef?
 
       [
         non_transferable(dash_fullhd_definition),
@@ -149,7 +149,7 @@ module Pageflow
     end
 
     def hls_highdef_definitions
-      return [] unless video_file.entry.feature_state('highdef_video_encoding')
+      return [] unless video_file.encode_highdef?
 
       [
         non_transferable(hls_fullhd_definition),
@@ -257,7 +257,7 @@ module Pageflow
     end
 
     def dash_highdef_stream_definitions
-      return [] unless video_file.entry.feature_state('highdef_video_encoding')
+      return [] unless video_file.encode_highdef?
       [
         {
           source: 'dash-fullhd',
@@ -367,7 +367,7 @@ module Pageflow
     end
 
     def hls_highdef_stream_definitions
-      return [] unless video_file.entry.feature_state('highdef_video_encoding')
+      return [] unless video_file.encode_highdef?
       [
         {
           source: 'hls-fullhd',
@@ -404,7 +404,7 @@ module Pageflow
       # these cases the input file is just a tiny bit larger than the
       # next lower resolution, so we do not really care if the SMIL
       # file which does not include the higher quality does not win.
-      if video_file.entry.feature_state('highdef_video_encoding')
+      if video_file.encode_highdef?
         [
           non_transferable(smil_definition.merge(streams: smil_default_stream_definitions,
                                                  skip: {

--- a/lib/pageflow/zencoder_video_output_definition.rb
+++ b/lib/pageflow/zencoder_video_output_definition.rb
@@ -350,17 +350,17 @@ module Pageflow
       [
         {
           source: 'hls-medium',
-          path: video_file.hls_medium.url(host: :hls_origin, default_protocol: 'http'),
+          path: video_file.hls_medium.url_relative_to(video_file.hls_playlist),
           bandwidth: 1769
         },
         {
           source: 'hls-low',
-          path: video_file.hls_low.url(host: :hls_origin, default_protocol: 'http'),
+          path: video_file.hls_low.url_relative_to(video_file.hls_playlist),
           bandwidth: 619
         },
         {
           source: 'hls-high',
-          path: video_file.hls_high.url(host: :hls_origin, default_protocol: 'http'),
+          path: video_file.hls_high.url_relative_to(video_file.hls_playlist),
           bandwidth: 3538
         }
       ] + hls_highdef_stream_definitions
@@ -371,12 +371,12 @@ module Pageflow
       [
         {
           source: 'hls-fullhd',
-          path: video_file.hls_fullhd.url(host: :hls_origin, default_protocol: 'http'),
+          path: video_file.hls_fullhd.url_relative_to(video_file.hls_playlist),
           bandwidth: 8575
         },
         {
           source: 'hls-4k',
-          path: video_file.hls_4k.url(host: :hls_origin, default_protocol: 'http'),
+          path: video_file.hls_4k.url_relative_to(video_file.hls_playlist),
           bandwidth: 32000
         }
       ]

--- a/lib/pageflow/zencoder_video_output_definition.rb
+++ b/lib/pageflow/zencoder_video_output_definition.rb
@@ -243,15 +243,15 @@ module Pageflow
       [
         {
           source: 'dash-low',
-          path: video_file.dash_low.url
+          path: video_file.dash_low.url_relative_to(video_file.dash_playlist)
         },
         {
           source: 'dash-medium',
-          path: video_file.dash_medium.url
+          path: video_file.dash_medium.url_relative_to(video_file.dash_playlist)
         },
         {
           source: 'dash-high',
-          path: video_file.dash_high.url
+          path: video_file.dash_high.url_relative_to(video_file.dash_playlist)
         }
       ] + dash_highdef_stream_definitions
     end
@@ -261,11 +261,11 @@ module Pageflow
       [
         {
           source: 'dash-fullhd',
-          path: video_file.dash_fullhd.url
+          path: video_file.dash_fullhd.url_relative_to(video_file.dash_playlist)
         },
         {
           source: 'dash-4k',
-          path: video_file.dash_4k.url
+          path: video_file.dash_4k.url_relative_to(video_file.dash_playlist)
         }
       ]
     end

--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -56,6 +56,10 @@ module Pageflow
           create(:revision, :published, entry: entry, password_protected: true)
         end
       end
+
+      trait :with_highdef_video_encoding do
+        feature_states('highdef_video_encoding' => true)
+      end
     end
   end
 end

--- a/spec/factories/video_files.rb
+++ b/spec/factories/video_files.rb
@@ -47,6 +47,10 @@ module Pageflow
 
       trait :encoded do
       end
+
+      trait :with_highdef_encoding do
+        association :entry, :with_highdef_video_encoding
+      end
     end
   end
 end

--- a/spec/models/pageflow/video_file_spec.rb
+++ b/spec/models/pageflow/video_file_spec.rb
@@ -39,5 +39,19 @@ module Pageflow
         expect(video_file.present_outputs).to include(:'hls-playlist')
       end
     end
+
+    describe '#encode_highdef?' do
+      it 'returns false by default' do
+        video_file = build(:video_file)
+
+        expect(video_file.encode_highdef?).to eq(false)
+      end
+
+      it 'returns true if entry has highdef_video_encoding feature enabled' do
+        video_file = build(:video_file, :with_highdef_encoding)
+
+        expect(video_file.encode_highdef?).to eq(true)
+      end
+    end
   end
 end

--- a/spec/models/pageflow/zencoder_attachment_spec.rb
+++ b/spec/models/pageflow/zencoder_attachment_spec.rb
@@ -40,6 +40,12 @@ module Pageflow
 
         expect(attachment.original_filename).to eq('thumbnail.jpg')
       end
+
+      it 'supports slashes in file name pattern' do
+        attachment = ZencoderAttachment.new(file_double(id: 5), 'dash/video.mp4')
+
+        expect(attachment.original_filename).to eq('dash/video.mp4')
+      end
     end
 
     describe '#path' do
@@ -63,6 +69,13 @@ module Pageflow
 
         expect(attachment.path).to eq("/#{version}/test-host/files/000/000/005/thumbnail.jpg")
       end
+
+      it 'supports slashed in file name pattern' do
+        file = file_double(id: 5)
+        attachment = ZencoderAttachment.new(file, 'dash/video.mp4')
+
+        expect(attachment.path).to eq("/#{version}/test-host/files/000/000/005/dash/video.mp4")
+      end
     end
 
     describe '#url' do
@@ -81,6 +94,14 @@ module Pageflow
 
         expect(attachment.url).to eq("//#{s3_host_alias}/#{version}/" \
                                      'test-host/files/000/000/005/video.mp4')
+      end
+
+      it 'supports slashes file name pattern' do
+        file = file_double(id: 5)
+        attachment = ZencoderAttachment.new(file, 'dash/video.mp4')
+
+        expect(attachment.url).to eq("#{s3_protocol}://#{s3_host_alias}/#{version}/" \
+                                     'test-host/files/000/000/005/dash/video.mp4')
       end
 
       context 'with default_protocol options ' do

--- a/spec/models/pageflow/zencoder_attachment_spec.rb
+++ b/spec/models/pageflow/zencoder_attachment_spec.rb
@@ -165,6 +165,38 @@ module Pageflow
       end
     end
 
+    describe '#url_relative_to' do
+      it 'returns url which is relative to given other ZencoderAttachment' do
+        file = file_double(id: 5)
+        manifest = ZencoderAttachment.new(file, 'manifest.mpd')
+        attachment = ZencoderAttachment.new(file, 'high/rendition.mpd')
+
+        result = attachment.url_relative_to(manifest)
+
+        expect(result).to eq('high/rendition.mpd')
+      end
+
+      it 'handles common sub directory' do
+        file = file_double(id: 5)
+        manifest = ZencoderAttachment.new(file, 'dash/manifest.mpd')
+        attachment = ZencoderAttachment.new(file, 'dash/high/rendition.mpd')
+
+        result = attachment.url_relative_to(manifest)
+
+        expect(result).to eq('high/rendition.mpd')
+      end
+
+      it 'fails if other attachment is in other directory' do
+        file = file_double(id: 5)
+        manifest = ZencoderAttachment.new(file, 'other/manifest.mpd')
+        attachment = ZencoderAttachment.new(file, 'dash/high/rendition.mpd')
+
+        expect {
+          attachment.url_relative_to(manifest)
+        }.to raise_error(/Could not generate relative url/)
+      end
+    end
+
     describe '#dir_name' do
       it 'returns directory path' do
         file = file_double(id: 5)

--- a/spec/models/pageflow/zencoder_attachment_spec.rb
+++ b/spec/models/pageflow/zencoder_attachment_spec.rb
@@ -186,6 +186,17 @@ module Pageflow
         expect(result).to eq('high/rendition.mpd')
       end
 
+      it 'handles protocol relative urls correctly' do
+        Pageflow.config.zencoder_options[:s3_protocol] = ''
+        file = file_double(id: 5)
+        manifest = ZencoderAttachment.new(file, 'dash/manifest.mpd')
+        attachment = ZencoderAttachment.new(file, 'dash/high/rendition.mpd')
+
+        result = attachment.url_relative_to(manifest)
+
+        expect(result).to eq('high/rendition.mpd')
+      end
+
       it 'fails if other attachment is in other directory' do
         file = file_double(id: 5)
         manifest = ZencoderAttachment.new(file, 'other/manifest.mpd')

--- a/spec/models/pageflow/zencoder_attachment_spec.rb
+++ b/spec/models/pageflow/zencoder_attachment_spec.rb
@@ -6,25 +6,37 @@ module Pageflow
       Pageflow.config.zencoder_options
     end
 
+    let(:s3_protocol) do
+      zencoder_options[:s3_protocol]
+    end
+
+    let(:s3_host_alias) do
+      zencoder_options[:s3_host_alias]
+    end
+
     let(:version) do
       zencoder_options[:attachments_version]
     end
 
+    def file_double(id:)
+      double('File', id: id, class: double(to_s: 'File'))
+    end
+
     describe '#original_filename' do
       it 'defaults to file_name_pattern' do
-        attachment = ZencoderAttachment.new(double('File'), 'video.mp4')
+        attachment = ZencoderAttachment.new(file_double(id: 5), 'video.mp4')
 
         expect(attachment.original_filename).to eq('video.mp4')
       end
 
       it 'replaces {{number}} in with 0' do
-        attachment = ZencoderAttachment.new(double('File'), 'thumbnail-{{number}}.jpg')
+        attachment = ZencoderAttachment.new(file_double(id: 5), 'thumbnail-{{number}}.jpg')
 
         expect(attachment.original_filename).to eq('thumbnail-0.jpg')
       end
 
       it 'appends format option' do
-        attachment = ZencoderAttachment.new(double('File'), 'thumbnail', :format => 'jpg')
+        attachment = ZencoderAttachment.new(file_double(id: 5), 'thumbnail', format: 'jpg')
 
         expect(attachment.original_filename).to eq('thumbnail.jpg')
       end
@@ -32,22 +44,22 @@ module Pageflow
 
     describe '#path' do
       it 'uses paperclip for interpolation' do
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
+        file = file_double(id: 5)
         attachment = ZencoderAttachment.new(file, 'video.mp4')
 
         expect(attachment.path).to eq("/#{version}/test-host/files/000/000/005/video.mp4")
       end
 
       it 'replaces {{number}} in with 0' do
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
+        file = file_double(id: 5)
         attachment = ZencoderAttachment.new(file, 'thumbnail-{{number}}.jpg')
 
         expect(attachment.path).to eq("/#{version}/test-host/files/000/000/005/thumbnail-0.jpg")
       end
 
       it 'appends format option' do
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
-        attachment = ZencoderAttachment.new(file, 'thumbnail', :format => 'jpg')
+        file = file_double(id: 5)
+        attachment = ZencoderAttachment.new(file, 'thumbnail', format: 'jpg')
 
         expect(attachment.path).to eq("/#{version}/test-host/files/000/000/005/thumbnail.jpg")
       end
@@ -55,78 +67,93 @@ module Pageflow
 
     describe '#url' do
       it 'uses s3_protocol and s3_host_alias from zencoder config' do
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
+        file = file_double(id: 5)
         attachment = ZencoderAttachment.new(file, 'video.mp4')
 
-        expect(attachment.url).to eq("#{zencoder_options[:s3_protocol]}://#{zencoder_options[:s3_host_alias]}/#{version}/test-host/files/000/000/005/video.mp4")
+        expect(attachment.url).to eq("#{s3_protocol}://#{s3_host_alias}/#{version}/" \
+                                     'test-host/files/000/000/005/video.mp4')
       end
 
       it 'supports protocol relative urls' do
         Pageflow.config.zencoder_options[:s3_protocol] = ''
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
+        file = file_double(id: 5)
         attachment = ZencoderAttachment.new(file, 'video.mp4')
 
-        expect(attachment.url).to eq("//#{zencoder_options[:s3_host_alias]}/#{version}/test-host/files/000/000/005/video.mp4")
+        expect(attachment.url).to eq("//#{s3_host_alias}/#{version}/" \
+                                     'test-host/files/000/000/005/video.mp4')
       end
 
       context 'with default_protocol options ' do
         it 'prepends protocol if url would be protocol relative' do
           Pageflow.config.zencoder_options[:s3_protocol] = ''
-          file = double('File', :id => 5, :class => double(:to_s => 'File'))
+          file = file_double(id: 5)
           attachment = ZencoderAttachment.new(file, 'video.mp4')
 
-          expect(attachment.url(default_protocol: 'http')).to eq("http://#{zencoder_options[:s3_host_alias]}/#{version}/test-host/files/000/000/005/video.mp4")
+          result = attachment.url(default_protocol: 'http')
+
+          expect(result).to eq("http://#{s3_host_alias}/#{version}/" \
+                               'test-host/files/000/000/005/video.mp4')
         end
 
         it 'does not alter relative urls' do
           Pageflow.config.zencoder_options[:s3_protocol] = ''
-          file = double('File', :id => 5, :class => double(:to_s => 'File'))
-          attachment = ZencoderAttachment.new(file, 'video.mp4', {url: ':filename'})
+          file = file_double(id: 5)
+          attachment = ZencoderAttachment.new(file, 'video.mp4', url: ':filename')
 
-          expect(attachment.url(default_protocol: 'http')).to eq("video.mp4")
+          expect(attachment.url(default_protocol: 'http')).to eq('video.mp4')
         end
 
         it 'does not alter protocol if configured' do
           Pageflow.config.zencoder_options[:s3_protocol] = 'https'
-          file = double('File', :id => 5, :class => double(:to_s => 'File'))
+          file = file_double(id: 5)
           attachment = ZencoderAttachment.new(file, 'video.mp4')
 
-          expect(attachment.url(default_protocol: 'http')).to eq("https://#{zencoder_options[:s3_host_alias]}/#{version}/test-host/files/000/000/005/video.mp4")
+          result = attachment.url(default_protocol: 'http')
+
+          expect(result).to eq("https://#{s3_host_alias}/#{version}/" \
+                               'test-host/files/000/000/005/video.mp4')
         end
       end
 
       it 'can append unique id to url' do
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
+        file = file_double(id: 5)
         attachment = ZencoderAttachment.new(file, 'video.mp4')
 
-        expect(attachment.url(:unique_id => 3)).to eq("#{zencoder_options[:s3_protocol]}://#{zencoder_options[:s3_host_alias]}/#{version}/test-host/files/000/000/005/video.mp4?n=3")
+        result = attachment.url(unique_id: 3)
+
+        expect(result).to eq("#{s3_protocol}://#{s3_host_alias}/#{version}/" \
+                             'test-host/files/000/000/005/video.mp4?n=3')
       end
 
       it 'can append url suffix to url' do
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
-        attachment = ZencoderAttachment.new(file, 'playlist.smil', :url_suffix => '/master.m3u8')
+        file = file_double(id: 5)
+        attachment = ZencoderAttachment.new(file, 'playlist.smil', url_suffix: '/master.m3u8')
 
-        expect(attachment.url).to eq("#{zencoder_options[:s3_protocol]}://#{zencoder_options[:s3_host_alias]}/#{version}/test-host/files/000/000/005/playlist.smil/master.m3u8")
+        expect(attachment.url).to eq("#{s3_protocol}://#{s3_host_alias}/#{version}/" \
+                                     'test-host/files/000/000/005/playlist.smil/master.m3u8')
       end
 
       it 'can append url suffix and unique id to url' do
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
-        attachment = ZencoderAttachment.new(file, 'playlist.smil', :url_suffix => '/master.m3u8')
+        file = file_double(id: 5)
+        attachment = ZencoderAttachment.new(file, 'playlist.smil', url_suffix: '/master.m3u8')
 
-        expect(attachment.url(:unique_id => 3)).to eq("#{zencoder_options[:s3_protocol]}://#{zencoder_options[:s3_host_alias]}/#{version}/test-host/files/000/000/005/playlist.smil/master.m3u8?n=3")
+        result = attachment.url(unique_id: 3)
+
+        expect(result).to eq("#{s3_protocol}://#{s3_host_alias}/#{version}/" \
+                             'test-host/files/000/000/005/playlist.smil/master.m3u8?n=3')
       end
     end
 
     describe '#dir_name' do
       it 'returns directory path' do
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
+        file = file_double(id: 5)
         attachment = ZencoderAttachment.new(file, 'video.mp4')
 
         expect(attachment.dir_name).to eq("/#{version}/test-host/files/000/000/005")
       end
 
       it 'includes dir components from file_name_pattern' do
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
+        file = file_double(id: 5)
         attachment = ZencoderAttachment.new(file, 'dir/video.mp4')
 
         expect(attachment.dir_name).to eq("/#{version}/test-host/files/000/000/005/dir")
@@ -135,7 +162,7 @@ module Pageflow
 
     describe '#base_name_pattern' do
       it 'removes dirs from pattern' do
-        file = double('File', :id => 5, :class => double(:to_s => 'File'))
+        file = file_double(id: 5)
         attachment = ZencoderAttachment.new(file, 'dir/video-{{number}}')
 
         expect(attachment.base_name_pattern).to eq('video-{{number}}')

--- a/spec/pageflow/zencoder_video_output_definition_spec.rb
+++ b/spec/pageflow/zencoder_video_output_definition_spec.rb
@@ -108,12 +108,31 @@ module Pageflow
       end
 
       it 'uses relative urls in dash playlist' do
-        video_file = build(:video_file, :with_highdef_encoding)
+        video_file = build_stubbed(:video_file, :with_highdef_encoding)
         definition = ZencoderVideoOutputDefinition.new(video_file)
 
         expect(definition).to have_output
           .with_label('dash-playlist')
           .with_all_streams_having(path: a_relative_url)
+      end
+
+      it 'uses relative urls in hls playlist' do
+        video_file = build_stubbed(:video_file, :with_highdef_encoding)
+        definition = ZencoderVideoOutputDefinition.new(video_file)
+
+        expect(definition).to have_output
+          .with_label('hls-playlist')
+          .with_all_streams_having(path: a_relative_url)
+      end
+
+      it 'uses absolute urls in smil playlist' do
+        video_file = build_stubbed(:video_file, :with_highdef_encoding)
+        definition = ZencoderVideoOutputDefinition.new(video_file)
+        definition.skip_smil = false
+
+        expect(definition).to have_output
+          .with_format('highwinds')
+          .with_all_streams_having(path: an_absolute_url)
       end
     end
   end

--- a/spec/pageflow/zencoder_video_output_definition_spec.rb
+++ b/spec/pageflow/zencoder_video_output_definition_spec.rb
@@ -82,8 +82,7 @@ module Pageflow
       end
 
       it 'produces highdef outputs if set to do so' do
-        video_file = build(:video_file)
-        video_file.entry.feature_states = {'highdef_video_encoding' => true}
+        video_file = build(:video_file, :with_highdef_encoding)
         definition = ZencoderVideoOutputDefinition.new(video_file)
         definition.skip_hls = false
         definition.skip_smil = false

--- a/spec/pageflow/zencoder_video_output_definition_spec.rb
+++ b/spec/pageflow/zencoder_video_output_definition_spec.rb
@@ -106,6 +106,15 @@ module Pageflow
         expect(definition).to have_output.to_s3(video_file.hls_playlist.path)
         expect(definition).to have_output.to_s3(video_file.smil.path)
       end
+
+      it 'uses relative urls in dash playlist' do
+        video_file = build(:video_file, :with_highdef_encoding)
+        definition = ZencoderVideoOutputDefinition.new(video_file)
+
+        expect(definition).to have_output
+          .with_label('dash-playlist')
+          .with_all_streams_having(path: a_relative_url)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,10 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
 
+  config.expect_with :rspec do |c|
+    c.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
   config.example_status_persistence_file_path = './tmp/rspec_failures'
 
   config.order = "random"

--- a/spec/support/matchers/have_output.rb
+++ b/spec/support/matchers/have_output.rb
@@ -7,6 +7,10 @@ RSpec::Matchers.define :have_output do
     output_matchers[:label] = label
   end
 
+  chain :with_format do |format|
+    output_matchers[:format] = format
+  end
+
   chain :with_stream do |stream_attributes|
     output_matchers[:streams] = array_including(hash_including(stream_attributes))
   end

--- a/spec/support/matchers/have_output.rb
+++ b/spec/support/matchers/have_output.rb
@@ -1,15 +1,37 @@
 RSpec::Matchers.define :have_output do
   chain :to_s3 do |path|
-    @s3_url = path.prepend('s3://com-example-pageflow-out')
+    output_matchers[:url] = path.prepend('s3://com-example-pageflow-out')
   end
+
+  chain :with_label do |label|
+    output_matchers[:label] = label
+  end
+
+  chain :with_stream do |stream_attributes|
+    output_matchers[:streams] = array_including(hash_including(stream_attributes))
+  end
+
+  chain :with_all_streams_having do |stream_attributes|
+    output_matchers[:streams] = all(include(stream_attributes))
+  end
+
   match do |definition|
-    definition.outputs.detect { |output| output[:url] == @s3_url }.try(:any?)
+    expect(definition.outputs).to include(hash_including(output_matchers))
   end
+
   failure_message do |definition|
-    urls = definition.outputs.map { |output| output[:url] }
-    "expected to find URL #{@s3_url} in output URLs #{urls}."
+    "expected #{description_of @actual} to #{description}#{pretty_print_actual(definition)}"
   end
-  failure_message_when_negated do
-    "expected to not find URL #{@s3_url} in output URLs, but found it."
+
+  failure_message do |definition|
+    "expected #{description_of @actual} not to #{description}#{pretty_print_actual(definition)}"
+  end
+
+  def pretty_print_actual(definition)
+    "\n\nActual:\n#{JSON.pretty_generate(definition.outputs)}"
+  end
+
+  def output_matchers
+    @matchers ||= {}
   end
 end

--- a/spec/support/matchers/url_matchers.rb
+++ b/spec/support/matchers/url_matchers.rb
@@ -12,3 +12,16 @@ RSpec::Matchers.define :be_relative_url do
 end
 
 RSpec::Matchers.alias_matcher :a_relative_url, :be_relative_url
+
+RSpec::Matchers.define :be_absolute_url do
+  match do |url|
+    begin
+      uri = URI.parse(url)
+      uri.host.present? && uri.scheme.present?
+    rescue URI::InvalidURIError
+      false
+    end
+  end
+end
+
+RSpec::Matchers.alias_matcher :an_absolute_url, :be_absolute_url

--- a/spec/support/matchers/url_matchers.rb
+++ b/spec/support/matchers/url_matchers.rb
@@ -1,0 +1,14 @@
+require 'uri'
+
+RSpec::Matchers.define :be_relative_url do
+  match do |url|
+    begin
+      uri = URI.parse(url)
+      uri.host.nil? && !uri.path.start_with?('/')
+    rescue URI::InvalidURIError
+      false
+    end
+  end
+end
+
+RSpec::Matchers.alias_matcher :a_relative_url, :be_relative_url


### PR DESCRIPTION
CDN urls might change or be generated dynamically. Prevent having to
regenerate all playlists then.