### PR TITLE
Include hls in output presences of legacy files

### DIFF
--- a/db/migrate/20170913105048_fix_hls_output_presences_for_legacy_video_files.rb
+++ b/db/migrate/20170913105048_fix_hls_output_presences_for_legacy_video_files.rb
@@ -1,0 +1,12 @@
+class FixHlsOutputPresencesForLegacyVideoFiles < ActiveRecord::Migration
+  def up
+    execute(<<-SQL)
+      UPDATE pageflow_video_files
+        SET output_presences = '{"high":true,"medium":true,"low":true,"hls-playlist":true}'
+        WHERE output_presences = '{"high":true,"medium":true,"low":true}';
+    SQL
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
Original migration has been fixed in #867, but this will not work for
people who are upgrading from 12.0.1 to 12.1. So we need to make sure
the fix is applied just in case.