### PR TITLE
Prevent escalation of privileges

### DIFF
--- a/admins/pageflow/user.rb
+++ b/admins/pageflow/user.rb
@@ -165,8 +165,7 @@ module Pageflow
                                      :current_password,
                                      :password,
                                      :password_confirmation,
-                                     :locale,
-                                     :admin)
+                                     :locale)
       end
 
       def permitted_params

--- a/admins/pageflow/user.rb
+++ b/admins/pageflow/user.rb
@@ -2,6 +2,8 @@ module Pageflow
   ActiveAdmin.register User do
     menu priority: 2, if: proc { authorized?(:index, current_user) }
 
+    actions :all, except: [:new, :create]
+
     config.batch_actions = false
     config.clear_action_items!
 
@@ -24,7 +26,7 @@ module Pageflow
 
     action_item(:invite, only: :index) do
       link_to I18n.t('pageflow.admin.users.invite_user'),
-              new_admin_user_path,
+              invitation_admin_users_path,
               data: {rel: 'invite_user'}
     end
 
@@ -91,6 +93,21 @@ module Pageflow
 
     form(partial: 'form')
 
+    collection_action :invitation, method: [:get, :post] do
+      @page_title = I18n.t('pageflow.admin.users.invite_user')
+      @invitation_form = InvitationForm.new(invitation_form_params.fetch(:invitation_form, {}),
+                                            AccountPolicy::Scope.new(current_user, Account)
+                                              .member_addable)
+
+      if request.post?
+        if @invitation_form.save
+          redirect_to(admin_user_path(@invitation_form.target_user))
+        else
+          render status: 422
+        end
+      end
+    end
+
     collection_action 'me', title: I18n.t('pageflow.admin.users.account'), method: [:get, :patch] do
       if request.patch?
         if current_user.update_with_password(user_profile_params)
@@ -137,26 +154,11 @@ module Pageflow
         super.includes(account_memberships: :entity)
       end
 
-      def build_new_resource
-        InvitedUser.new(permitted_params[:user])
-      end
-
-      def create_resource(user)
-        verify_quota!(:users, params[:user][:account])
-        known_user = User.find_by(email: resource.email)
-        membership_user = known_user ? known_user : resource
-        membership_params = {user: membership_user,
-                             entity_id: resource.initial_account,
-                             entity_type: 'Pageflow::Account'}
-        if resource.initial_role.present?
-          membership_params.merge!(role: resource.initial_role.to_sym)
-        end
-        Membership.create(membership_params)
-        if known_user
-          known_user
-        else
-          super
-        end
+      def invitation_form_params
+        params.permit(invitation_form: {
+                        user: permitted_user_attributes,
+                        membership: [:entity_id, :role]
+                      })
       end
 
       def user_profile_params
@@ -169,31 +171,21 @@ module Pageflow
       end
 
       def permitted_params
-        result = params.permit(user: [:first_name,
-                                      :last_name,
-                                      :email,
-                                      :password,
-                                      :password_confirmation,
-                                      :locale,
-                                      :admin,
-                                      :initial_role,
-                                      :initial_account])
-        restrict_attributes(params[:id], result[:user]) if result[:user]
-        result
+        params.permit(user: permitted_user_attributes)
       end
 
       private
 
-      def restrict_attributes(_id, attributes)
-        unless authorized?(:set_admin, current_user)
-          attributes.delete(:admin)
-        end
+      def permitted_user_attributes
+        attributes = [
+          :first_name,
+          :last_name,
+          :email,
+          :locale
+        ]
 
-        if AccountPolicy::Scope.new(current_user, Pageflow::Account).member_addable.empty? ||
-           action_name.to_sym != :create
-          attributes.delete(:initial_role)
-          attributes.delete(:initial_account)
-        end
+        attributes << :admin if authorized?(:set_admin, current_user)
+        attributes
       end
     end
   end

