### PR TITLE
[WIP] Initial spike for text embeds feature

### DIFF
--- a/app/assets/javascripts/pageflow/base.js
+++ b/app/assets/javascripts/pageflow/base.js
@@ -48,6 +48,8 @@
 //= require_tree ./widgets
 //= require ./react
 
+//= require ./test_embed
+
 pageflow = {
   log: function(text, options) {
     if (window.console && (pageflow.debugMode() || (options && options.force))) {

--- a/app/assets/javascripts/pageflow/components.js
+++ b/app/assets/javascripts/pageflow/components.js
@@ -1,5 +1,6 @@
 //= require_self
 //= require pageflow/react
+//= require ./test_embed
 
 var PAGEFLOW_EDITOR = false;
 

--- a/app/assets/javascripts/pageflow/test_embed.jsx
+++ b/app/assets/javascripts/pageflow/test_embed.jsx
@@ -1,0 +1,22 @@
+pageflow.react.registerTextEmbed('greeting', {
+  component: class Greeting extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {c: 0};
+
+      this.handleClick = () => {
+        this.setState({c: this.state.c + 1});
+      }
+    }
+
+    render() {
+      return (
+        <div style={{'pointerEvents': 'all'}}>
+          Hello {this.props.name || 'reader'} <br />
+          Counter: {this.state.c} <br />
+          <button onClick={this.handleClick}>Incr</button>
+        </div>
+      );
+    }
+  }
+});

--- a/doc/creating_text_embeds.md
+++ b/doc/creating_text_embeds.md
@@ -1,0 +1,27 @@
+# Creating Text Embeds
+
+Text embeds allow inserting rich, interactive components into the
+content text of pages. They are implemented using React components:
+
+     pageflow.react.registerTextEmbed('greeting', GreetingEmbed);
+
+     function Greeting(props) {
+       return (
+         <div>Hello {props.name || 'dear reader'}.</div>
+       );
+     }
+
+Users creating an entry need to use the following special syntax when
+editing the text of a page. To display the friendly greeting provided
+by the example component above, the following text would have to be
+used:
+
+     {greeting}
+
+It is also possible to pass additional parameters:
+
+     {greeting name="John"}
+
+Text embed components can hold state. Note that inside the editor
+state is reset whenever the page text is changed since this triggers
+re-creation embedded components.

--- a/node_package/src/__spec__/textEmbeds-spec.jsx
+++ b/node_package/src/__spec__/textEmbeds-spec.jsx
@@ -1,0 +1,102 @@
+import {TextEmbeds} from '../textEmbeds';
+
+import ReactDOMServer from 'react-dom/server';
+
+import {expect} from 'support';
+
+describe('TextEmbeds', () => {
+  describe('#renderInString', () => {
+    it('replaces placeholders with rendered result of component', () => {
+      function GreetingEmbed() {
+        return (<em>Hello</em>);
+      }
+
+      const textEmbeds = new TextEmbeds(ReactDOMServer);
+      textEmbeds.register('greeting', {component: GreetingEmbed});
+
+      const result = textEmbeds.renderInString('<h1>{greeting}</h1>');
+
+      expect(result).to.match(new RegExp('<h1>.*<em .*>Hello</em>.*</h1>'));
+    });
+
+    it('supports passing parameters to embed', () => {
+      function GreetingEmbed(props) {
+        return (<span>Hello {props.name}</span>);
+      }
+
+      const textEmbeds = new TextEmbeds(ReactDOMServer);
+      textEmbeds.register('greeting', {component: GreetingEmbed});
+
+      const result = textEmbeds.renderInString('<h1>{greeting name="John"}</h1>');
+
+      expect(result).to.match(new RegExp('Hello.*John'));
+    });
+
+    it('supports passing multiple parameters', () => {
+      function GreetingEmbed(props) {
+        return (<span>{props.word} {props.name}</span>);
+      }
+
+      const textEmbeds = new TextEmbeds(ReactDOMServer);
+      textEmbeds.register('greeting', {component: GreetingEmbed});
+
+      const result = textEmbeds.renderInString('<h1>{greeting word="Hello" name="John"}</h1>');
+
+      expect(result).to.match(new RegExp('Hello.*John'));
+    });
+  });
+
+  describe('#mountInElement', () => {
+    it('hydrates rendered embed component', () => {
+      class GreetingEmbed extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {mounted: false};
+        }
+
+        componentDidMount() {
+          this.setState({mounted: true});
+        }
+
+        render() {
+          return (<span>{this.state.mounted ? 'Mounted': 'Not yet'}</span>);
+        }
+      }
+
+      const textEmbeds = new TextEmbeds(ReactDOMServer);
+      textEmbeds.register('greeting', {component: GreetingEmbed});
+
+      const container = document.createElement('div');
+      container.innerHTML = textEmbeds.renderInString('<h1>{greeting}</h1>');
+      textEmbeds.mountInElement(container);
+
+      expect(container.innerHTML).to.include('Mounted');
+    });
+
+    it('supports passing params', () => {
+      class GreetingEmbed extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {mounted: false};
+        }
+
+        componentDidMount() {
+          this.setState({mounted: true});
+        }
+
+        render() {
+          return (<span>{this.props.name} is {this.state.mounted ? 'mounted': 'not mounted'}</span>);
+        }
+      }
+
+      const textEmbeds = new TextEmbeds(ReactDOMServer);
+      textEmbeds.register('greeting', {component: GreetingEmbed});
+
+      const container = document.createElement('div');
+      container.innerHTML = textEmbeds.renderInString('<h1>{greeting name="Component"}</h1>');
+      textEmbeds.mountInElement(container);
+
+      expect(container.innerHTML).to.match(/Component.*is.*mounted/);
+    });
+  });
+});

