### PR TITLE
Use copy of current_user in profile form

### DIFF
--- a/admins/pageflow/user.rb
+++ b/admins/pageflow/user.rb
@@ -111,9 +111,11 @@ module Pageflow
     end
 
     collection_action 'me', title: I18n.t('pageflow.admin.users.account'), method: [:get, :patch] do
+      @user = User.find(current_user.id)
+
       if request.patch?
-        if current_user.update_with_password(user_profile_params)
-          sign_in current_user, bypass: true
+        if @user.update_with_password(user_profile_params)
+          sign_in @user, bypass: true
           redirect_to admin_root_path, notice: I18n.t('pageflow.admin.users.me.updated')
         end
       end

--- a/app/views/admin/users/me.html.erb
+++ b/app/views/admin/users/me.html.erb
@@ -1,4 +1,4 @@
-<%= admin_form_for current_user, :url => me_admin_users_path, :html => {:class => 'profile'} do |form| %>
+<%= admin_form_for @user, url: me_admin_users_path, html: {class: 'profile'} do |form| %>
   <%= form.inputs :first_name, :last_name %>
 
   <%= form.inputs do %>
@@ -9,7 +9,7 @@
   <% end %>
 
   <%= form.inputs do %>
-    <%= form.input :current_password, :hint => t('pageflow.admin.users.me.change_password_hint') %>
+    <%= form.input :current_password, hint: t('pageflow.admin.users.me.change_password_hint') %>
     <%= form.input :password %>
     <%= form.input :password_confirmation %>
   <% end %>

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -428,6 +428,8 @@ module Pageflow
     end
 
     describe '#me' do
+      render_views
+
       it 'allows users to update their profile' do
         user = create(:user,
                       first_name: 'Tom',
@@ -493,6 +495,19 @@ module Pageflow
         patch(:me, user: {admin: true})
 
         expect(user.reload).not_to be_admin
+      end
+
+      it 'does not change user name in navigation when validation fails' do
+        user = create(:user,
+                      first_name: 'Tom',
+                      last_name: 'Thomson')
+
+        sign_in(user)
+        patch(:me, user: {
+                first_name: ''
+              })
+
+        expect(response.body).to have_selector('#current_user > a', text: 'Tom Thomson')
       end
     end
 

--- a/spec/models/pageflow/user_spec.rb
+++ b/spec/models/pageflow/user_spec.rb
@@ -27,6 +27,14 @@ module Pageflow
 
         expect(user.errors).not_to be_empty
       end
+
+      it 'does not allow to set empty first and last name' do
+        user = create(:user, first_name: 'Bob', last_name: 'Bing')
+
+        user.update_with_password(first_name: '', last_name: '')
+
+        expect(user.reload.first_name).to eq('Bob')
+      end
     end
 
     describe '#destroy_with_password' do


### PR DESCRIPTION
Prevent displaying unsafed data in utility navigation when validation
failed.