--- a/app/models/pageflow/invitation_form.rb
+++ b/app/models/pageflow/invitation_form.rb
@@ -1,0 +1,58 @@
+module Pageflow
+  # @api private
+  class InvitationForm
+    include ActiveModel::Model
+
+    attr_reader :membership, :target_user, :available_accounts
+
+    def initialize(attributes, available_accounts)
+      @attributes = attributes
+      @available_accounts = available_accounts
+
+      @invited_user = InvitedUser.new(attributes[:user])
+      @target_user = existing_user || @invited_user
+
+      @membership = @target_user.memberships.build(entity: initial_account,
+                                                   role: initial_role)
+    end
+
+    def user
+      @invited_user.becomes(User)
+    end
+
+    def save
+      return false unless valid?
+      Pageflow.config.quotas.get(:users, initial_account).verify_available!
+
+      membership.save!
+    end
+
+    def valid?
+      (existing_user || @invited_user.valid?) && membership.valid?
+    end
+
+    def existing_member
+      @existing_member ||=
+        initial_account && initial_account.users.find_by_email(user.email)
+    end
+
+    private
+
+    def existing_user
+      @existing_user ||=
+        User.find_by_email(user.email)
+    end
+
+    def initial_account
+      @initial_account ||= available_accounts.find_by_id(initial_account_id)
+    end
+
+    def initial_account_id
+      @attributes.fetch(:membership, {})[:entity_id]
+    end
+
+    def initial_role
+      @attributes.fetch(:membership, {})[:role] || 'member'
+    end
+  end
+end

--- a/app/models/pageflow/invited_user.rb
+++ b/app/models/pageflow/invited_user.rb
@@ -2,8 +2,6 @@ module Pageflow
   # Specialized User class containing invitation logic used by in the
   # users admin.
   class InvitedUser < User
-    attr_accessor :initial_account, :initial_role
-
     before_create :prepare_invitation
     after_create :send_invitation
 

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,34 +1,12 @@
-<%= admin_form_for([:admin, @user.becomes(User)]) do |f| %>
+<%= admin_form_for([:admin, resource]) do |f| %>
   <%= f.inputs "Details" do %>
-    <% if @user.new_record? %>
-      <% Pageflow::AccountPolicy::Scope
-           .new(current_user, Pageflow::Account).member_addable.each do |account| %>
-        <%= quota_state_description(:users, account) %>
-      <% end %>
-    <% end %>
-
-    <%= f.input :email, hint: f.object.new_record? &&
-                                I18n.t('pageflow.admin.users.email_invitation_hint') %>
+    <%= f.input :email %>
     <%= f.input :first_name %>
     <%= f.input :last_name %>
     <%= f.input :locale,
                 as: :select,
                 include_blank: false,
                 collection: available_locales_collection %>
-
-    <% if Pageflow::AccountPolicy::Scope
-        .new(current_user, Pageflow::Account).member_addable.any? && @user.new_record? %>
-      <%= f.input :initial_account,
-                  collection: membership_accounts_collection(@user,
-                                                             Pageflow::Membership.new(user: @user)),
-                  include_blank: false,
-                  selected: (params[:user][:initial_account] if params[:user].present?) %>
-      <%= f.input :initial_role,
-                  collection: membership_roles_collection('Pageflow::Account'),
-                  include_blank: false,
-                  hint: t('pageflow.admin.memberships.on_account.role.hint_html'),
-                  selected: (params[:user][:initial_role] if params[:user].present?) %>
-    <% end %>
     <%= f.input :admin if authorized?(:set_admin, current_user) %>
   <% end %>
   <%= f.actions %>

--- a/app/views/admin/users/invitation.html.erb
+++ b/app/views/admin/users/invitation.html.erb
@@ -1,0 +1,42 @@
+<%= admin_form_for(@invitation_form, url: invitation_admin_users_path) do |f| %>
+  <%= f.semantic_fields_for(@invitation_form.membership) do |m| %>
+    <%= f.semantic_fields_for(@invitation_form.user) do |u| %>
+      <% if @invitation_form.existing_member %>
+        <ul class="errors">
+          <li>
+            <%= t('pageflow.admin.users.member_exists') %>
+            <%= link_to(t('pageflow.admin.users.member_exists_link'),
+                        admin_user_path(@invitation_form.existing_member)) %>
+          </li>
+        </ul>
+      <% end %>
+
+      <%= f.inputs "Details" do %>
+        <% @invitation_form.available_accounts.each do |account| %>
+          <%= quota_state_description(:users, account) %>
+        <% end %>
+
+        <%= u.input :email, hint: I18n.t('pageflow.admin.users.email_invitation_hint') %>
+        <%= u.input :first_name %>
+        <%= u.input :last_name %>
+        <%= u.input :locale,
+                    as: :select,
+                    include_blank: false,
+                    collection: available_locales_collection %>
+        <%= m.input :entity_id,
+                    as: :select,
+                    collection: @invitation_form.available_accounts,
+                    include_blank: false,
+                    label: Pageflow::Membership.human_attribute_name(:account) %>
+        <%= m.input :role,
+                    collection: membership_roles_collection('Pageflow::Account'),
+                    include_blank: false,
+                    hint: t('pageflow.admin.memberships.on_account.role.hint_html') %>
+        <%= u.input :admin if authorized?(:set_admin, current_user) %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <%= f.actions do %>
+    <%= f.action :submit, label: t('pageflow.admin.users.invite_user') %>
+  <% end %>
+<% end %>

