### PR TITLE
Work around breaking change in resque_mailer 2.4.3

### DIFF
--- a/app/mailers/pageflow/user_mailer.rb
+++ b/app/mailers/pageflow/user_mailer.rb
@@ -3,7 +3,17 @@ module Pageflow
     include Resque::Mailer
 
     def invitation(options)
-      options.symbolize_keys!
+      # Different versions of resque_mailer either pass:
+      #
+      # - Hash with string keys (<= 2.4.0)
+      # - Hash with symbol keys (2.4.1)
+      # - Hash with both string and symbol keys (2.4.2)
+      # - HashWithIndifferentAccess (2.4.3)
+      #
+      # Symbolize keys to support 2.4.1, but do not use bang version
+      # (i.e. `smbolize_keys!`) since that is not supported by
+      # HashWithIndifferentAccess.
+      options = options.symbolize_keys
 
       @user = User.find(options[:user_id])
       @password_token = options[:password_token]


### PR DESCRIPTION
Stating with [1] a `HashWithIndifferentAccess` is passed which does
not support the `symbolize_keys!` method which we used before to
ensure compatbility with `resque_mailer` 2.4.1.

[1] https://github.com/zapnap/resque_mailer/pull/102