--- a/node_package/src/components/PageText.jsx
+++ b/node_package/src/components/PageText.jsx
@@ -1,5 +1,7 @@
 import {Component} from 'react';
 
+import textEmbeds from 'textEmbeds';
+
 /**
  * @desc Place inside
  * {@link pageflow.react.components.PageScroller|PageScroller} to
@@ -13,9 +15,32 @@ import {Component} from 'react';
  *   Required. The page object to read configuration properties from.
  */
 export default class PageText extends Component {
+  updateDOMRef(element) {
+    if (element) {
+      textEmbeds.mountInElement(element);
+    }
+    else {
+      textEmbeds.unmountInElement(this.element);
+    }
+
+    this.element = element;
+  }
+
+  shouldComponentUpdate(nextProps) {
+    return nextProps.page.text !== this.props.page.text;
+  }
+
+  componentWillUpdate() {
+    textEmbeds.unmountInElement(this.element);
+  }
+
+  componentDidUpdate() {
+    textEmbeds.mountInElement(this.element);
+  }
+
   render() {
     return (
-      <div className="contentText">
+      <div className="contentText" ref={this.updateDOMRef.bind(this)}>
         <p dangerouslySetInnerHTML={this.text()} />
         {this.props.children}
       </div>
@@ -23,6 +48,6 @@ export default class PageText extends Component {
   }
 
   text() {
-    return {__html: this.props.page.text};
+    return {__html: textEmbeds.renderInString(this.props.page.text || '')};
   }
 }

--- a/node_package/src/index.js
+++ b/node_package/src/index.js
@@ -21,6 +21,8 @@ import registerPageType from 'registerPageType';
 import registerPageTypeWithDefaultBackground from 'registerPageTypeWithDefaultBackground';
 import registerWidgetType from 'registerWidgetType';
 
+import textEmbeds from 'textEmbeds';
+
 import iconMapping from 'components/icons/mapping';
 import SvgIcon from 'components/icons/Container';
 
@@ -59,6 +61,7 @@ module.exports = {
   registerPageType,
   registerPageTypeWithDefaultBackground,
   registerWidgetType,
+  registerTextEmbed: (...args) => textEmbeds.register(...args),
 
   mediaReduxModule,
   mediaPageBackgroundReduxModule,

--- a/node_package/src/textEmbeds.js
+++ b/node_package/src/textEmbeds.js
@@ -1,0 +1,67 @@
+/*global ReactDOMServer*/
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export class TextEmbeds {
+  constructor(reactDOMServer) {
+    this.textEmbedComponents = {};
+    this.reactDOMServer = reactDOMServer;
+  }
+
+  register(name, {component}) {
+    this.textEmbedComponents[name] = component;
+  }
+
+  renderInString(html) {
+    return html.replace(/\{([a-z]+)(( [a-z]+="[^"]*")*)\}/gi, (match, embedName, params) => {
+      const props = parseParams(params);
+      const component = React.createElement(this.textEmbedComponents[embedName],
+                                            props);
+
+      const html = this.reactDOMServer.renderToString(component);
+
+      return `<div data-embed="${embedName}" ` +
+             `data-embed-props="${escapeHTML(JSON.stringify(props))}">${html}</div>`;
+    });
+  }
+
+  mountInElement(element) {
+    Array.from(element.querySelectorAll('[data-embed]')).forEach(embedWrapper => {
+      const embedName = embedWrapper.getAttribute('data-embed');
+      const props = JSON.parse(embedWrapper.getAttribute('data-embed-props'));
+
+      const component = React.createElement(this.textEmbedComponents[embedName],
+                                            props);
+
+      ReactDOM.render(component, embedWrapper);
+    });
+  }
+
+  unmountInElement(element) {
+    Array.from(element.querySelectorAll('[data-embed]')).forEach(embedWrapper => {
+      ReactDOM.unmountComponentAtNode(embedWrapper);
+    });
+  }
+}
+
+export default new TextEmbeds(typeof ReactDOMServer !== 'undefined' ?
+                              ReactDOMServer :
+                              {renderToString() { return ''; }});
+
+function parseParams(paramsString) {
+  const paramRegExp = /([a-z]+)="([^"]*)"/g;
+  const result = {};
+
+  var matches;
+
+  while ((matches = paramRegExp.exec(paramsString))) {
+    result[matches[1]] = matches[2];
+  }
+
+  return result;
+}
+
+function escapeHTML(text) {
+  return text.replace(/"/g, '&quot;');
+}


### PR DESCRIPTION
Allow embedding React components in page text via explicit,
parameterized placeholders.

See `doc/creating_text_embeds.md` inside this PR for a rough outline of the idea.

Includes support for:
* Passing parameters to embeds
* Server side rendering
* Client side rendering
* Editor preview

To make this more user friendly, mainly additions to the editor would be needed:
* Menu in text area input to list available embeds
* Popup form to ease discovery and editing of parameters