### PR TITLE
Fix dummy app generation on Travis for Rubygems 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ before_install:
 before_script:
   - bin/npm install
   - bin/npm run build
-  - bin/rake pageflow:dummy
+
+  # We need to use "bundle exec" instead of binstubs until
+  # https://github.com/rubygems/rubygems/issues/2055 is fixed
+  - bundle exec rake pageflow:dummy
   - bin/rake app:assets:precompile
 
 script:


### PR DESCRIPTION
Calling `bundle exec` from a ruby script after Bundler has been set up
fails for vendored Bundler version that comes with Rubygems 2.7.

  https://github.com/rubygems/rubygems/issues/2055

`rake pageflow:dummy` invokes `bundle exec rails new`. Calling `rake`
via `bundle exec` can be used as a temporary workaround.