### PR TITLE
Add config options to restrict account manager permissions

### DIFF
--- a/admins/pageflow/accounts.rb
+++ b/admins/pageflow/accounts.rb
@@ -89,8 +89,7 @@ module Pageflow
         result = params.permit(account: permitted_account_attributes)
 
         if result[:account]
-          feature_states = params[:account][:feature_states].try(:permit!)
-          result[:account].merge!(feature_states: feature_states || {})
+          permit_feature_states(result[:account])
         end
 
         result
@@ -134,6 +133,13 @@ module Pageflow
           Pageflow.config_for(resource).admin_form_inputs.permitted_attributes_for(resource_name)
         else
           []
+        end
+      end
+
+      def permit_feature_states(attributes)
+        if params[:id] && authorized?(:update_feature_configuration_on, resource)
+          feature_states = params[:account][:feature_states].try(:permit!)
+          attributes.merge!(feature_states: feature_states || {})
         end
       end
     end

--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -169,6 +169,12 @@ module Pageflow
         entry.theming ||= entry.account.default_theming
       end
 
+      before_update do |entry|
+        if entry.account_id_changed? && !authorized?(:update_theming_on, resource)
+          entry.theming = entry.account.default_theming
+        end
+      end
+
       def update
         update! do |success, _|
           success.html { redirect_to(admin_entry_path(resource, params.slice(:tab))) }

--- a/admins/pageflow/user.rb
+++ b/admins/pageflow/user.rb
@@ -43,7 +43,9 @@ module Pageflow
           row :locale do
             I18n.t('language', locale: user.locale)
           end
-          boolean_status_tag_row(:admin?, 'admin warning')
+          if authorized?(:see_admin_status, user)
+            boolean_status_tag_row(:admin?, 'admin warning')
+          end
         end
 
         para do

--- a/app/policies/pageflow/account_policy.rb
+++ b/app/policies/pageflow/account_policy.rb
@@ -111,6 +111,12 @@ module Pageflow
       manage?
     end
 
+    def update_feature_configuration_on?
+      user.admin? ||
+        (!permissions_config.only_admins_may_update_features &&
+         manage?)
+    end
+
     def add_member_to?
       manage?
     end

--- a/app/policies/pageflow/application_policy.rb
+++ b/app/policies/pageflow/application_policy.rb
@@ -7,5 +7,11 @@ module Pageflow
         ActiveRecord::Base.send(:sanitize_sql_array, array)
       end
     end
+
+    protected
+
+    def permissions_config
+      Pageflow.config.permissions
+    end
   end
 end

--- a/app/policies/pageflow/entry_policy.rb
+++ b/app/policies/pageflow/entry_policy.rb
@@ -132,7 +132,9 @@ module Pageflow
     end
 
     def update_feature_configuration_on?
-      manage_account_of?
+      user.admin? ||
+        (!permissions_config.only_admins_may_update_features &&
+         manage_account_of?)
     end
 
     def destroy?

--- a/app/policies/pageflow/entry_policy.rb
+++ b/app/policies/pageflow/entry_policy.rb
@@ -124,7 +124,9 @@ module Pageflow
     end
 
     def update_theming_on?
-      publish_on_account_of?
+      user.admin? ||
+        (!permissions_config.only_admins_may_update_theming &&
+         publish_on_account_of?)
     end
 
     def manage_account_of?

--- a/app/policies/pageflow/user_policy.rb
+++ b/app/policies/pageflow/user_policy.rb
@@ -69,6 +69,14 @@ module Pageflow
       admin?
     end
 
+    def see_admin_status?
+      if permissions_config.only_admins_may_see_admin_boolean
+        admin?
+      else
+        read?
+      end
+    end
+
     def delete_own_user?
       Pageflow.config.authorize_user_deletion.call(@managed_user) == true
     end

--- a/config/initializers/admin_resource_tabs.rb
+++ b/config/initializers/admin_resource_tabs.rb
@@ -2,15 +2,28 @@ Pageflow.configure do |config|
   config.admin_resource_tabs.register(:entry, name: :members, component: Pageflow::Admin::MembersTab)
   config.admin_resource_tabs.register(:entry, name: :revisions, component: Pageflow::Admin::RevisionsTab)
 
