### PR TITLE
remove html page head cache

### DIFF
--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -1,17 +1,15 @@
 <% @page_title = pretty_entry_title(@entry) %>
 
 <% content_for(:head) do %>
-  <%= cache [@entry, :head, @entry.share_target] do %>
-    <%= stylesheet_link_tag('pageflow/application', media: 'all', 'data-turbolinks-track' => true) %>
-    <%= entry_theme_stylesheet_link_tag(@entry) %>
-    <%= entry_stylesheet_link_tag(@entry) %>
+  <%= stylesheet_link_tag('pageflow/application', media: 'all', 'data-turbolinks-track' => true) %>
+  <%= entry_theme_stylesheet_link_tag(@entry) %>
+  <%= entry_stylesheet_link_tag(@entry) %>
 
-    <%= social_share_meta_tags_for(@entry.share_target) %>
-    <%= render_widget_head_fragments(@entry) %>
+  <%= social_share_meta_tags_for(@entry.share_target) %>
+  <%= render_widget_head_fragments(@entry) %>
 
-    <%= tag :link, :rel => 'icon', :href => image_path("pageflow/themes/#{@entry.theme.directory_name}/favicon.ico"), :type => 'image/ico' %>
-    <%= meta_tags_for_entry(@entry) %>
-  <% end %>
+  <%= tag :link, :rel => 'icon', :href => image_path("pageflow/themes/#{@entry.theme.directory_name}/favicon.ico"), :type => 'image/ico' %>
+  <%= meta_tags_for_entry(@entry) %>
 <% end %>
 
 <%= cache [@entry, :body, @widget_scope] do %>


### PR DESCRIPTION
I do not believe it to be correct that the entirety for a published entry's page HEAD should be cacged on the entry and it's share target. There is lots of stuff here that will change before this cache is busted.