--- a/config/locales/new/invitation_form.de.yml
+++ b/config/locales/new/invitation_form.de.yml
@@ -1,0 +1,6 @@
+de:
+  pageflow:
+    admin:
+      users:
+        member_exists: "Ein Benutzer mit der angegebenen E-Mail-Adresse ist bereits Mitglied des Kontos."
+        member_exists_link: "Benutzer anzeigen"

--- a/config/locales/new/invitation_form.en.yml
+++ b/config/locales/new/invitation_form.en.yml
@@ -1,0 +1,6 @@
+en:
+  pageflow:
+    admin:
+      users:
+        member_exists: "A user with the given email address is already member of the account."
+        member_exists_link: "View user"

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -65,7 +65,7 @@ module Pageflow
       end
     end
 
-    describe '#invite' do
+    describe 'get #invitation' do
       render_views
 
       it 'displays quota state description' do
@@ -74,112 +74,242 @@ module Pageflow
         Pageflow.config.quotas.register(:users, QuotaDouble.available)
 
         sign_in(create(:user, :manager, on: account))
-        get(:new)
+        get(:invitation)
 
         expect(response.body).to have_content('Quota available')
       end
     end
 
-    describe '#create' do
+    describe 'post #invitation' do
+      render_views
+
+      it 'allows account managers to create user' do
+        account = create(:account)
+
+        sign_in(create(:user, :manager, on: account))
+
+        expect {
+          post(:invitation,
+               invitation_form: {
+                 user: attributes_for(:valid_user),
+                 membership: {
+                   entity_id: account.id,
+                   role: 'member'
+                 }
+               })
+        }.to change { User.count }
+      end
+
+      it 'allows account managers to create user in account with manager role' do
+        account = create(:account)
+        account_members = AccountMemberQuery::Scope.new(account)
+
+        sign_in(create(:user, :manager, on: account))
+
+        expect {
+          post(:invitation,
+               invitation_form: {
+                 user: attributes_for(:valid_user),
+                 membership: {
+                   entity_id: account.id,
+                   role: 'manager'
+                 }
+               })
+        }.to change { account_members.with_role_at_least(:manager).count }
+      end
+
+      it 'create membership in account if user with email already exisits' do
+        account = create(:account)
+        user = create(:user, email: 'existing_user@example.com')
+
+        sign_in(create(:user, :manager, on: account))
+
+        expect {
+          post(:invitation,
+               invitation_form: {
+                 user: attributes_for(:valid_user,
+                                      email: user.email),
+                 membership: {
+                   entity_id: account.id,
+                   role: 'member'
+                 }
+               })
+        }.to change { account.users.count }
+      end
+
+      it 'responds with unprocessable entity if user is already member of account' do
+        account = create(:account)
+        existing_user = create(:user, :member, on: account)
+
+        sign_in(create(:user, :manager, on: account))
+
+        expect {
+          post(:invitation,
+               invitation_form: {
+                 user: attributes_for(:valid_user,
+                                      email: existing_user.email),
+                 membership: {
+                   entity_id: account.id,
+                   role: 'manager'
+                 }
+               })
+        }.not_to change { Membership.count }
+
+        expect(response).to have_http_status(422)
+        expect(response.body).to include(I18n.t('pageflow.admin.users.member_exists'))
+      end
+
+      it 'responds with unprocessable entity if initial role is invalid' do
+        account = create(:account)
+
+        sign_in(create(:user, :manager, on: account))
+
+        expect {
+          post(:invitation,
+               invitation_form: {
+                 user: attributes_for(:valid_user),
+                 membership: {
+                   entity_id: account.id,
+                   role: 'superman'
+                 }
+               })
+        }.not_to change { User.count }
+
+        expect(response).to have_http_status(422)
+      end
+
+      it 'responds with unprocessable entity if initial account is invalid' do
+        account = create(:account)
+
+        sign_in(create(:user, :manager, on: account))
+
+        expect {
+          post(:invitation,
+               invitation_form: {
+                 user: attributes_for(:valid_user),
+                 membership: {
+                   entity_id: -1,
+                   role: 'member'
+                 }
+               })
+        }.not_to change { User.count }
+
+        expect(response).to have_http_status(422)
+      end
+
       it 'does not allow account managers to create admins' do
         account = create(:account)
 
         sign_in(create(:user, :manager, on: account))
 