-  config.admin_resource_tabs.register(:entry,
-                                      name: :features,
-                                      component: Pageflow::Admin::FeaturesTab,
-                                      required_account_role: :manager)
-
   config.admin_resource_tabs.register(:user, name: :accounts, component: Pageflow::Admin::UserAccountsTab)
   config.admin_resource_tabs.register(:user, name: :entries, component: Pageflow::Admin::UserEntriesTab)
 
   config.admin_resource_tabs.register(:theming, name: :entries, component: Pageflow::Admin::EntriesTab)
   config.admin_resource_tabs.register(:theming, name: :users, component: Pageflow::Admin::UsersTab)
-  config.admin_resource_tabs.register(:theming, name: :features, component: Pageflow::Admin::FeaturesTab)
+end
+
+Pageflow.after_configure do |config|
+  features_tab_permissions =
+    if config.permissions.only_admins_may_update_features
+      {admin_only: true}
+    else
+      {required_account_role: :manager}
+    end
+
+  config.admin_resource_tabs.register(:entry,
+                                      name: :features,
+                                      component: Pageflow::Admin::FeaturesTab,
+                                      **features_tab_permissions)
+
+  config.admin_resource_tabs.register(:theming,
+                                      name: :features,
+                                      component: Pageflow::Admin::FeaturesTab,
+                                      **features_tab_permissions)
 end

--- a/lib/pageflow/ability_mixin.rb
+++ b/lib/pageflow/ability_mixin.rb
@@ -222,6 +222,10 @@ module Pageflow
           UserPolicy.new(user, managed_user).read?
         end
 
+        can :see_admin_status, ::User do |managed_user|
+          UserPolicy.new(user, managed_user).see_admin_status?
+        end
+
         can :redirect_to_user,
             ::User,
             UserPolicy::Scope.new(user, ::User).resolve do |managed_user|

--- a/lib/pageflow/ability_mixin.rb
+++ b/lib/pageflow/ability_mixin.rb
@@ -15,6 +15,10 @@ module Pageflow
         AccountPolicy.new(user, account).update?
       end
 
+      can :update_feature_configuration_on, Account do |account|
+        AccountPolicy.new(user, account).update_feature_configuration_on?
+      end
+
       can :add_member_to, Account do |account|
         AccountPolicy.new(user, account).add_member_to?
       end

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -257,6 +257,10 @@ module Pageflow
     # @since edge
     attr_accessor :account_admin_menu_options
 
+    # Sublayer for permissions related config.
+    # @since edge
+    attr_reader :permissions
+
     def initialize
       @paperclip_filesystem_default_options = {validate_media_type: false}
       @paperclip_s3_default_options = {validate_media_type: false}
@@ -301,6 +305,8 @@ module Pageflow
       @available_text_track_kinds = [:captions, :subtitles, :descriptions]
 
       @account_admin_menu_options = {}
+
+      @permissions = Permissions.new
     end
 
     # Activate a plugin.

--- a/lib/pageflow/configuration/permissions.rb
+++ b/lib/pageflow/configuration/permissions.rb
@@ -6,6 +6,7 @@ module Pageflow
       def initialize
         @only_admins_may_update_features = false
         @only_admins_may_see_admin_boolean = false
+        @only_admins_may_update_theming = false
       end
 
       # Restrict access to features tabs to admins. Defaults to false.
@@ -16,6 +17,11 @@ module Pageflow
       # admins. Defaults to false.
       # @since edge
       attr_accessor :only_admins_may_see_admin_boolean
+
+      # Restrict access to theming drop down on entry edit admin page
+      # to admins. Defaults to false.
+      # @since edge
+      attr_accessor :only_admins_may_update_theming
     end
   end
 end

--- a/lib/pageflow/configuration/permissions.rb
+++ b/lib/pageflow/configuration/permissions.rb
@@ -5,11 +5,17 @@ module Pageflow
     class Permissions
       def initialize
         @only_admins_may_update_features = false
