### PR TITLE
Improve handling of NaN duration

### DIFF
--- a/node_package/src/components/PlayerControls/TimeDisplay.jsx
+++ b/node_package/src/components/PlayerControls/TimeDisplay.jsx
@@ -8,11 +8,17 @@ export default function TimeDisplay(props) {
   );
 }
 
+export const unknownTimePlaceholder = '-:--';
+
 TimeDisplay.defaultProps = {
   value: 0
 };
 
 function format(value) {
+  if (isNaN(value)) {
+    return unknownTimePlaceholder;
+  }
+
   const seconds = Math.floor(value) % 60;
   const minutes = Math.floor(value / 60) % 60;
   const hours = Math.floor(value / 60 / 60);

--- a/node_package/src/components/PlayerControls/__spec__/TimeDisplay-spec.jsx
+++ b/node_package/src/components/PlayerControls/__spec__/TimeDisplay-spec.jsx
@@ -1,4 +1,4 @@
-import TimeDisplay from '../TimeDisplay';
+import TimeDisplay, {unknownTimePlaceholder} from '../TimeDisplay';
 
 import {shallow} from 'enzyme';
 import {expect} from 'support/chai';
@@ -32,5 +32,11 @@ describe('TimeDisplay', () => {
     const result = shallow(<TimeDisplay value={undefined} />);
 
     expect(result).to.have.text('0:00');
+  });
+
+  it('handles NaN', () => {
+    const result = shallow(<TimeDisplay value={NaN} />);
+
+    expect(result).to.have.text(unknownTimePlaceholder);
   });
 });

--- a/node_package/src/media/__spec__/createReducer-spec.js
+++ b/node_package/src/media/__spec__/createReducer-spec.js
@@ -28,9 +28,19 @@ describe('createReducer creates function that', () => {
       const {timeUpdate} = actionCreators();
       const reducer = createReducer();
 
-      const nextState = reducer({currentTime: 30}, timeUpdate({currentTime: 40}));
+      const nextState = reducer({currentTime: 30},
+                                timeUpdate({currentTime: 40, duration: 60}));
 
       expect(nextState.currentTime).to.eq(40);
+    });
+
+    it('updates duration', () => {
+      const {timeUpdate} = actionCreators();
+      const reducer = createReducer();
+
+      const nextState = reducer({}, timeUpdate({currentTime: 40, duration: 60}));
+
+      expect(nextState.duration).to.eq(60);
     });
   });
 

--- a/node_package/src/media/actions.js
+++ b/node_package/src/media/actions.js
@@ -113,9 +113,10 @@ export function actionCreators({scope = 'default'} = {}) {
       return pageAction(PAUSED);
     },
 
-    timeUpdate({currentTime}) {
+    timeUpdate({currentTime, duration}) {
       return pageAction(TIME_UPDATE, {
-        currentTime
+        currentTime,
+        duration
       });
     },
 

--- a/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
+++ b/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
@@ -139,7 +139,8 @@ describe('createFilePlayer', () => {
       {event: 'play', action: 'playing'},
       {event: 'pause', action: 'paused'},
       {event: 'loadedmetadata', action: 'metaDataLoaded', payload: {currentTime: 5, duration: 10}},
-      {event: 'timeupdate', action: 'timeUpdate', payload: {currentTime: 5}},
+      {event: 'progress', action: 'progress', payload: {bufferedEnd: 7}},
+      {event: 'timeupdate', action: 'timeUpdate', payload: {currentTime: 5, duration: 10}},
       {event: 'ended', action: 'ended'},
     ].forEach(({action, event, payload}) => {
       it(`invokes ${action} playerAction when player emits ${event}`, () => {
@@ -151,6 +152,7 @@ describe('createFilePlayer', () => {
         mount(<FilePlayer {...requiredProps} playerActions={playerActions}/>);
 
         mockPlayer.currentTime.returns(5);
+        mockPlayer.bufferedEnd.returns(7);
         mockPlayer.duration.returns(10);
         mockPlayer.trigger(event);
 
@@ -340,6 +342,7 @@ describe('createFilePlayer', () => {
   function createMockPlayer(element) {
     return {
       currentTime: sinon.stub(),
+      bufferedEnd: sinon.stub(),
       duration: sinon.stub(),
       isAudio: sinon.stub(),
 

--- a/node_package/src/media/components/createFilePlayer/watchPlayer.js
+++ b/node_package/src/media/components/createFilePlayer/watchPlayer.js
@@ -17,7 +17,8 @@ export default function(player, actions) {
   player.on('bufferunderruncontinue', actions.bufferUnderrunContinue);
 
   player.on('timeupdate', () => actions.timeUpdate({
-    currentTime: player.currentTime()
+    currentTime: player.currentTime(),
+    duration: player.duration()
   }));
 
   player.on('ended', actions.ended);

--- a/node_package/src/media/createReducer.js
+++ b/node_package/src/media/createReducer.js
@@ -161,6 +161,7 @@ export default function({scope = 'default'} = {}) {
       return {
         ...state,
         currentTime: action.payload.currentTime,
+        duration: action.payload.duration,
         isLoading: false
       };
     case ENDED:


### PR DESCRIPTION
HLS on Android reports NaN initially. Update on timeupdate and prevent
display of broken time stamps.