### PR TITLE
Precompile assets in Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_install:
 before_script:
   - bin/npm install
   - bin/npm run build
+  - bin/rake pageflow:dummy
+  - bin/rake app:assets:precompile
 
 script:
   - bin/rspec

--- a/Rakefile
+++ b/Rakefile
@@ -20,8 +20,8 @@ Semmy::Tasks.install do |config|
   config.source_files_with_docs_tags = '{app,lib,node_package/src}/**/*.{js,jsx,rb,scss}'
 end
 
-require File.expand_path('spec/support/pageflow/rails_version', File.dirname(__FILE__))
-APP_RAKEFILE = File.expand_path("../spec/dummy/rails-#{Pageflow::RailsVersion.detect}/Rakefile", __FILE__)
+require File.expand_path('spec/support/pageflow/dummy/app', File.dirname(__FILE__))
+APP_RAKEFILE = File.expand_path("../#{Pageflow::Dummy::App.new.directory}/Rakefile", __FILE__)
 
 load 'rails/tasks/engine.rake' if File.exists?(APP_RAKEFILE)
 load File.expand_path('lib/tasks/pageflow_tasks.rake', File.dirname(__FILE__))

--- a/spec/support/pageflow/dummy/app.rb
+++ b/spec/support/pageflow/dummy/app.rb
@@ -9,9 +9,8 @@ module Pageflow
         if File.exist?(directory)
           puts("Dummy directory #{directory} exists.")
         else
-          travis_fold('setup_dummy') do
-            system("bundle exec rails new #{directory} --template #{template_path} #{rails_new_options}")
-          end
+          system("bundle exec rails new #{directory} " \
+                 "--template #{template_path} #{rails_new_options}")
         end
 
         require(File.join(ENV['RAILS_ROOT'], 'config', 'environment'))
@@ -28,12 +27,6 @@ module Pageflow
 
       def rails_new_options
         '--skip-test-unit --skip-bundle --database=mysql'
-      end
-
-      def travis_fold(name)
-        system("[ $TRAVIS ] && echo 'travis_fold:start:#{name}'")
-        yield
-        system("[ $TRAVIS ] && echo 'travis_fold:end:#{name}'")
       end
     end
   end


### PR DESCRIPTION
On some internal projects this approach reduced the timout related
Poltergeist errors since assets are no longer precompiled in the
request cycle the first time any asset is used.