### PR TITLE
Remove sensitive data from Active Admin downloads

### DIFF
--- a/admins/pageflow/accounts.rb
+++ b/admins/pageflow/accounts.rb
@@ -35,6 +35,12 @@ module Pageflow
       end
     end
 
+    csv do
+      column :name
+      column :entries_count
+      column :users_count
+    end
+
     filter :name
 
     searchable_select_options(text_attribute: :name,

--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -48,6 +48,14 @@ module Pageflow
       end
     end
 
+    csv do
+      column :slug
+      column :title
+      column :created_at
+      column :edited_at
+      column :published_at
+    end
+
     filter :title
     filter :account,
            as: :searchable_select,

--- a/admins/pageflow/user.rb
+++ b/admins/pageflow/user.rb
@@ -20,6 +20,16 @@ module Pageflow
       boolean_status_tag_column :suspended?
     end
 
+    csv do
+      column :id
+      column :first_name
+      column :last_name
+      column :email
+      column :last_sign_in_at
+      column :sign_in_count
+      column :suspended?
+    end
+
     filter :last_name
     filter :first_name
     filter :email

--- a/app/models/concerns/pageflow/serialization_blacklist.rb
+++ b/app/models/concerns/pageflow/serialization_blacklist.rb
@@ -1,0 +1,19 @@
+module Pageflow
+  # @api private
+  module SerializationBlacklist
+    def serializable_hash(options = nil)
+      options ||= {}
+
+      options[:except] = Array(options[:except])
+      options[:except].concat(blacklist_for_serialization)
+
+      super(options)
+    end
+
+    private
+
+    def blacklist_for_serialization
+      []
+    end
+  end
+end

--- a/app/models/pageflow/account.rb
+++ b/app/models/pageflow/account.rb
@@ -1,6 +1,7 @@
 module Pageflow
   class Account < ApplicationRecord
     include FeatureTarget
+    include SerializationBlacklist
 
     has_many :entries, dependent: :restrict_with_exception
     has_many :folders, dependent: :destroy
@@ -21,6 +22,10 @@ module Pageflow
       super.tap do |theming|
         theming.account = self
       end
+    end
+
+    def blacklist_for_serialization
+      [:features_configuration]
     end
   end
 end

--- a/app/models/pageflow/entry.rb
+++ b/app/models/pageflow/entry.rb
@@ -5,6 +5,7 @@ module Pageflow
 
     include FeatureTarget
     include EntryPublicationStates
+    include SerializationBlacklist
 
     extend FriendlyId
     friendly_id :slug_candidates, :use => [:finders, :slugged]
@@ -113,6 +114,10 @@ module Pageflow
 
     def self.ransackable_scopes(_)
       [:with_publication_state, :published]
+    end
+
+    def blacklist_for_serialization
+      [:password_digest, :features_configuration]
     end
 
     private

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -2,6 +2,26 @@ require 'spec_helper'
 
 module Admin
   describe AccountsController do
+    describe '#index' do
+      describe 'downloads' do
+        render_views
+
+        %w(csv json xml).each do |format|
+          describe "with #{format} format" do
+            it 'does not include sensitive data' do
+              user = create(:user, :admin)
+              create(:account, features_configuration: {some_feature: true})
+
+              sign_in(user)
+              get(:index, format: format)
+
+              expect(response.body).not_to include('some_feature')
+            end
+          end
+        end
+      end
+    end
+
     describe '#show' do
       render_views
 

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -53,6 +53,22 @@ describe Admin::EntriesController do
         expect(response.body).not_to have_text(new_button_text)
       end
     end
+
+    describe 'downloads' do
+      %w(csv json xml).each do |format|
+        describe "with #{format} format" do
+          it 'does not include sensitive data' do
+            user = create(:user, :admin)
+            create(:entry, password_digest: 'secret')
+
+            sign_in(user)
+            get(:index, format: format)
+
+            expect(response.body).not_to include('secret')
+          end
+        end
+      end
+    end
   end
 
   describe '#show' do

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -2,6 +2,26 @@ require 'spec_helper'
 
 module Pageflow
   describe ::Admin::UsersController do
+    describe '#index' do
+      describe 'downloads' do
+        render_views
+
+        %w(csv json xml).each do |format|
+          describe "with #{format} format" do
+            it 'does not include sensitive data' do
+              user = create(:user, :admin)
+
+              sign_in(user)
+              get(:index, format: format)
+
+              expect(response.body).not_to include('password')
+              expect(response.body).not_to include(user.encrypted_password)
+            end
+          end
+        end
+      end
+    end
+
     describe '#show' do
       render_views
 

--- a/spec/models/concerns/pageflow/serialization_blacklist_spec.rb
+++ b/spec/models/concerns/pageflow/serialization_blacklist_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+module Pageflow
+  describe SerializationBlacklist do
+    let(:model) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = 'pageflow_entries'
+
+        include SerializationBlacklist
+
+        def self.name
+          'Entry'
+        end
+
+        def blacklist_for_serialization
+          [:password_digest]
+        end
+      end
+    end
+
+    it 'includes non sensitive data' do
+      entry = model.new(title: 'some title')
+
+      expect(entry.to_json).to include('some title')
+    end
+
+    it 'supports excluding attributes' do
+      entry = model.new(title: 'some title')
+
+      expect(entry.to_json(except: :title)).not_to include('some title')
+    end
+
+    it 'does not include sensitive data in json' do
+      entry = model.new(password_digest: 'secret')
+
+      expect(entry.to_json).not_to include('secret')
+    end
+
+    it 'does not include sensitive data in xml' do
+      entry = model.new(password_digest: 'secret')
+
+      expect(entry.to_xml).not_to include('secret')
+    end
+
+    it 'excludes sensitive data even if except option is passed' do
+      entry = model.new(password_digest: 'secret')
+
+      expect(entry.to_json(except: :title)).not_to include('secret')
+    end
+  end
+end

--- a/spec/models/pageflow/account_spec.rb
+++ b/spec/models/pageflow/account_spec.rb
@@ -51,4 +51,12 @@ module Pageflow
       expect { account.destroy }.to change(Folder, :count).by(-1)
     end
   end
+
+  describe 'serialization' do
+    it 'does not include features_configuration' do
+      account = build(:account, features_configuration: {some_feature: true})
+
+      expect(account.to_json).not_to include('some_feature')
+    end
+  end
 end

--- a/spec/models/pageflow/entry_spec.rb
+++ b/spec/models/pageflow/entry_spec.rb
@@ -431,4 +431,18 @@ module Pageflow
       expect(entry.account_name).to eq('Some account')
     end
   end
+
+  describe 'serialization' do
+    it 'does not include password_digest' do
+      entry = build(:entry, password_digest: 'secret')
+
+      expect(entry.to_json).not_to include('secret')
+    end
+
+    it 'does not include features configuration' do
+      entry = build(:entry, features_configuration: {some_feature: true})
+
+      expect(entry.to_json).not_to include('some_feature')
+    end
+  end
 end


### PR DESCRIPTION
* Define CSV columns to work around unsafe defaults.

* Remove entry password_digest and feature_configuration attributes
  from JSON/XML serializations.