### PR TITLE
Update setting_up_s3_bucket_policies.md

### DIFF
--- a/doc/setting_up_s3_bucket_policies.md
+++ b/doc/setting_up_s3_bucket_policies.md
@@ -50,7 +50,6 @@ Grant read access to main bucket:
 Grant full access to output bucket:
 
     {
-      "Version": "2017-06-20",
       "Id": "PageflowOutputBucketPolicy",
       "Statement": [
         {


### PR DESCRIPTION
The `"Version": "2017-06-20",` is invalid according to the S3 bucket policy editor (error of `The policy must contain a valid version string`.) The policy doesn't need it.