### PR TITLE
Activate text track after it has been added

### DIFF
--- a/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
+++ b/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
@@ -345,7 +345,7 @@ describe('createFilePlayer', () => {
 
       // Emulate VideoJS textTracks interface
       textTracks: function() {
-        return this.el ? [].slice.call(this.el.querySelectorAll('track')).map(track => {
+        var list = this.el ? [].slice.call(this.el.querySelectorAll('track')).map(track => {
           const fakeTrack = {};
 
           ['id', 'label', 'mode', 'kind', 'src'].forEach(property =>
@@ -372,6 +372,9 @@ describe('createFilePlayer', () => {
 
           return fakeTrack;
         }) : [];
+
+        list.on = sinon.stub();
+        return list;
       },
 
       play: sinon.spy(),

--- a/node_package/src/media/components/createFilePlayer/textTracks.js
+++ b/node_package/src/media/components/createFilePlayer/textTracks.js
@@ -3,6 +3,10 @@ export function initTextTracks(player, getActiveTexTrackFileId, getPosition) {
     updateOnNextPlay(player, getActiveTexTrackFileId, getPosition);
   });
 
+  player.textTracks().on('addtrack', () => {
+    updateTextTracks(player, null, getActiveTexTrackFileId(), getPosition());
+  });
+
   updateTextTracks(player, null, getActiveTexTrackFileId(), getPosition());
   updateOnNextPlay(player, getActiveTexTrackFileId, getPosition);
 }


### PR DESCRIPTION
When text tracks load asynchronously, we need to make sure to update
the mode once they have been added. In some cases text tracks
activated by default were not displayed during the initial run.