### PR TITLE
Make url template generation more robust

### DIFF
--- a/app/models/pageflow/url_template.rb
+++ b/app/models/pageflow/url_template.rb
@@ -1,13 +1,19 @@
 module Pageflow
   module UrlTemplate
-    module_function
+    extend self
 
     def from_attachment(attachment, *style)
       insert_id_partition_placeholder(attachment.url(*style))
     end
 
+    private
+
     def insert_id_partition_placeholder(url)
-      url.gsub(%r'(\d{3}/)+', ':id_partition/')
+      replace_last_group_of_digit_segments(url, with: '/:id_partition/')
+    end
+
+    def replace_last_group_of_digit_segments(str, with:)
+      str.reverse.sub(%r'/(\d{3}/)+', with.reverse).reverse
     end
   end
 end

--- a/spec/models/pageflow/url_template_spec.rb
+++ b/spec/models/pageflow/url_template_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+module Pageflow
+  describe UrlTemplate do
+    describe '.from_attachment' do
+      def create_attachment(url:, filename: 'file.png')
+        Class.new(ActiveRecord::Base) {
+          self.table_name = 'pageflow_pages'
+
+          has_attached_file(:thumbnail, url: url)
+          attr_accessor(:thumbnail_file_name)
+
+          def self.to_s
+            'Page'
+          end
+        }.new(id: 5, thumbnail_file_name: filename).thumbnail
+      end
+
+      it 'returns url with :id_partition placeholder' do
+        attachment = create_attachment(url: '/:class/:attachment/:id_partition/:style/:filename')
+
+        result = UrlTemplate.from_attachment(attachment)
+
+        expect(result).to eq('/pages/thumbnails/:id_partition/original/file.png')
+      end
+
+      it 'only replaces last set of digits' do
+        attachment = create_attachment(url: '/123/:class/:id_partition/:style/:filename')
+
+        result = UrlTemplate.from_attachment(attachment)
+
+        expect(result).to eq('/123/pages/:id_partition/original/file.png')
+      end
+
+      it 'ignores other numeric values in url pattern' do
+        attachment = create_attachment(url: '/_a123/_e1001/:class/:id_partition/:style/:filename')
+
+        result = UrlTemplate.from_attachment(attachment)
+
+        expect(result).to eq('/_a123/_e1001/pages/:id_partition/original/file.png')
+      end
+
+      it 'ignores numeric file names' do
+        attachment = create_attachment(url: '/:class/:id_partition/:style/:filename',
+                                       filename: '123')
+
+        result = UrlTemplate.from_attachment(attachment)
+
+        expect(result).to eq('/pages/:id_partition/original/123')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prevent `:id_partition` placeholder from being inserted multiple
times.