### PR TITLE
split up base JS into vendor/app

### DIFF
--- a/app/assets/javascripts/pageflow/base.js
+++ b/app/assets/javascripts/pageflow/base.js
@@ -1,31 +1,12 @@
-// This is a manifest file that'll be compiled into application.js, which will include all the files
-// listed below.
-//
-// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
-// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
-//
-// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
-// compiled file.
-//
-// Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
-// about supported directives.
-//
+// base JavaScript file for Pageflow.
+// This file is meant to hold code we develop.
+// And vendor code that changes a lot.
 
 //= require polyfills/bind
 
-//= require i18n
-//= require jquery
-//= require jquery-ui/widget
-//= require jquery_ujs
 //= require ./jquery_utils
-//= require iscroll
-//= require audio5.min
 //= require ./videojs
-//= require jquery.fullscreen
-//= require jquery.placeholder
 
-//= require react
-//= require backbone-rails
 //= require_self
 
 //= require ./object

--- a/app/assets/javascripts/pageflow/vendor.js
+++ b/app/assets/javascripts/pageflow/vendor.js
@@ -1,0 +1,16 @@
+// vendor JavaScript manifest for Pageflow.
+// This file is meant to hold code we don't develop and/or rarely change.
+// It means this asset will stay cached for much longer.
+
+//= require i18n
+//= require jquery
+//= require jquery-ui/widget
+//= require jquery_ujs
+//= require jquery.fullscreen
+//= require jquery.placeholder
+
+//= require iscroll
+//= require audio5.min
+
+//= require react
+//= require backbone-rails

--- a/app/views/layouts/pageflow/application.html.erb
+++ b/app/views/layouts/pageflow/application.html.erb
@@ -7,7 +7,8 @@
     window.PAGEFLOW_EDITOR = <%= @editor_scope ? 'true' : 'false' %>;
   </script>
 
-  <%= javascript_include_tag "pageflow/application", "data-turbolinks-track" => true %>
+  <%= javascript_include_tag 'pageflow/vendor', 'data-turbolinks-track' => true %>
+  <%= javascript_include_tag 'pageflow/application', 'data-turbolinks-track' => true %>
 
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, minimum-scale=1, maximum-scale=1" />

--- a/lib/pageflow/engine.rb
+++ b/lib/pageflow/engine.rb
@@ -57,25 +57,6 @@ module Pageflow
       config.i18n.reload!
     end
 
-    # Precompile additional assets. pageflow/editor.* has to be
-    # provided by the main app.
-    config.assets.precompile += %w(pageflow/editor.js pageflow/editor.css
-                                   pageflow/application_with_simulated_media_queries.css
-                                   pageflow/print_view.css
-                                   pageflow/lt_ie9.js pageflow/lt_ie9.css pageflow/ie9.js pageflow/ie9.css
-                                   video-js.swf vjs.eot vjs.svg vjs.ttf vjs.woff)
-
-    config.assets.precompile << lambda do |path, _filename|
-      Pageflow.config.themes.any? do |theme|
-        path == theme.stylesheet_path
-      end
-    end
-
-    config.assets.precompile << lambda do |path, filename|
-      filename.start_with?(Engine.root.join('app/assets').to_s) &&
-        !['.js', '.css', ''].include?(File.extname(path))
-    end
-
     # Make sure the configuration is recreated when classes are
     # reloded. Otherwise registered page types might still point to
     # unloaded classes in development mode.
@@ -86,6 +67,30 @@ module Pageflow
     initializer "pageflow.factories", :after => "factory_girl.set_factory_paths" do
       if Pageflow.configured? && defined?(FactoryGirl)
         FactoryGirl.definition_file_paths.unshift(Engine.root.join('spec', 'factories'))
+      end
+    end
+
+    # Precompile additional assets. pageflow/editor.* has to be
+    # provided by the main app.
+    initializer 'pageflow.assets.precompile' do |app|
+      app.config.assets.precompile += %w(
+        pageflow/editor.js pageflow/editor.css
+        pageflow/application_with_simulated_media_queries.css
+        pageflow/print_view.css
+        pageflow/lt_ie9.js pageflow/lt_ie9.css pageflow/ie9.js pageflow/ie9.css
+        pageflow/vendor.js
+        video-js.swf vjs.eot vjs.svg vjs.ttf vjs.woff
+      )
+
+      app.config.assets.precompile << lambda do |path, _filename|
+        Pageflow.config.themes.any? do |theme|
+          path == theme.stylesheet_path
+        end
+      end
+
+      app.config.assets.precompile << lambda do |path, filename|
+        filename.start_with?(Engine.root.join('app/assets').to_s) &&
+          !['.js', '.css', ''].include?(File.extname(path))
       end
     end
   end

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -3,6 +3,7 @@
 //= require support/chai-jq-0.0.7
 //= require support/sinon-chai
 
+//= require pageflow/vendor
 //= require pageflow/application
 //= require pageflow/editor
 


### PR DESCRIPTION
This pattern is quite common for Webpack and it makes a lot of sense to me too.

We split up application.js into a vendor part and an app part. The engine precompiles both. They are meant to be included separately into the html <head>. Vendor won't change nearly as often and so will remain cached for longer.

It's backwards compatible with the current way. I'll update docs etc if you think this is a good idea.