### PR TITLE
Update setting_up_s3_bucket_policies.md

### DIFF
--- a/doc/setting_up_s3_bucket_policies.md
+++ b/doc/setting_up_s3_bucket_policies.md
@@ -11,7 +11,6 @@ with the correct bucket names below.
 Grant read access to main bucket:
 
     {
-      "Version": "2017-06-20",
       "Id": "PageflowMainBucketPolicy",
       "Statement": [
         {


### PR DESCRIPTION
The `"Version": "2017-06-20",` is invalid according to the S3 bucket policy editor. The policy doesn't need it.