### PR TITLE
Handle async tech loading in VideoJS 6

### DIFF
--- a/app/assets/javascripts/pageflow/media_player.js
+++ b/app/assets/javascripts/pageflow/media_player.js
@@ -1,4 +1,5 @@
 //= require_self
+//= require ./media_player/catch_play_promise
 //= require ./media_player/volume_fading
 //= require ./media_player/volume_binding
 //= require ./media_player/load_waiting
@@ -7,6 +8,7 @@
 
 pageflow.mediaPlayer = {
   enhance: function(player, options) {
+    pageflow.mediaPlayer.catchPlayerPromise(player);
     pageflow.mediaPlayer.asyncPlay(player);
 
     if (options.hooks) {

--- a/app/assets/javascripts/pageflow/media_player/catch_play_promise.js
+++ b/app/assets/javascripts/pageflow/media_player/catch_play_promise.js
@@ -1,0 +1,23 @@
+/*global Promise*/
+
+// Chrome returns a promise from `play` that is rejected if another
+// operation (like calling `pause` or updating the source) happens
+// before playing started. If the promise rejection is not handled,
+// the operation that caused `play` to abort will fail with an
+// exception. Code following the operation will not be executed. Catch
+// and ignore the promise to prevent this.
+pageflow.mediaPlayer.catchPlayerPromise = function(player) {
+  var originalPlay = player.play;
+
+  player.play = function(/* arguments */) {
+    var result = originalPlay.apply(player, arguments);
+
+    if (result && (typeof Promise !== 'undefined') && (result instanceof Promise)) {
+      result.catch(function() {
+        pageflow.log('Caught pending play exception - continuing');
+      });
+    }
+
+    return result;
+  };
+};

--- a/app/assets/javascripts/pageflow/video_player/use_slim_controls_during_phone_playback.js
+++ b/app/assets/javascripts/pageflow/video_player/use_slim_controls_during_phone_playback.js
@@ -11,6 +11,6 @@ pageflow.mediaPlayer.useSlimPlayerControlsDuringPhonePlayback = function(player)
       });
     }
 
-    originalPlay.apply(this, arguments);
+    return originalPlay.apply(this, arguments);
   };
 };

--- a/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
+++ b/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
@@ -343,6 +343,10 @@ describe('createFilePlayer', () => {
       duration: sinon.stub(),
       isAudio: sinon.stub(),
 
+      ready: function(callback) {
+        callback();
+      },
+
       // Emulate VideoJS textTracks interface
       textTracks: function() {
         var list = this.el ? [].slice.call(this.el.querySelectorAll('track')).map(track => {

--- a/node_package/src/media/components/createFilePlayer/index.jsx
+++ b/node_package/src/media/components/createFilePlayer/index.jsx
@@ -48,21 +48,23 @@ export default function({
           playsInline: props.playsInline
         });
 
-        initPlayerFromPlayerState(this.player,
-                                  () => this.props.playerState,
-                                  this.props.playerActions,
-                                  this.prevFileId,
-                                  this.props.file.id);
+        this.player.ready(() => {
+          initPlayerFromPlayerState(this.player,
+                                    () => this.props.playerState,
+                                    this.props.playerActions,
+                                    this.prevFileId,
+                                    this.props.file.id);
 
-        if (!this.displaysTextTracksInNativePlayer) {
-          initTextTracks(this.player,
-                         () => this.props.textTracks.activeFileId,
-                         () => this.props.textTrackPosition);
-        }
+          if (!this.displaysTextTracksInNativePlayer) {
+            initTextTracks(this.player,
+                           () => this.props.textTracks.activeFileId,
+                           () => this.props.textTrackPosition);
+          }
 
-        watchPlayer(this.player, this.props.playerActions);
+          watchPlayer(this.player, this.props.playerActions);
 
-        this.prevFileId = this.props.file.id;
+          this.prevFileId = this.props.file.id;
+        });
       };
 
       this.disposeMediaTag = () => {


### PR DESCRIPTION
VideoJS 6 initialized the HTML5 tech asynchronously. Interaction with the
API is only possible after the `ready` callback has been invoked.

When updating video related attributes in the editor, attempts to interact
with the player shortly after its recreation lead to exceptions which
prevented changes to be saved to the server.

Fixes #874