### PR TITLE
Use Web Audio volume fading only if player has getMediaElement

### DIFF
--- a/app/assets/javascripts/pageflow/media_player/volume_fading.js
+++ b/app/assets/javascripts/pageflow/media_player/volume_fading.js
@@ -5,7 +5,7 @@ pageflow.mediaPlayer.volumeFading = function(player) {
   if (!pageflow.browser.has('volume control support')) {
     return pageflow.mediaPlayer.volumeFading.noop(player);
   }
-  else if (pageflow.audioContext.get()) {
+  else if (pageflow.audioContext.get() && player.getMediaElement) {
     return pageflow.mediaPlayer.volumeFading.webAudio(
       player,
       pageflow.audioContext.get()


### PR DESCRIPTION
`pagefow-vr` player does not support accessing the media element
directly.