### PR TITLE
Fix file type detection for vtt uploads on Safari

### DIFF
--- a/app/assets/javascripts/pageflow/editor/initializers/setup_file_types.js
+++ b/app/assets/javascripts/pageflow/editor/initializers/setup_file_types.js
@@ -85,7 +85,7 @@ pageflow.app.addInitializer(function(options) {
   pageflow.editor.fileTypes.register('text_track_files', {
     model: pageflow.TextTrackFile,
     matchUpload: function(upload) {
-      return upload.type.match(/\/vtt$/) ||
+      return upload.name.match(/\.vtt$/) ||
         upload.name.match(/\.srt$/);
     },
     skipUploadConfirmation: true,


### PR DESCRIPTION
Safari gives an empty string as `type` for vtt file uploads. Test for
file extension instead. We already do this for `srt` files anyway.