### PR TITLE
Include hls in output presences of legacy files

### DIFF
--- a/db/migrate/20170222124848_update_video_file_output_presences.rb
+++ b/db/migrate/20170222124848_update_video_file_output_presences.rb
@@ -2,7 +2,7 @@ class UpdateVideoFileOutputPresences < ActiveRecord::Migration
   def up
     execute(<<-SQL)
       UPDATE pageflow_video_files
-        SET output_presences = '{"high":true,"medium":true,"low":true}'
+        SET output_presences = '{"high":true,"medium":true,"low":true,"hls-playlist":true}'
         WHERE output_presences IS NULL;
     SQL
   end


### PR DESCRIPTION
If hls files are generated from smil files, the output will be [marked as present automatically][1]. If Zencoder generated hls playlists were used, they need to be marked as present in this migration. We can simply add the item to the list by default since the externally generated items are [merged as a hash][2] preventing duplicates in the resulting list.

[1]: https://github.com/codevise/pageflow/blob/c54d3fce638f8ed40f4ec0d6a9c0e8f1be5d7bc3/app/models/pageflow/video_file.rb#L143
[2]: https://github.com/codevise/pageflow/blob/c54d3fce638f8ed40f4ec0d6a9c0e8f1be5d7bc3/app/models/concerns/pageflow/output_source.rb#L44