### PR TITLE
Reset snapshot type when restoring revision

### DIFF
--- a/app/models/pageflow/entry.rb
+++ b/app/models/pageflow/entry.rb
@@ -87,6 +87,7 @@ module Pageflow
       restored_revision.copy do |revision|
         revision.restored_from = restored_revision
         revision.frozen_at = nil
+        revision.snapshot_type = nil
         revision.published_at = nil
         revision.published_until = nil
         revision.password_protected = nil

--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -40,8 +40,8 @@ module Pageflow
 
     scope :publications, -> { where('published_at IS NOT NULL') }
     scope :publications_and_user_snapshots, -> { where('published_at IS NOT NULL OR snapshot_type = "user"') }
-    scope :user_snapshots, -> { where('snapshot_type = "user"') }
-    scope :auto_snapshots, -> { where('snapshot_type = "auto"') }
+    scope :user_snapshots, -> { where(snapshot_type: 'user') }
+    scope :auto_snapshots, -> { where(snapshot_type: 'auto') }
 
     validates :entry, :presence => true
     validates :creator, :presence => true, :if => :published?

--- a/db/migrate/20170912165050_reset_copied_snapshot_type.rb
+++ b/db/migrate/20170912165050_reset_copied_snapshot_type.rb
@@ -1,0 +1,24 @@
+class ResetCopiedSnapshotType < ActiveRecord::Migration
+  def up
+    fix_restored_drafts
+    fix_publications_created_from_restored_drafts
+  end
+
+  private
+
+  def fix_restored_drafts
+    execute(<<-SQL)
+      UPDATE pageflow_revisions
+        SET snapshot_type = NULL
+        WHERE frozen_at IS NULL;
+    SQL
+  end
+
+  def fix_publications_created_from_restored_drafts
+    execute(<<-SQL)
+      UPDATE pageflow_revisions
+        SET snapshot_type = NULL
+        WHERE published_at IS NOT NULL;
+    SQL
+  end
+end

--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -18,6 +18,16 @@ module Pageflow
         published_until { 1.day.ago }
       end
 
+      trait :user_snapshot do
+        frozen
+        snapshot_type 'user'
+      end
+
+      trait :auto_snapshot do
+        frozen
+        snapshot_type 'auto'
+      end
+
       trait :with_home_button do
         home_button_enabled true
         home_url 'http://example.com'

--- a/spec/models/pageflow/entry_spec.rb
+++ b/spec/models/pageflow/entry_spec.rb
@@ -321,15 +321,25 @@ module Pageflow
         end
       end
 
-      context 'for frozen revision' do
+      context 'for snapshot revision' do
         it 'turns copy of passed revision into new draft' do
           creator = create(:user)
           entry = create(:entry)
-          earlier_revision = create(:revision, :frozen, title: 'the way it was', entry: entry)
+          earlier_revision = create(:revision, :auto_snapshot, title: 'the way it was', entry: entry)
 
           entry.restore(revision: earlier_revision, creator: creator)
 
           expect(entry.draft(true).title).to eq('the way it was')
+        end
+
+        it 'resets snapshot type' do
+          creator = create(:user)
+          entry = create(:entry)
+          earlier_revision = create(:revision, :auto_snapshot, title: 'the way it was', entry: entry)
+
+          entry.restore(revision: earlier_revision, creator: creator)
+
+          expect(Revision.auto_snapshots).not_to include(entry.draft(true))
         end
       end
 

--- a/spec/models/pageflow/revision_spec.rb
+++ b/spec/models/pageflow/revision_spec.rb
@@ -66,13 +66,13 @@ module Pageflow
       end
 
       it 'returns :user for snapshot of user type' do
-        revision = create(:revision, :frozen, :snapshot_type => 'user')
+        revision = create(:revision, :user_snapshot)
 
         expect(revision.created_with).to eq(:user)
       end
 
       it 'returns :auto for snapshot of auto type' do
-        revision = create(:revision, :frozen, :snapshot_type => 'auto')
+        revision = create(:revision, :auto_snapshot)
 
         expect(revision.created_with).to eq(:auto)
       end
@@ -333,7 +333,7 @@ module Pageflow
     end
 
     describe '.frozen' do
-      it 'does not invclude draft revisions' do
+      it 'does not include draft revisions' do
         revision = create(:revision)
 
         expect(Revision.frozen).not_to include(revision)
@@ -343,7 +343,104 @@ module Pageflow
         revision = create(:revision, :frozen)
 
         expect(Revision.frozen).to include(revision)
+      end
+    end
 
+    describe '.publications' do
+      it 'includes published revisions' do
+        revision = create(:revision, :published)
+
+        expect(Revision.publications).to include(revision)
+      end
+
+      it 'does not include draft revision' do
+        revision = create(:revision)
+
+        expect(Revision.publications).not_to include(revision)
+      end
+
+      it 'does not include snapshot revision' do
+        revision = create(:revision, :user_snapshot)
+
+        expect(Revision.publications).not_to include(revision)
+      end
+    end
+
+    describe '.publications_and_user_snapshots' do
+      it 'includes published revisions' do
+        revision = create(:revision, :published)
+
+        expect(Revision.publications_and_user_snapshots).to include(revision)
+      end
+
+      it 'does not include draft revision' do
+        revision = create(:revision)
+
+        expect(Revision.publications_and_user_snapshots).not_to include(revision)
+      end
+
+      it 'includes user snapshot revision' do
+        revision = create(:revision, :user_snapshot)
+
+        expect(Revision.publications_and_user_snapshots).to include(revision)
+      end
+
+      it 'does not include auto snapshot revision' do
+        revision = create(:revision, :auto_snapshot)
+
+        expect(Revision.publications_and_user_snapshots).not_to include(revision)
+      end
+    end
+
+    describe '.user_snapshots' do
+      it 'does not includes published revisions' do
+        revision = create(:revision, :published)
+
+        expect(Revision.user_snapshots).not_to include(revision)
+      end
+
+      it 'does not include draft revision' do
+        revision = create(:revision)
+
+        expect(Revision.user_snapshots).not_to include(revision)
+      end
+
+      it 'includes user snapshot revision' do
+        revision = create(:revision, :user_snapshot)
+
+        expect(Revision.user_snapshots).to include(revision)
+      end
+
+      it 'does not include auto snapshot revision' do
+        revision = create(:revision, :auto_snapshot)
+
+        expect(Revision.user_snapshots).not_to include(revision)
+      end
+    end
+
+    describe '.auto_snapshots' do
+      it 'does not includes published revisions' do
+        revision = create(:revision, :published)
+
+        expect(Revision.auto_snapshots).not_to include(revision)
+      end
+
+      it 'does not include draft revision' do
+        revision = create(:revision)
+
+        expect(Revision.auto_snapshots).not_to include(revision)
+      end
+
+      it 'does not include user snapshot revision' do
+        revision = create(:revision, :user_snapshot)
+
+        expect(Revision.auto_snapshots).not_to include(revision)
+      end
+
+      it 'includes auto snapshot revision' do
+        revision = create(:revision, :auto_snapshot)
+
+        expect(Revision.auto_snapshots).to include(revision)
       end
     end
 


### PR DESCRIPTION
Reset the snapshot type attribute when copying a snapshot revision to
make it the new draft.

Migrate database to reset snapshot type of drafts that were restored
from snapshot or publications that were copied from such drafts.