### PR TITLE
Ensure new entry button is hidden for editors

### DIFF
--- a/admins/pageflow/accounts.rb
+++ b/admins/pageflow/accounts.rb
@@ -1,8 +1,6 @@
 module Pageflow
   ActiveAdmin.register Account, :as => 'Account' do
-    menu({priority: 3,
-          if: proc { authorized?(:index, :accounts) }}
-           .merge(Pageflow.config.account_admin_menu_options))
+    menu({priority: 3}.merge(Pageflow.config.account_admin_menu_options))
 
     config.batch_actions = false
 

--- a/admins/pageflow/user.rb
+++ b/admins/pageflow/user.rb
@@ -1,6 +1,6 @@
 module Pageflow
   ActiveAdmin.register User do
-    menu priority: 2, if: proc { authorized?(:index, current_user) }
+    menu priority: 2
 
     actions :all, except: [:new, :create]
 

--- a/app/policies/pageflow/entry_policy.rb
+++ b/app/policies/pageflow/entry_policy.rb
@@ -86,6 +86,10 @@ module Pageflow
       query.has_at_least_role?(:publisher)
     end
 
+    def create_any?
+      AccountPolicy::Scope.new(@user, Account).entry_creatable.any?
+    end
+
     def create?
       query.has_at_least_account_role?(:publisher)
     end

--- a/app/policies/pageflow/user_policy.rb
+++ b/app/policies/pageflow/user_policy.rb
@@ -29,9 +29,15 @@ module Pageflow
       end
     end
 
+    attr_reader :user
+
     def initialize(user, managed_user)
       @user = user
       @managed_user = managed_user
+    end
+
+    def create_any?
+      index?
     end
 
     def create?
@@ -39,7 +45,8 @@ module Pageflow
     end
 
     def index?
-      @user.memberships.on_accounts.where(role: 'manager').any?
+      @user.admin? ||
+        @user.memberships.on_accounts.where(role: 'manager').any?
     end
 
     def read?

--- a/lib/pageflow/active_admin_can_can_fix.rb
+++ b/lib/pageflow/active_admin_can_can_fix.rb
@@ -1,0 +1,34 @@
+module Pageflow
+  # @api private
+  #
+  # ActiveAdmin passes class objects to CanCan when authorizing access
+  # to the "index" and "new resource" pages. CanCan does not evaluate
+  # `can` blocks when classes are passed as subjects. Since the above
+  # code relies on block evaluation for all but the `admin` case, this
+  # causes "new" buttons and menu items to be displayed even though
+  # access should not be permitted.
+  #
+  # see also https://github.com/activeadmin/activeadmin/issues/5144
+  #
+  # Detect these cases and pass the collection name as subject
+  # instead. To prevent collision with existing cases, rename actions:
+  #
+  #     :read, User  ->  :index, :users
+  #     :create, User  ->  :create_any, :users
+  module ActiveAdminCanCanFix
+    def can?(action, subject)
+      if [:read, :create].include?(action) &&
+         [Entry, Account, User].include?(subject)
+        collection_name = subject.name.demodulize.underscore.pluralize.to_sym
+
+        if action == :read
+          super(:index, collection_name)
+        elsif action == :create
+          super(:create_any, collection_name)
+        end
+      else
+        super
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -26,6 +26,33 @@ describe Admin::EntriesController do
         expect(response.body).not_to have_selector('#q_account_id')
       end
     end
+
+    describe 'new entry button' do
+      let(:new_button_text) do
+        I18n.t('active_admin.new_model',
+               model: I18n.t('activerecord.models.entry.one'))
+      end
+
+      it 'is visible for account manager' do
+        user = create(:user)
+        create(:account, with_manager: user)
+
+        sign_in(user)
+        get :index
+
+        expect(response.body).to have_text(new_button_text)
+      end
+
+      it 'is hidden for account editors' do
+        user = create(:user)
+        create(:account, with_editor: user)
+
+        sign_in(user)
+        get :index
+
+        expect(response.body).not_to have_text(new_button_text)
+      end
+    end
   end
 
   describe '#show' do

--- a/spec/features/account_manager/listing_users_spec.rb
+++ b/spec/features/account_manager/listing_users_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+feature 'as account manager, listening users' do
+  scenario 'only users from managed accounts show up' do
+    account = create(:account)
+    create(:user, :member, on: account, first_name: 'Michael', last_name: 'Managed')
+    create(:user, first_name: 'Otis', last_name: 'Other')
+
+    Dom::Admin::Page.sign_in_as(:manager, on: account)
+    visit(admin_users_path)
+
+    expect(Dom::Admin::UserInIndexTable.find_by_full_name('Michael Managed')).to be_present
+    expect(Dom::Admin::UserInIndexTable.find_by_full_name('Otis Other')).not_to be_present
+  end
+end

