### PR TITLE
add Resque::Server to install generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Generate a secure password in the seeds
   ([#775](https://github.com/codevise/pageflow/pull/775))
 
+- Add Resque::Server to the generated routes
+  ([#856](https://github.com/codevise/pageflow/issues/856))
+
+  Mounting the Resque web server makes it easier to inspect background workers and restart jobs that have failed. See the issue description on how to add this to existing apps.
+
 See
 [12-0-stable](https://github.com/codevise/pageflow/blob/12-0-stable/CHANGELOG.md)
 branch for previous changes.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Consider using the [foreman gem](https://github.com/ddollar/foreman) to start al
 these processes (including the Rails server) with a single command in your
 development environment.
 
+The built-in Resque web server is mounted at `/background_jobs`. Use it to
+inspect the state of background jobs, and restart failed jobs. This functionality
+is only available for admins.
+
 ## Troubleshooting
 
 If you run into problems during the installation of Pageflow, please refer to the [Troubleshooting](https://github.com/codevise/pageflow/wiki/Troubleshooting) wiki

--- a/lib/generators/pageflow/routes/routes_generator.rb
+++ b/lib/generators/pageflow/routes/routes_generator.rb
@@ -7,8 +7,18 @@ module Pageflow
 
       def add_route
         inject_into_file 'config/routes.rb', after: "  ActiveAdmin.routes(self)\n" do
-          "  Pageflow.routes(self)\n"
+          <<-HEREDOC
+  Pageflow.routes(self)
+
+  authenticate :user, lambda { |user| user.admin? } do
+    mount Resque::Server.new, at: "/background_jobs"
+  end
+          HEREDOC
         end
+      end
+
+      def require_resque_server
+        prepend_to_file 'config/routes.rb', "require 'resque/server'\nrequire 'resque_scheduler/server'\n\n"
       end
     end
   end

--- a/spec/generators/pageflow/routes/routes_generator_spec.rb
+++ b/spec/generators/pageflow/routes/routes_generator_spec.rb
@@ -12,10 +12,30 @@ module Pageflow
           "Rails.application.routes.draw do\n  ActiveAdmin.routes(self)\nend"
       end
 
+      let(:routes) { file('config/routes.rb') }
+
       it 'adds the Pageflow routes' do
         run_generator
-        routes = file('config/routes.rb')
+
         expect(routes).to contain("  Pageflow.routes(self)\n")
+      end
+
+      it 'adds Resque::Server' do
+        run_generator
+
+        expect(routes).to contain("Resque::Server")
+      end
+
+      it 'requires resque/server' do
+        run_generator
+
+        expect(routes).to contain("require 'resque/server'")
+      end
+
+      it 'requires resque_scheduler/server' do
+        run_generator
+
+        expect(routes).to contain("require 'resque_scheduler/server'")
       end
     end
   end


### PR DESCRIPTION
This will mount Resque::Web in the routes at /background_jobs.
Fixes #856