### PR TITLE
Prevent calling localeCompare of null.

### DIFF
--- a/node_package/src/media/selectors.js
+++ b/node_package/src/media/selectors.js
@@ -41,7 +41,7 @@ export function textTracks({file, defaultTextTrackFileId = () => {}}) {
 
       return {
         files: files.sort((file1, file2) =>
-                          file1.displayLabel.localeCompare(file2.displayLabel)
+                          (file1.displayLabel || '').localeCompare(file2.displayLabel || '')
                          ),
         autoFile,
         activeFileId: getActiveTextTrackFileId(files,


### PR DESCRIPTION
Fails in server side rendering.