--- a/spec/features/admin/sees_all_users_spec.rb
+++ b/spec/features/admin/sees_all_users_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+feature 'as system admin, viewing all users' do
+  scenario 'all users show up in users table' do
+    create(:user,
+           first_name: 'John',
+           last_name: 'Doe',
+           email: 'john@example.com')
+
+    Dom::Admin::Page.sign_in_as(:admin)
+    visit(admin_users_path)
+
+    expect(Dom::Admin::UserInIndexTable.find_by_full_name('John Doe')).to be_present
+  end
+end

--- a/spec/pageflow/active_admin_can_can_fix_spec.rb
+++ b/spec/pageflow/active_admin_can_can_fix_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+module Pageflow
+  describe ActiveAdminCanCanFix do
+    describe '#can? for :read action with Entry class as subject' do
+      it 'converts subject to collection name' do
+        ability = Class.new {
+          include CanCan::Ability
+          include ActiveAdminCanCanFix
+
+          def initialize
+            can :index, :entries do
+              true
+            end
+          end
+        }.new
+
+        result = ability.can?(:read, Entry)
+
+        expect(result).to eq(true)
+      end
+
+      it 'allows Entry class as subject for other actions' do
+        ability = Class.new {
+          include CanCan::Ability
+          include ActiveAdminCanCanFix
+
+          def initialize
+            can :purchase, Entry
+          end
+        }.new
+
+        result = ability.can?(:purchase, Entry)
+
+        expect(result).to eq(true)
+      end
+
+      it 'allows classes as subject for other classes' do
+        some_class = Class.new
+        ability = Class.new {
+          include CanCan::Ability
+          include ActiveAdminCanCanFix
+
+          define_method :initialize do
+            can :read, some_class
+          end
+        }.new
+
+        result = ability.can?(:read, some_class)
+
+        expect(result).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/policies/pageflow/entry_policy_spec.rb
+++ b/spec/policies/pageflow/entry_policy_spec.rb
@@ -159,6 +159,40 @@ module Pageflow
                     to: :destroy,
                     topic: -> { create(:entry) }
 
+    describe 'create_any?' do
+      it 'allows admin to view new entry form' do
+        user = create(:user, :admin)
+
+        policy = EntryPolicy.new(user, Entry.new)
+
+        expect(policy).to permit_action(:create_any)
+      end
+
+      it 'allows publisher of at least one account to view new entry form' do
+        user = create(:user, :publisher, on: create(:account))
+
+        policy = EntryPolicy.new(user, Entry.new)
+
+        expect(policy).to permit_action(:create_any)
+      end
+
+      it 'does not allow account editor to view new entry from' do
+        user = create(:user, :editor, on: create(:account))
+
+        policy = EntryPolicy.new(user, Entry.new)
+
+        expect(policy).not_to permit_action(:create_any)
+      end
+
+      it 'does not allow entry manager to view new entry form' do
+        user = create(:user, :manager, on: create(:entry))
+
+        policy = EntryPolicy.new(user, Entry.new)
+
+        expect(policy).not_to permit_action(:create_any)
+      end
+    end
+
     describe '.resolve' do
       it 'includes all entries for admins' do
         user = create(:user, :admin)

--- a/spec/policies/pageflow/user_policy_spec.rb
+++ b/spec/policies/pageflow/user_policy_spec.rb
@@ -90,6 +90,14 @@ module Pageflow
     end
 
     describe 'index?' do
+      it 'allows admin to index users' do
+        user = create(:user, :admin)
+
+        policy = UserPolicy.new(user, create(:user))
+
+        expect(policy).to permit_action(:index)
+      end
+
       it 'allows user with manager permissions on account to index users' do
         user = create(:user, :manager, on: create(:account))
 
@@ -112,6 +120,40 @@ module Pageflow
         policy = UserPolicy.new(user, create(:user))
 
         expect(policy).not_to permit_action(:index)
+      end
+    end
+
+    describe 'create_any?' do
+      it 'allows admin to view invite user form' do
+        user = create(:user, :admin)
+
+        policy = UserPolicy.new(user, create(:user))
+
+        expect(policy).to permit_action(:create_any)
+      end
+
+      it 'allows user with manager permissions on account to view invite user form' do
+        user = create(:user, :manager, on: create(:account))
+
+        policy = UserPolicy.new(user, User.new)
+
+        expect(policy).to permit_action(:create_any)
+      end
+
+      it 'does not allow user with publisher permissions on account to view invite user form' do
+        user = create(:user, :publisher, on: create(:account))
+
+        policy = UserPolicy.new(user, User.new)
+
+        expect(policy).not_to permit_action(:create_any)
+      end
+
+      it 'does not allow user with manager permissions on entry to view invite user form' do
+        user = create(:user, :manager, on: create(:entry))
+
+        policy = UserPolicy.new(user, User.new)
+
+        expect(policy).not_to permit_action(:create_any)
       end
     end
 


### PR DESCRIPTION
CanCan does not evaluate `can` blocks when classes are passed as
subject. Switch to passing symbols in these cases to prevent new and
index pages from being accessible for users without permissions.