### PR TITLE
Remove RubyGems 2.7.0 dummy app generation fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,7 @@ before_install:
 before_script:
   - bin/npm install
   - bin/npm run build
-
-  # We need to use "bundle exec" instead of binstubs until
-  # https://github.com/rubygems/rubygems/issues/2055 is fixed
-  - bundle exec rake pageflow:dummy
+  - bin/rake pageflow:dummy
   - bin/rake app:assets:precompile
 
 script:


### PR DESCRIPTION
The fix introduced in #893 is no longer needed with RubyGems 2.7.3.