### PR TITLE
Introduce ApplicationRecord

### DIFF
--- a/app/models/pageflow/account.rb
+++ b/app/models/pageflow/account.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class Account < ActiveRecord::Base
+  class Account < ApplicationRecord
     include FeatureTarget
 
     has_many :entries, dependent: :restrict_with_exception

--- a/app/models/pageflow/application_record.rb
+++ b/app/models/pageflow/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/pageflow/application_record.rb
+++ b/app/models/pageflow/application_record.rb
@@ -1,3 +1,5 @@
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
+module Pageflow
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
 end

--- a/app/models/pageflow/audio_file.rb
+++ b/app/models/pageflow/audio_file.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class AudioFile < ActiveRecord::Base
+  class AudioFile < ApplicationRecord
     include HostedFile
     include EncodedFileStateMachine
 

--- a/app/models/pageflow/chapter.rb
+++ b/app/models/pageflow/chapter.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class Chapter < ActiveRecord::Base
+  class Chapter < ApplicationRecord
     include SerializedConfiguration
 
     belongs_to :storyline, touch: true

--- a/app/models/pageflow/edit_lock.rb
+++ b/app/models/pageflow/edit_lock.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class EditLock < ActiveRecord::Base
+  class EditLock < ApplicationRecord
     scope :active, (lambda do
       time = Time.now - EditLock.time_to_live
       where('pageflow_edit_locks.updated_at >= ?', time)

--- a/app/models/pageflow/entry.rb
+++ b/app/models/pageflow/entry.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class Entry < ActiveRecord::Base
+  class Entry < ApplicationRecord
     class PasswordMissingError < StandardError
     end
 

--- a/app/models/pageflow/file_usage.rb
+++ b/app/models/pageflow/file_usage.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class FileUsage < ActiveRecord::Base
+  class FileUsage < ApplicationRecord
     include SerializedConfiguration
 
     belongs_to :revision

--- a/app/models/pageflow/folder.rb
+++ b/app/models/pageflow/folder.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class Folder < ActiveRecord::Base
+  class Folder < ApplicationRecord
     belongs_to :account
     has_many :entries
 

--- a/app/models/pageflow/image_file.rb
+++ b/app/models/pageflow/image_file.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class ImageFile < ActiveRecord::Base
+  class ImageFile < ApplicationRecord
     include ImageFileStateMachine
     include UploadedFile
 

--- a/app/models/pageflow/membership.rb
+++ b/app/models/pageflow/membership.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class Membership < ActiveRecord::Base
+  class Membership < ApplicationRecord
     belongs_to :user
     belongs_to :entity, polymorphic: true
     belongs_to :entry,

--- a/app/models/pageflow/page.rb
+++ b/app/models/pageflow/page.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class Page < ActiveRecord::Base
+  class Page < ApplicationRecord
     include SerializedConfiguration
 
     belongs_to :chapter, :touch => true

--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class Revision < ActiveRecord::Base
+  class Revision < ApplicationRecord
     PAGE_ORDER = [
       'pageflow_storylines.position ASC',
       'pageflow_chapters.position ASC',

--- a/app/models/pageflow/storyline.rb
+++ b/app/models/pageflow/storyline.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class Storyline < ActiveRecord::Base
+  class Storyline < ApplicationRecord
     include SerializedConfiguration
     include RevisionComponent
 

--- a/app/models/pageflow/text_track_file.rb
+++ b/app/models/pageflow/text_track_file.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class TextTrackFile < ActiveRecord::Base
+  class TextTrackFile < ApplicationRecord
     include HostedFile
 
     processing_state_machine do

--- a/app/models/pageflow/theming.rb
+++ b/app/models/pageflow/theming.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class Theming < ActiveRecord::Base
+  class Theming < ApplicationRecord
     include ThemeReferencer
 
     belongs_to :account

--- a/app/models/pageflow/video_file.rb
+++ b/app/models/pageflow/video_file.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class VideoFile < ActiveRecord::Base
+  class VideoFile < ApplicationRecord
     include HostedFile
     include EncodedFileStateMachine
     include OutputSource

--- a/app/models/pageflow/widget.rb
+++ b/app/models/pageflow/widget.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  class Widget < ActiveRecord::Base
+  class Widget < ApplicationRecord
     include SerializedConfiguration
 
     belongs_to :subject, polymorphic: true, touch: true


### PR DESCRIPTION
All models inherit from it instead of `ActiveRecord::Base`.
This is the default in Rails too and it provides a standard approach to
put things applicable to all models.