### PR TITLE
Fix order of public i18n fallback

### DIFF
--- a/app/helpers/pageflow/public_i18n_helper.rb
+++ b/app/helpers/pageflow/public_i18n_helper.rb
@@ -9,9 +9,9 @@ module Pageflow
     def public_i18n_translations(entry)
       {
         pageflow: {
-          public: I18n.t('pageflow.public', locale: entry.locale)
+          public: I18n.t('pageflow.public', locale: I18n.default_locale)
                       .dup
-                      .deep_merge(I18n.t('pageflow.public', locale: I18n.default_locale))
+                      .deep_merge(I18n.t('pageflow.public', locale: entry.locale))
         }
       }
     end

--- a/spec/helpers/pageflow/public_i18n_helper_spec.rb
+++ b/spec/helpers/pageflow/public_i18n_helper_spec.rb
@@ -41,8 +41,8 @@ module Pageflow
       end
 
       it 'falls back to default locale for missing keys' do
-        translation(:es, 'pageflow.public.some', 'text')
-        translation(I18n.default_locale, 'pageflow.public.some', 'text')
+        translation(:es, 'pageflow.public.some', 'es_text')
+        translation(I18n.default_locale, 'pageflow.public.some', 'default_text')
         translation(I18n.default_locale, 'pageflow.public.some_new', 'new')
 
         entry = PublishedEntry.new(create(:entry,
@@ -51,6 +51,7 @@ module Pageflow
 
         result = helper.public_i18n_translations(entry)
 
+        expect(result[:pageflow][:public][:some]).to eq('es_text')
         expect(result[:pageflow][:public][:some_new]).to eq('new')
       end
     end


### PR DESCRIPTION
Only use default locale if key is missing.