### PR TITLE
[WIP] Permit custom params for file types that request this

### DIFF
--- a/app/controllers/pageflow/editor/files_controller.rb
+++ b/app/controllers/pageflow/editor/files_controller.rb
@@ -81,6 +81,7 @@ module Pageflow
         file_attachment_params
           .merge(file_configuration_params)
           .merge(file_parent_file_params)
+          .merge(file_custom_params)
       end
 
       def file_reuse_params
@@ -107,6 +108,10 @@ module Pageflow
 
       def file_parent_file_params
         file_params.permit(:parent_file_id, :parent_file_model_type)
+      end
+
+      def file_custom_params
+        file_params.permit(file_type.custom_attributes)
       end
 
       def file_params

--- a/app/views/pageflow/files/_file.json.jbuilder
+++ b/app/views/pageflow/files/_file.json.jbuilder
@@ -1,9 +1,11 @@
-json.call(file,
-          :id,
-          :basename,
-          :configuration,
-          :parent_file_id,
-          :parent_file_model_type)
+attributes = [:id,
+              :basename,
+              :configuration,
+              :parent_file_id,
+              :parent_file_model_type] +
+             file_type.custom_attributes
+
+json.call(file, *attributes)
 
 json.is_ready(file.ready?)
 

--- a/lib/pageflow/file_type.rb
+++ b/lib/pageflow/file_type.rb
@@ -29,6 +29,10 @@ module Pageflow
     # @return [#call]
     attr_reader :url_templates
 
+    # Attributes that are custom to this file type.
+    # @return {Array<Symbol>}
+    attr_reader :custom_attributes
+
     # Create file type to be returned in {PageType#file_types}.
     #
     # @example
@@ -53,6 +57,9 @@ module Pageflow
     # @option options [#call] :url_templates
     #   Optional. Callable returning a hash of url template strings
     #   indexed by their names.
+    # @option options [Array<Symbol>] :custom_attributes
+    #   Optional. Array of strings containing attribute names that are
+    #   custom to this file type
     def initialize(options)
       @model_string_or_reference = options.fetch(:model)
       @partial = options[:partial]
@@ -61,6 +68,7 @@ module Pageflow
       @nested_file_types = options.fetch(:nested_file_types, [])
       @top_level_type = options.fetch(:top_level_type, false)
       @url_templates = options.fetch(:url_templates, ->() { {} })
+      @custom_attributes = options.fetch(:custom_attributes, [])
     end
 
     # ActiveRecord model that represents the files of this type.

--- a/spec/pageflow/file_type_spec.rb
+++ b/spec/pageflow/file_type_spec.rb
@@ -71,5 +71,14 @@ module Pageflow
         expect(file_type.editor_partial).to eq('pageflow/editor/image_files/image_file')
       end
     end
+
+    describe '#custom_attributes' do
+      it 'returns passed custom_attributes' do
+        file_type = FileType.new(model: ImageFile,
+                                 custom_attributes: [:neural_network_analysis])
+
+        expect(file_type.custom_attributes).to eq([:neural_network_analysis])
+      end
+    end
   end
 end


### PR DESCRIPTION
Also, file types can now define custom attributes. Custom attributes
serve a different purpose than configuration attributes: Their values
do not change after a file is created. Thus, we can persist them
directly on the file as opposed to on file usages, since constant
attributes need no versioning.