### PR TITLE
Ensure page order in editor preview stays up to date

### DIFF
--- a/app/assets/javascripts/pageflow/editor/collections/pages_collection.js
+++ b/app/assets/javascripts/pageflow/editor/collections/pages_collection.js
@@ -35,6 +35,7 @@ pageflow.PagesCollection = Backbone.Collection.extend({
     if (!this._persisted) {
       this._persisted = new pageflow.SubsetCollection({
         parent: this,
+        sortOnParentSort: true,
 
         filter: function(page) {
           return !page.isNew();

--- a/app/assets/javascripts/pageflow/editor/collections/subset_collection.js
+++ b/app/assets/javascripts/pageflow/editor/collections/subset_collection.js
@@ -1,6 +1,8 @@
 pageflow.SubsetCollection = Backbone.Collection.extend({
   constructor: function(options) {
     var adding = false;
+    var sorting = false;
+    var parentSorting = false;
 
     options = options || {};
 
@@ -41,8 +43,26 @@ pageflow.SubsetCollection = Backbone.Collection.extend({
       });
     }
 
+    if (options.sortOnParentSort) {
+      this.listenTo(this.parent, 'sort', function() {
+        parentSorting = true;
+
+        if (!sorting) {
+          this.sort();
+        }
+
+        parentSorting = false;
+      });
+    }
+
     this.listenTo(this, 'sort', function() {
-      this.parent.sort();
+      sorting = true;
+
+      if (!parentSorting) {
+        this.parent.sort();
+      }
+
+      sorting = false;
     });
 
     Backbone.Collection.prototype.constructor

--- a/spec/javascripts/collections/subset_collection_spec.js
+++ b/spec/javascripts/collections/subset_collection_spec.js
@@ -1,0 +1,97 @@
+describe('SubsetCollection', function() {
+  var SubsetCollection = pageflow.SubsetCollection;
+  var ParentCollection = Backbone.Collection.extend({
+    comparator: function(item) {
+      return item.get('position');
+    }
+  });
+
+  it('propagates sort to parent', function() {
+    var parentCollection = new ParentCollection([
+      {position: 0, inSubset: true},
+      {position: 1, inSubset: true},
+      {position: 2, inSubset: false}
+    ]);
+    var subsetCollection = new SubsetCollection({
+      parent: parentCollection,
+
+      filter: function(item) {
+        return item.get('inSubset');
+      }
+    });
+
+    subsetCollection.at(1).set('position', 10);
+    subsetCollection.sort();
+
+    expect(parentCollection.pluck('position')).to.eql([0, 2, 10]);
+  });
+
+  describe('with sortOnParentSort option set to true', function() {
+    it('sorts when parent is sorted', function() {
+      var parentCollection = new ParentCollection([
+        {position: 0, inSubset: true},
+        {position: 1, inSubset: false},
+        {position: 2, inSubset: true}
+      ]);
+      var subsetCollection = new SubsetCollection({
+        parent: parentCollection,
+        sortOnParentSort: true,
+
+        filter: function(item) {
+          return item.get('inSubset');
+        }
+      });
+
+      parentCollection.at(0).set('position', 10);
+      parentCollection.sort();
+
+      expect(subsetCollection.pluck('position')).to.eql([2, 10]);
+    });
+
+    it('does not propagate sort back to parent if sort origininated on parent', function() {
+      var parentCollection = new ParentCollection([
+        {position: 0, inSubset: true},
+        {position: 1, inSubset: false},
+        {position: 2, inSubset: true}
+      ]);
+      new SubsetCollection({
+        parent: parentCollection,
+        sortOnParentSort: true,
+
+        filter: function(item) {
+          return item.get('inSubset');
+        }
+      });
+      var sortEventHandler = sinon.spy();
+
+      parentCollection.at(0).set('position', 10);
+      parentCollection.on('sort', sortEventHandler);
+      parentCollection.sort();
+
+      expect(sortEventHandler).to.have.been.calledOnce;
+    });
+
+    it('does not sort again in response to propagated parent sort', function() {
+      var parentCollection = new ParentCollection([
+        {position: 0, inSubset: true},
+        {position: 1, inSubset: true},
+        {position: 2, inSubset: false}
+      ]);
+      var subsetCollection = new SubsetCollection({
+        parent: parentCollection,
+        sortOnParentSort: true,
+
+        filter: function(item) {
+          return item.get('inSubset');
+        }
+      });
+      var sortEventHandler = sinon.spy();
+
+      subsetCollection.at(1).set('position', 10);
+      subsetCollection.on('sort', sortEventHandler);
+      subsetCollection.sort();
+
+      expect(sortEventHandler).to.have.been.calledOnce;
+    });
+  });
+});


### PR DESCRIPTION
fixes #890

The editor preview displays a subset collection of persisted
pages. Ensure subset collections sort when parent collection is
sorted.