+        @only_admins_may_see_admin_boolean = false
       end
 
       # Restrict access to features tabs to admins. Defaults to false.
       # @since edge
       attr_accessor :only_admins_may_update_features
+
+      # Restrict visibility of admin flag on user admin page to
+      # admins. Defaults to false.
+      # @since edge
+      attr_accessor :only_admins_may_see_admin_boolean
     end
   end
 end

--- a/lib/pageflow/configuration/permissions.rb
+++ b/lib/pageflow/configuration/permissions.rb
@@ -1,0 +1,15 @@
+module Pageflow
+  class Configuration
+    # Permissions related options to be defined in the pageflow
+    # initializer of the main app.
+    class Permissions
+      def initialize
+        @only_admins_may_update_features = false
+      end
+
+      # Restrict access to features tabs to admins. Defaults to false.
+      # @since edge
+      attr_accessor :only_admins_may_update_features
+    end
+  end
+end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -5,6 +5,51 @@ module Pageflow
     describe '#show' do
       render_views
 
+      it 'shows admin boolean for account managers' do
+        pageflow_configure do |config|
+          config.permissions.only_admins_may_see_admin_boolean = false
+        end
+
+        user = create(:user, :manager, on: create(:account))
+
+        sign_in(user)
+        get(:show, id: user.id)
+
+        expect(response.body)
+          .to have_css('.status_tag_row th',
+                       text: ::User.human_attribute_name(:admin))
+      end
+
+      context 'with config.permissions.only_admins_may_see_admin_boolean' do
+        it 'shows admin boolean for admin' do
+          pageflow_configure do |config|
+            config.permissions.only_admins_may_see_admin_boolean = true
+          end
+
+          user = create(:user, :admin)
+
+          sign_in(user)
+          get(:show, id: user.id)
+
+          expect(response.body).to have_css('.status_tag_row th',
+                                            text: ::User.human_attribute_name(:admin))
+        end
+
+        it 'does not show admin boolean for account manager' do
+          pageflow_configure do |config|
+            config.permissions.only_admins_may_see_admin_boolean = true
+          end
+
+          user = create(:user, :manager, on: create(:account))
+
+          sign_in(user)
+          get(:show, id: user.id)
+
+          expect(response.body).not_to have_css('.status_tag_row th',
+                                                text: ::User.human_attribute_name(:admin))
+        end
+      end
+
       describe 'additional admin resource tab' do
         let(:tab_view_component) do
           Class.new(Pageflow::ViewComponent) do

--- a/spec/policies/pageflow/account_policy_spec.rb
+++ b/spec/policies/pageflow/account_policy_spec.rb
@@ -44,6 +44,35 @@ module Pageflow
                     to: :update,
                     topic: -> { create(:account) }
 
+    context 'without only_admins_may_update_features' do
+      before do
+        pageflow_configure do |config|
+          config.permissions.only_admins_may_update_features = false
+        end
+      end
+
+      it_behaves_like 'a membership-based permission that',
+                      allows: :manager,
+                      but_forbids: :publisher,
+                      of_account: ->(topic) { topic },
+                      to: :update_feature_configuration_on,
+                      topic: -> { create(:account) }
+    end
+
+    context 'with only_admins_may_update_features' do
+      before do
+        pageflow_configure do |config|
+          config.permissions.only_admins_may_update_features = true
+        end
+      end
+
+      it_behaves_like 'an admin permission that',
+                      allows_admins_but_forbids_even_managers: true,
+                      of_account: ->(topic) { topic },
+                      to: :update_feature_configuration_on,
+                      topic: -> { create(:account) }
+    end
+
     it_behaves_like 'a membership-based permission that',
                     allows: :manager,
                     but_forbids: :publisher,

--- a/spec/policies/pageflow/entry_policy_spec.rb
+++ b/spec/policies/pageflow/entry_policy_spec.rb
@@ -145,12 +145,34 @@ module Pageflow
                     to: :manage_account_of,
                     topic: -> { create(:entry) }
 
