### PR TITLE
Add crossorigin attribute to video tag rendered by helper

### DIFF
--- a/app/helpers/pageflow/video_files_helper.rb
+++ b/app/helpers/pageflow/video_files_helper.rb
@@ -42,6 +42,7 @@ module Pageflow
 
     def video_file_video_tag(video_file, options = {})
       defaults = {
+        crossorigin: 'anonymous',
         class: [
           'player video-js video-viewport vjs-default-skin',
           options.delete(:class)


### PR DESCRIPTION
The `VideoFilesHelper` is still used to render video tags in linkmap
pages. Without the crossorigin attribute, volume fading via Web Audio
Api is not permitted.