-        expect do
-          post :create, user: attributes_for(:valid_user, admin: true)
-        end.not_to change { User.admins.count }
+        expect {
+          post(:invitation,
+               invitation_form: {
+                 user: attributes_for(:valid_user,
+                                      admin: true),
+                 membership: {
+                   entity_id: account.id,
+                   role: 'member'
+                 }
+               })
+        }.not_to change { User.admins.count }
       end
 
       it 'allows admins to create admins' do
+        account = create(:account)
+
         sign_in(create(:user, :admin))
 
-        expect do
-          post :create, user: attributes_for(:valid_user, admin: true)
-        end.to change { User.admins.count }
+        expect {
+          post(:invitation,
+               invitation_form: {
+                 user: attributes_for(:valid_user,
+                                      admin: true),
+                 membership: {
+                   entity_id: account.id,
+                   role: 'member'
+                 }
+               })
+        }.to change { User.admins.count }
       end
 
-      it 'does not allow account manager to create users for own account' do
+      it 'does not allow account manager to create users for off-limits account' do
         account = create(:account)
+        other_account = create(:account)
 
         sign_in(create(:user, :manager, on: account))
 
-        expect do
-          post :create, user: attributes_for(:valid_user)
-        end.to_not change { account.users.count }
+        expect {
+          post(:invitation,
+               invitation_form: {
+                 user: attributes_for(:valid_user),
+                 membership: {
+                   entity_id: other_account.id,
+                   role: 'member'
+                 }
+               })
+        }.to_not change { other_account.users.count }
       end
 
-      it 'does not create user if quota is exhausted and e-mail is new' do
-        account = create(:account)
+      context 'when users quota is exhausted' do
+        it 'does not create new user' do
+          account = create(:account)
 
-        Pageflow.config.quotas.register(:users, QuotaDouble.exhausted)
-        sign_in(create(:user, :manager, on: account))
+          Pageflow.config.quotas.register(:users, QuotaDouble.exhausted)
+          sign_in(create(:user, :manager, on: account))
 
-        expect do
+          expect {
+            request.env['HTTP_REFERER'] = admin_users_path
+            post(:invitation,
+                 invitation_form: {
+                   user: attributes_for(:valid_user),
+                   membership: {
+                     entity_id: account.id,
+                     role: 'member'
+                   }
+                 })
+          }.not_to change { User.count }
+        end
+
+        it 'does not create membership for existing user' do
+          account = create(:account)
+          user = create(:user)
+
+          Pageflow.config.quotas.register(:users, QuotaDouble.exhausted)
+          sign_in(create(:user, :manager, on: account))
+
+          expect {
+            request.env['HTTP_REFERER'] = admin_users_path
+            post(:invitation,
+                 invitation_form: {
+                   user: attributes_for(:valid_user,
+                                        email: user.email),
+                   membership: {
+                     entity_id: account.id,
+                     role: 'member'
+                   }
+                 })
+          }.not_to change { account.users.count }
+        end
+
+        it 'redirects with flash' do
+          account = create(:account)
+
+          Pageflow.config.quotas.register(:users, QuotaDouble.exhausted)
+          sign_in(create(:user, :manager, on: account))
+
           request.env['HTTP_REFERER'] = admin_users_path
-          post :create, user: attributes_for(:valid_user)
-        end.not_to change { User.count }
-      end
+          post(:invitation,
+               invitation_form: {
+                 user: attributes_for(:valid_user),
+                 membership: {
+                   entity_id: account.id,
+                   role: 'member'
+                 }
+               })
 