-    it_behaves_like 'a membership-based permission that',
-                    allows: :manager,
-                    but_forbids: :publisher,
-                    of_account: ->(topic) { topic.account },
-                    to: :update_feature_configuration_on,
-                    topic: -> { create(:entry) }
+    context 'without only_admins_may_update_features' do
+      before do
+        pageflow_configure do |config|
+          config.permissions.only_admins_may_update_features = false
+        end
+      end
+
+      it_behaves_like 'a membership-based permission that',
+                      allows: :manager,
+                      but_forbids: :publisher,
+                      of_account: ->(topic) { topic.account },
+                      to: :update_feature_configuration_on,
+                      topic: -> { create(:entry) }
+    end
+
+    context 'with only_admins_may_update_features' do
+      before do
+        pageflow_configure do |config|
+          config.permissions.only_admins_may_update_features = true
+        end
+      end
+
+      it_behaves_like 'an admin permission that',
+                      allows_admins_but_forbids_even_managers: true,
+                      of_account: ->(topic) { topic.account },
+                      to: :update_feature_configuration_on,
+                      topic: -> { create(:entry) }
+    end
 
     it_behaves_like 'a membership-based permission that',
                     allows: :manager,

--- a/spec/policies/pageflow/entry_policy_spec.rb
+++ b/spec/policies/pageflow/entry_policy_spec.rb
@@ -131,12 +131,34 @@ module Pageflow
                     to: :update_account_on,
                     topic: -> { create(:entry) }
 
-    it_behaves_like 'a membership-based permission that',
-                    allows: :publisher,
-                    but_forbids: :editor,
-                    of_account: ->(topic) { topic.account },
-                    to: :update_theming_on,
-                    topic: -> { create(:entry) }
+    context 'without only_admins_may_update_theming' do
+      before do
+        pageflow_configure do |config|
+          config.permissions.only_admins_may_update_theming = false
+        end
+      end
+
+      it_behaves_like 'a membership-based permission that',
+                      allows: :publisher,
+                      but_forbids: :editor,
+                      of_account: ->(topic) { topic.account },
+                      to: :update_theming_on,
+                      topic: -> { create(:entry) }
+    end
+
+    context 'with only_admins_may_update_theming' do
+      before do
+        pageflow_configure do |config|
+          config.permissions.only_admins_may_update_theming = true
+        end
+      end
+
+      it_behaves_like 'an admin permission that',
+                      allows_admins_but_forbids_even_managers: true,
+                      of_account: ->(topic) { topic.account },
+                      to: :update_theming_on,
+                      topic: -> { create(:entry) }
+    end
 
     it_behaves_like 'a membership-based permission that',
                     allows: :manager,

--- a/spec/policies/pageflow/user_policy_spec.rb
+++ b/spec/policies/pageflow/user_policy_spec.rb
@@ -9,6 +9,35 @@ module Pageflow
                     to: :read,
                     topic: -> { create(:user, :member, on: create(:account)) }
 
+    context 'without only_admins_may_see_admin_boolean' do
+      before do
+        pageflow_configure do |config|
+          config.permissions.only_admins_may_see_admin_boolean = false
+        end
+      end
+
+      it_behaves_like 'a membership-based permission that',
+                      allows: :manager,
+                      but_forbids: :publisher,
+                      of_account: ->(topic) { topic.accounts.first },
+                      to: :see_admin_status,
+                      topic: -> { create(:user, :member, on: create(:account)) }
+    end
+
+    context 'with only_admins_may_see_admin_boolean' do
+      before do
+        pageflow_configure do |config|
+          config.permissions.only_admins_may_see_admin_boolean = true
+        end
+      end
+
+      it_behaves_like 'an admin permission that',
+                      allows_admins_but_forbids_even_managers: true,
+                      of_account: ->(topic) { topic.accounts.first },
+                      to: :see_admin_status,
+                      topic: -> { create(:user, :member, on: create(:account)) }
+    end
+
     it_behaves_like 'a membership-based permission that',
                     allows: :manager,
                     but_forbids: :publisher,


### PR DESCRIPTION
Allow taking permissions from account managers to

* manage features
* set entry theming
* see admin flags on user admin page