### PR TITLE
Move theme name drop down into defaults sections

### DIFF
--- a/app/views/admin/accounts/_form.html.erb
+++ b/app/views/admin/accounts/_form.html.erb
@@ -12,7 +12,6 @@
 
   <%= f.semantic_fields_for :default_theming do |theming| %>
     <%= f.inputs do %>
-      <%= theming.input :theme_name, include_blank: false, collection: account_config.themes.names %>
       <%= theming.input :cname, hint: t('pageflow.admin.themings.cname_hint') %>
       <%= theming.input :additional_cnames, hint: t('pageflow.admin.themings.additional_cnames_hint') %>
       <%= theming.input :home_url, hint: t('pageflow.admin.themings.home_url_hint') %>
@@ -31,7 +30,6 @@
     <% end %>
 
     <%= f.inputs do %>
-      <%= theming.input :home_button_enabled_by_default %>
       <%= theming.input :imprint_link_label %>
       <%= theming.input :imprint_link_url %>
       <%= theming.input :copyright_link_label %>
@@ -43,7 +41,9 @@
     <% end %>
 
     <%= f.inputs do %>
-      <%= render('admin/accounts/widgets_inline_help') %>
+      <%= render('admin/accounts/theming_defaults_inline_help') %>
+      <%= theming.input :theme_name, include_blank: false, collection: account_config.themes.names %>
+      <%= theming.input :home_button_enabled_by_default %>
       <%= admin_widgets_fields(theming, account_config) %>
     <% end %>
   <% end %>

--- a/app/views/admin/accounts/_theming_defaults_inline_help.html.erb
+++ b/app/views/admin/accounts/_theming_defaults_inline_help.html.erb
@@ -1,0 +1,5 @@
+<li class="inline_help_item">
+  <p>
+    <%= t('pageflow.admin.accounts.theming_defaults_inline_help') %>
+  </p>
+</li>

--- a/app/views/admin/accounts/_widgets_inline_help.html.erb
+++ b/app/views/admin/accounts/_widgets_inline_help.html.erb
@@ -1,5 +1,0 @@
-<li class="inline_help_item">
-  <p>
-    <%= t('pageflow.admin.accounts.widgets_inline_help') %>
-  </p>
-</li>

--- a/config/locales/new/theming_defaults.de.yml
+++ b/config/locales/new/theming_defaults.de.yml
@@ -1,0 +1,6 @@
+de:
+  pageflow:
+    admin:
+      accounts:
+        theming_defaults_inline_help: "Die folgenden Einstellungen werden als Standard für neue Beiträge des Kontos verwendet. Änderungen wirken sich nicht auf existierende Beiträge aus."
+        widgets_inline_help: "DELETED"

--- a/config/locales/new/theming_defaults.en.yml
+++ b/config/locales/new/theming_defaults.en.yml
@@ -1,0 +1,6 @@
+en:
+  pageflow:
+    admin:
+      accounts:
+        theming_defaults_inline_help: "The following settings will be used as defaults for new entries in this account. Changes do not affect existing entries."
+        widgets_inline_help: "DELETED"


### PR DESCRIPTION
Themes can now be configured per entry. The theme name stored in
`Theming` only acts as a default.