-      it 'creates user via membership in spite of exhausted quota ' \
-         'if their e-mail was already in the database' do
-        account = create(:account)
-        create(:user, email: 'existing_user@example.com')
-
-        Pageflow.config.quotas.register(:users, QuotaDouble.exhausted)
-        sign_in(create(:user, :manager, on: account))
-
-        expect do
-          request.env['HTTP_REFERER'] = admin_users_path
-          post :create,
-               user: {email: 'existing_user@example.com',
-                      initial_role: :member,
-                      initial_account: account}
-        end.not_to change { account.users.count }
-      end
-
-      it 'creates account membership if e-mail unknown but quota allows it' do
-        account = create(:account)
-
-        sign_in(create(:user, :manager, on: account))
-
-        expect do
-          request.env['HTTP_REFERER'] = admin_users_path
-          post :create,
-               user: {email: 'new_user@example.com',
-                      first_name: 'Adelheid',
-                      last_name: 'Doe',
-                      initial_role: :member,
-                      initial_account: account}
-        end.to change { account.users.count }
-      end
-
-      it 'creates invited user if e-mail unknown but quota allows it' do
-        account = create(:account)
-
-        sign_in(create(:user, :manager, on: account))
-
-        expect do
-          request.env['HTTP_REFERER'] = admin_users_path
-          post :create,
-               user: {email: 'new_user@example.com',
-                      first_name: 'Wiltrud',
-                      last_name: 'Doe',
-                      initial_role: :member,
-                      initial_account: account}
-        end.to change { User.count }
-      end
-
-      it 'redirects with flash if :users quota is exhausted and e-mail is unknown' do
-        account = create(:account)
-
-        Pageflow.config.quotas.register(:users, QuotaDouble.exhausted)
-
-        sign_in(create(:user, :manager, on: account))
-        request.env['HTTP_REFERER'] = admin_users_path
-        post(:create, user: attributes_for(:valid_user))
-
-        expect(flash[:alert]).to eq(I18n.t('pageflow.quotas.exhausted'))
+          expect(flash[:alert]).to eq(I18n.t('pageflow.quotas.exhausted'))
+        end
       end
     end
 

--- a/spec/features/registered_user/editing_profile_spec.rb
+++ b/spec/features/registered_user/editing_profile_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'as registered user, editing own profile' do
-  scenario 'change first and last name', focus: true do
+  scenario 'change first and last name' do
     create(:user, email: 'john@example.com', password: '@qwert12345')
 
     Dom::Admin::Page.sign_in(email: 'john@example.com', password: '@qwert12345')

--- a/spec/support/dominos/admin/invitation_form.rb
+++ b/spec/support/dominos/admin/invitation_form.rb
@@ -1,0 +1,42 @@
+module Dom
+  module Admin
+    class InvitationForm < Domino
+      selector 'form.pageflow_invitation_form'
+
+      def submit_with(options)
+        within(node) do
+          if options[:email]
+            fill_in('invitation_form_user_email', with: options[:email])
+          end
+
+          if options[:first_name]
+            fill_in('invitation_form_user_first_name', with: options[:first_name])
+          end
+
+          if options[:last_name]
+            fill_in('invitation_form_user_last_name', with: options[:last_name])
+          end
+
+          if options[:account_id]
+            select(Pageflow::Account.find(options[:account_id]).name,
+                   from: 'invitation_form_membership_entity_id')
+          end
+
+          if has_selector?('#user_admin')
+            if options[:admin]
+              check 'invitation_form_user_admin'
+            else
+              uncheck 'invitation_form_user_admin'
+            end
+          end
+
+          find('[name="commit"]').click
+        end
+      end
+
+      def has_error_on?(field)
+        node.has_selector?("#invitation_form_user_#{field}_input.error")
+      end
+    end
+  end
+end


### PR DESCRIPTION
There a are two bugs in Pageflow 12.0.0 that allow signed in users to escalate their privileges.

* With a manually crafted request, any signed in user can set the `admin` flag on their own user account.

* With a manually crafted request, a user with account manager role in at least one account, can add users to arbitrary accounts. This can be used to gain account manager privileges in any account.

Affected versions: 12.0.0 (including all release candidates)
Unaffected version: 0.11.x and older
Versions fixes: 12.0.1
