### PR TITLE
[WIP] include the Pageflow version in all the cache keys

### DIFF
--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -50,7 +50,6 @@ module Pageflow
     def entry_stylesheet_link_tag(entry)
       url = polymorphic_path(entry.stylesheet_model,
                              v: entry.stylesheet_cache_key,
-                             p: Pageflow::VERSION,
                              format: 'css')
 
       stylesheet_link_tag(url,

--- a/app/models/pageflow/application_record.rb
+++ b/app/models/pageflow/application_record.rb
@@ -7,9 +7,7 @@ module Pageflow
     # A Pageflow version change warrants expiry of all caches.
     # TODO on Rails 5.2 move this code into the `version`.
     def cache_key
-      pageflow_version = Pageflow::VERSION.gsub('.', '')
-
-      super.sub(/\d+/, pageflow_version)
+      super.sub(/\d+/, Pageflow::VERSION.delete('.'))
     end
   end
 end

--- a/app/models/pageflow/application_record.rb
+++ b/app/models/pageflow/application_record.rb
@@ -1,5 +1,15 @@
 module Pageflow
   class ApplicationRecord < ActiveRecord::Base
     self.abstract_class = true
+
+    # We turn "people/5-20071224150000" into "people/1220-20071224150000"
+    # Where 1220 is the Pageflow::VERSION with periods removed.
+    # A Pageflow version change warrants expiry of all caches.
+    # TODO on Rails 5.2 move this code into the `version`.
+    def cache_key
+      pageflow_version = Pageflow::VERSION.gsub('.', '')
+
+      super.sub(/\d+/, pageflow_version)
+    end
   end
 end

--- a/spec/models/pageflow/revision_spec.rb
+++ b/spec/models/pageflow/revision_spec.rb
@@ -577,9 +577,9 @@ module Pageflow
     describe '#cache_key' do
       it 'contains the Pageflow version with periods removed' do
         revision = create(:revision, :published)
-        pageflow_version = Pageflow::VERSION.gsub('.', '')
+        pageflow_version = Pageflow::VERSION.delete('.')
 
-        #should look like pageflow/revisions/1220dev-20121231230000000000000
+        # should look like pageflow/revisions/1220dev-20121231230000000000000
         expect(revision.cache_key).to include(pageflow_version)
       end
     end

--- a/spec/models/pageflow/revision_spec.rb
+++ b/spec/models/pageflow/revision_spec.rb
@@ -573,5 +573,15 @@ module Pageflow
         expect(theming.theme.name).to eq('named_theme')
       end
     end
+
+    describe '#cache_key' do
+      it 'contains the Pageflow version with periods removed' do
+        revision = create(:revision, :published)
+        pageflow_version = Pageflow::VERSION.gsub('.', '')
+
+        #should look like pageflow/revisions/1220dev-20121231230000000000000
+        expect(revision.cache_key).to include(pageflow_version)
+      end
+    end
   end
 end


### PR DESCRIPTION
It's pretty safe to say we want all caches purged after a version change.

When we do it like this, it's all taken care of.