### PR TITLE
Print only styles

### DIFF
--- a/app/assets/stylesheets/pageflow/page.scss
+++ b/app/assets/stylesheets/pageflow/page.scss
@@ -1,4 +1,4 @@
-.print_image, .print_only {
+.print_only {
   display: none;
 }
 

--- a/app/assets/stylesheets/pageflow/print_view.scss
+++ b/app/assets/stylesheets/pageflow/print_view.scss
@@ -3,6 +3,14 @@
   page-break-inside: avoid !important;
 }
 
+.print_image {
+  width: auto;
+  height: auto;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 1em;
+}
+
 .page_url {
   padding-left: 17px;
 }
@@ -57,14 +65,6 @@ body {
         top: 30px;
         z-index: 200;
       }
-    }
-
-    .print_image {
-      width: auto;
-      height: auto;
-      margin-left: auto;
-      margin-right: auto;
-      margin-bottom: 1em;
     }
 
     .page_header {

--- a/app/assets/stylesheets/pageflow/print_view.scss
+++ b/app/assets/stylesheets/pageflow/print_view.scss
@@ -1,3 +1,12 @@
+.print_only {
+  display: block;
+  page-break-inside: avoid !important;
+}
+
+.page_url {
+  padding-left: 17px;
+}
+
 body {
 
   #outer_wrapper {
@@ -13,13 +22,6 @@ body {
 
   .navigation, .navigation_mobile, .scroll_indicator {
     display: none !important;
-  }
-
-  .print_image, .print_only {
-    display: block;
-  }
-  .print_only.page_url {
-    padding-left: 17px;
   }
 
   sidebar {
@@ -57,14 +59,12 @@ body {
       }
     }
 
-    .print_image, .print_only {
-      display: block;
+    .print_image {
       width: auto;
       height: auto;
       margin-left: auto;
       margin-right: auto;
       margin-bottom: 1em;
-      page-break-inside: avoid !important;
     }
 
     .page_header {

--- a/app/helpers/pageflow/assets_helper.rb
+++ b/app/helpers/pageflow/assets_helper.rb
@@ -1,0 +1,15 @@
+module Pageflow
+  module AssetsHelper
+    def asset_exists?(path)
+      if Rails.configuration.assets.compile
+        Rails.application.precompiled_assets.include? path
+      else
+        Rails.application.assets_manifest.assets[path].present?
+      end
+    end
+
+    def print_logo_path(entry)
+      "pageflow/themes/#{entry.theme.directory_name}/logo_print.png"
+    end
+  end
+end

--- a/app/views/pageflow/entries/_entry.html.erb
+++ b/app/views/pageflow/entries/_entry.html.erb
@@ -8,7 +8,9 @@
   <h1 class="hidden"><%= entry.title %></h1>
 
   <section class="print_only">
-    <img src="<%= image_path("pageflow/themes/#{entry.theme.directory_name}/logo_print.png") %>" class="print_image" alt="<%= t('pageflow.public.logo') %>">
+    <%= image_tag print_logo_path(entry),
+      class: "print_image",
+      alt: t('pageflow.public.logo') if asset_exists?(print_logo_path(entry)) %>
     <span class="page_url"><%= request.original_url %></span>
   </section>
 

--- a/app/views/pageflow/entries/_entry.html.erb
+++ b/app/views/pageflow/entries/_entry.html.erb
@@ -7,8 +7,10 @@
 
   <h1 class="hidden"><%= entry.title %></h1>
 
-  <img src="<%= image_path("pageflow/themes/#{entry.theme.directory_name}/logo_print.png") %>" class="print_image" alt="<%= t('pageflow.public.logo') %>">
-  <span class="print_only page_url"><%= request.original_url %></span>
+  <section class="print_only">
+    <img src="<%= image_path("pageflow/themes/#{entry.theme.directory_name}/logo_print.png") %>" class="print_image" alt="<%= t('pageflow.public.logo') %>">
+    <span class="page_url"><%= request.original_url %></span>
+  </section>
 
   <%= content_tag :div, :id => 'content', :class => 'entry', :data => {:role => 'slideshow'} do %>
     <%= render entry.pages, entry: entry %>


### PR DESCRIPTION
Changed `.print_only` to have single responsibility of display property.
Moved the print-only style out of `body` parent, as the non-print doesn't have it either.
Detect presence of this logo and don't render a dom node if it isn't there.
Move hardcoded logo path into a helper, making it slightly less painful to override.