### PR TITLE
Fix N+1 query in account admin users tab

### DIFF
--- a/app/views/components/pageflow/admin/users_tab.rb
+++ b/app/views/components/pageflow/admin/users_tab.rb
@@ -19,7 +19,7 @@ module Pageflow
               if authorized?(:update, membership)
                 link_to(I18n.t('pageflow.admin.users.edit_role'),
                         edit_admin_account_membership_path(
-                          membership.entity,
+                          account,
                           membership,
                           entity_type: 'Pageflow::Account'
                         ),
@@ -31,7 +31,7 @@ module Pageflow
             column do |membership|
               if authorized?(:destroy, membership)
                 link_to(I18n.t('pageflow.admin.users.delete'),
-                        admin_account_membership_path(membership.entity, membership),
+                        admin_account_membership_path(account, membership),
                         method: :delete,
                         data: {
                           confirm: I18n.t('active_admin.delete_confirmation'),


### PR DESCRIPTION
Do not load account N times via `membership.entity`. We already know
that it's the account we are currently viewing.