### PR TITLE
Update page type and widget type creation guides

### DIFF
--- a/doc/adding_editor_help_entries.md
+++ b/doc/adding_editor_help_entries.md
@@ -1,0 +1,37 @@
+# Adding Editor Help Entries
+
+To add an item to editor's help dialog, define a plugin and register
+the entry:
+
+```ruby
+# rainbow/lib/rainbow/plugin.rb
+module Rainbow
+  class Plugin < Pageflow::Plugin
+    def configure(config)
+      config.help_entries.register('pageflow.rainbow.help_entries.general', priority: 49)
+    end
+  end
+end
+```
+
+Entries with high priority come first in the list.  The name of the
+entry is interpreted as a translation key:
+
+```yml
+# config/locales/en.yml
+en:
+  pageflow:
+    rainbow:
+      help_entries:
+        general:
+          menu_item: "Name to display in the help index"
+          text: "Contents of the help entry as Markdown."
+```
+
+The help index supports nesting entries:
+
+```ruby
+config.help_entries.register('pageflow.rainbow.help_entries.parent', priority: 49)
+config.help_entries.register('pageflow.rainbow.help_entries.child',
+                             parent: 'pageflow.rainbow.help_entries.parent')
+```

--- a/doc/creating_a_pageflow_plugin_rails_engine.md
+++ b/doc/creating_a_pageflow_plugin_rails_engine.md
@@ -1,0 +1,62 @@
+# Creating a Pageflow Plugin Rails Engine
+
+## Generate a New Gem
+
+You'll have to distribute Pageflow plugins as a Rubygem; either if you
+mean to share it with others like you, or keep the code private.  The
+easiest way to go about this is to generate a gem, and then add the
+Rails Engine parts in later.
+
+``` bash
+$ bundle gem some_plugin # your gem name will be different!
+```
+
+Fill in the missing fields in the gemspec that's created for you.
+While you're in there, add `pageflow` as a dependency:
+
+```ruby
+# some_plugin.gemspec
+spec.add_dependency 'pageflow', '~> x.y'
+spec.add_dependency 'pageflow-public-i18n', '~> 1.0'
+```
+
+Where `x` is the current major and `y` is the minimal required minor
+version of Pageflow your plugin depends on. If your gem supports
+multiple major versions, specify an explicit range. For example, if
+the latest released Pageflow version is `13.3` and your plugin
+supports all versions equal to or above `12.1`:
+
+```ruby
+# some_plugin.gemspec
+spec.add_dependency 'pageflow', ['>= 12.1', '< 14]'
+```
+
+Always use a pessimistic approach, excluding the next major version to
+prevent your plugin from breaking applications. Explicitly check that
+breaking changes in new major version releases do not effect your
+plugin before extending the range.
+
+## Rails Engine
+
+Require the engine from your main file:
+
+``` ruby
+# lib/some_plugin.rb`
+require some_plugin/engine'
+```
+
+And add it:
+
+``` ruby
+# lib/some_engine/engine.rb
+require 'rails/engine'
+
+module SomePlugin
+  class Engine < ::Rails::Engine
+    isolate_namespace SomePlugin
+
+    # By default locales from sub directories are ignored
+    config.i18n.load_path += Dir[config.root.join('config', 'locales', '**', '*.yml').to_s]
+  end
+end
+```

--- a/doc/creating_a_pageflow_plugin_rails_engine.md
+++ b/doc/creating_a_pageflow_plugin_rails_engine.md
@@ -55,7 +55,7 @@ module SomePlugin
   class Engine < ::Rails::Engine
     isolate_namespace SomePlugin
 
-    # By default locales from sub directories are ignored
+    # By default, locales from subdirectories are ignored
     config.i18n.load_path += Dir[config.root.join('config', 'locales', '**', '*.yml').to_s]
   end
 end

--- a/doc/creating_page_types.md
+++ b/doc/creating_page_types.md
@@ -1,6 +1,6 @@
 # Creating Page Types
 
-Page types present one of the main axis along which Pageflow can be
+Page types present one of the main axes along which Pageflow can be
 extended.
 
 ## Ingredients of a Page Type
@@ -36,18 +36,18 @@ Pageflow files.
 
 The React based approach outlined in this guide requires Pageflow 12
 or newer. A lot of the existing page types still rely on the legacy
-approach of using ERB-templates and jQuery to render pages. This is no
+approach of using ERB templates and jQuery to render pages. This is no
 longer recommended for new page types. Examples of page types using
-the recommended React based approach include:
+the recommended React-based approach include:
 
 * [`pageflow-timeline-page`](https://github.com/codevise/pageflow-timeline-page)
 * [`pageflow-vr`](https://github.com/codevise/pageflow-vr)
 * All of the
   [built in page types](https://github.com/codevise/pageflow/tree/master/node_package/src/builtInPageTypes). Note
   that the Pageflow gem itself internally
-  [uses a Webpack based build process](contributing/directory_layout_overview.md). This
+  [uses a Webpack-based build process](contributing/directory_layout_overview.md). This
   causes the source code to have a different shape than in the
-  Sprockets based examples in this guide.
+  Sprockets-based examples in this guide.
 
 ## JavaScript Directory Layout
 
@@ -141,9 +141,9 @@ pages. See the [reference documentation](#) for a list of existing
 components that you can use to build your page. Of course, you are
 always free to create additional components on your own.
 
-Some of the used components depend on the page's configuration. For
+Some of the components used depend on the page's configuration. For
 example, `PageHeader` needs to know the actual texts to display that
-were entered in the editor. They, therefore, expect an object
+were entered in the editor. Therefore, they expect an object
 containing all page attributes in a prop called `page`.
 
 Pageflow stores all of the entry's data including page configurations

--- a/doc/creating_page_types.md
+++ b/doc/creating_page_types.md
@@ -1,118 +1,286 @@
-# @title Creating Page Types
+# Creating Page Types
 
 Page types present one of the main axis along which Pageflow can be
 extended.
 
-## The Basic Setup
+## Ingredients of a Page Type
 
-### The Page Type Object
+Page types are
+[packaged as Rails engines](creating_a_pageflow_plugin_rails_engine.md)
+that commonly contain the following elements:
 
-Page types are packaged as Rails engines that contain templates,
-stylesheets and javascript. Each page type is represented by a Ruby
-object whose class derived from `Pageflow::PageType`. The page type
-can be customized by overriding methods in this class. All exampled
-below are taken from the `pageflow-before-after` gem.
+* JavaScript for the front end that provides React components and other
+  functionality that make up the page type.
 
-    module Pageflow
-      module BeforeAfter
-        class PageType < Pageflow::PageType
-          def name
-            'before_after'
-          end
-        end
+* JavaScript defining the editor integration for the page type,
+  e.g. available inputs in the page type's edit form.
 
-        def self.page_type
-          BeforeAfter::PageType.new
-        end
-      end
-    end
+* Locale files containing translations for the editor UI and help
+  entries.
 
-The name method is used to construct conventional template paths and
-translation keys.
+* SCSS to be imported in Pageflow themes.
 
-To use a new page type in a Pageflow application, it has to be
-registered in the Pageflow initializer:
+* Pictogram images to represent the page type in navigation bars and
+  the editor UI.
 
-    # some_pageflow_app/config/initializers/pageflow.rb
-    Pageflow.configure do |config|
-      config.page_types.register(Pageflow::BeforeAfter.page_type)
+* A Ruby class defining a Pageflow plugin that can be registered in
+  a host application's Pageflow initializer.
 
-      # ...
-    end
+In the following sections, we build an imaginary plugin called
+`rainbow`. You can choose whatever name you like for your plugin
+instead. Only be sure to name your root folder something other than
+`pageflow` to prevent namespace conflicts with existing or future
+Pageflow files.
 
-It's best practice to provide a `page_type` class method as above to
-decouple page type registration from the class constants defined by
-your page type engine. That way, for example, the name of the
-`Pageflow::BeforeAfter::PageType` class can change without having to
-update all Pageflow applications using the page type.
+## Note Regarding Legacy Page Types
 
-### View Templates
+The React based approach outlined in this guide requires Pageflow 12
+or newer. A lot of the existing page types still rely on the legacy
+approach of using ERB-templates and jQuery to render pages. This is no
+longer recommended for new page types. Examples of page types using
+the recommended React based approach include:
 
-### Translation Keys
+* [`pageflow-timeline-page`](https://github.com/codevise/pageflow-timeline-page)
+* [`pageflow-vr`](https://github.com/codevise/pageflow-vr)
+* All of the
+  [built in page types](https://github.com/codevise/pageflow/tree/master/node_package/src/builtInPageTypes). Note
+  that the Pageflow gem itself internally
+  [uses a Webpack based build process](contributing/directory_layout_overview.md). This
+  causes the source code to have a different shape than in the
+  Sprockets based examples in this guide.
+
+## JavaScript Directory Layout
+
+Let's create the minimal required JavaScript code for our page
+type. The resulting directory structure inside our engine will look
+like this:
+
+```
+rainbow/
+  app/
+    assets/
+      javascripts/
+        rainbow.js
+        rainbow/
+          components.jsx
+          editor.js
+```
+
+The three files are used in different contexts:
+
+* The main `rainbow.js` JavaScript file is supposed to be required in
+  the `pageflow/application.js` file of host applications using our
+  plugin. It provides everything that is needed for the page type to
+  run inside the browser.
+
+* `rainbow/components.js` is meant to be required from the host
+  application's `components.js` file, which is loaded for server side
+  rendering.
+
+* Finally, the `editor.js` file contains all code required to
+  integrate the page type with the Pageflow editor and will be
+  required in the host application's `pageflow/editor.js` file.
+
+In the simplest case, `rainbow.js` only contains a `require` directive
+to include `rainbow/components.js`
+
+```js
+// rainbow/app/assets/javascripts/rainbow.js
+//= require ./rainbow/components
+```
+
+## Registering the Page Component
+
+To render the contents of our page, we define a React component and
+pass it to `pageflow.react.registerPageType`. Note that we can use ES6
+syntax inside of `jsx` files:
+
+```jsx
+// rainbow/app/assets/javascripts/rainbow/components.jsx
+(function() {
+  const {
+    PageWrapper,
+    PageBackground, PageBackgroundImage, PageShadow,
+    PageContent, PageHeader, PageText
+  } = pageflow.react.components;
+
+  function Page(props) {
+    return (
+      <PageWrapper>
+        <PageBackground>
+          <PageBackgroundImage page={props.page} />
+          <PageShadow page={props.page} />
+        </PageBackground>
+
+        <PageContent>
+          <PageHeader page={props.page} />
+          <PageText page={props.page} />
+        </PageContent>
+      </PageWrapper>
+    );
+  }
+
+  const {registerPageType, connectInPage, combine} = pageflow.react;
+  const {pageAttributes} = pageflow.react.selectors;
+
+  registerPageType('rainbow', {
+    component: connectInPage(
+      combine({
+        page: pageAttributes()
+      })
+    )(Page)
+  });
+}());
+```
+
+The basic structure consisting of `PageWrapper`, `PageBackground` and
+`PageContent` is required for the page to work correctly inside the
+entry. The specifics inside `PageBackground` and `PageContent` are
+just an example and depend on the content you wish to present on your
+pages. See the [reference documentation](#) for a list of existing
+components that you can use to build your page. Of course, you are
+always free to create additional components on your own.
+
+Some of the used components depend on the page's configuration. For
+example, `PageHeader` needs to know the actual texts to display that
+were entered in the editor. They, therefore, expect an object
+containing all page attributes in a prop called `page`.
+
+Pageflow stores all of the entry's data including page configurations
+in a Redux store. To access data from the store, we need to connect
+our component. Pageflow offers selectors and a special connect
+function called `connectInPage` which allows to retrieve data about a
+page from the store without having to know the id of the current page.
+See [the guide on using selectors](using_redux_selectors.md) for more
+information.
+
+Advanced topics:
+
+* [Displaying background images or videos](creating_page_types/displaying_background_images_or_videos.md)
+* [Managing page state and side effects with custom Redux modules](creating_page_types/custom_redux_modules.md)
+* [Using separate scroller and foreground](creating_page_types/using_separate_scroller_and_foreground.md)
+
+## Setting Up the Editor Integration
+
+Finally, we need to provide a Backbone view that will be displayed
+inside the editor to allow configuring pages using our page type.
+
+```js
+// rainbow/app/assets/javascripts/rainbow/editor.js
+pageflow.editor.pageTypes.register('rainbow', {
+  configurationEditorView: pageflow.ConfigurationEditorView.extend({
+    configure: function() {
+      this.tab('general', function() {
+        this.group('general');
+      });
+
+      this.tab('files', function() {
+        this.input('background_image_id', pageflow.FileInputView, {
+          collection: 'image_files',
+        });
+        this.input('thumbnail_image_id', pageflow.FileInputView, {
+          collection: 'image_files',
+          positioning: false
+        });
+      });
+
+      this.tab('options', function() {
+        this.group('options');
+      });
+    }
+  });
+});
+```
+
+We extend `pageflow.ConfigurationEditorView` which provides a DSL to
+define the structure of the form. See
+[the page type editor integration guide](creating_page_types/editor_integration.md)
+for details.
 
 The following translation keys have to be defined for use inside the
 editor:
 
-    pageflow:
-      before_after:
-        page_type_name: "Name to display in the editor."
-        page_type_description: "A short description to display in the editor."
-        page_type_category_name: "Category for editor page type select box"
-        help_entries:
-          page_type:
-            ...
-
-For a new input key, add e.g. `config/locales/new/some_input_key.de.yml` and `some_input_key.en.yml` with the following translation keys:
-
+    # config/locales/en.yml
     en:
       pageflow:
-        chart:
-          page_attributes:
-            some_input_key:
-              inline_help: This text is displayed in the inline help displayed via a small "?" next to the field 
-              label: This is the actual label text
+        rainbow:
+          page_type_name: "Name to display in the editor."
+          page_type_description: "A short description to display in the editor."
+          page_type_category_name: "Category for editor page type select box"
+          help_entries:
+            page_type:
+              menu_item: "Name to display in the help index"
+              text: "Contents of the help entry as Markdown."
 
+See the [help entries guide](adding_editor_help_entries.md) for
+more information on adding items to the editor help dialog.
 
-See the [help entries guide]() for more information on the adding a
-help pages.
+The icon used to represent the page type in the editor's page type
+select box is expected at
+`rainbow/app/assets/images/pageflow/rainbow_pictogram_small.png`.
 
-### Using View Helpers
+## Providing a Default Theme
 
-TODO
+We add a default theme file to be included in applications' theme
+files. We need to include a special mixin to ensure pictograms for our
+page type are displayed in navigation bars.
 
-### The Configuration Editor Schema
+```scss
+// rainbow/app/assets/stylesheets/rainbow/themes/default.scss
+@include pageflow-page-type-pictograms("rainbow")
 
-TODO
+/// Some description of the variable.
+$rainbow-size: 100px !default;
 
-### The Default Theme
+```
 
-Add a default theme fragment to be included in applications theme
-files:
+The default pictogram files are expected in
+`rainbow/app/assets/images/pageflow/rainbow/themes/default/pictograms/`
 
-    # pageflow/before_after/themes/default.scss
-    @include pageflow-page-type-pictograms("before_after")
+* `sprite.png` - Used in navigation bars.
+* `wide.png` - Used in the overview
 
-Now the default pictogram files are taken from
-`app/assets/images/pageflow/before_after/pictograms/`.
+See
+[the pictogram directory of one of the built in page types](https://github.com/codevise/pageflow/tree/master/app/assets/images/pageflow/themes/default/page_type_pictograms/background_image)
+for reference files.
 
-## Advanced Integrations
+It is best practice to provide SCSS variables to let themes apply
+customizations. Prefix each variable with the plugin name to prevent
+name clashes and provide sensible default values. Consider documenting
+variables using SassDoc.
 
-### Thumbnail Candidates
+### Creating the Plugin Class
 
-TODO
+Finally, we need to create a plugin class in our engine's Ruby code
+that users of our plugin can reference in their Pageflow initializer:
 
-### Defining View Helpers
+```ruby
+# rainbow/lib/rainbow/plugin.rb
+module Rainbow
+  class Plugin < Pageflow::Plugin
+    def configure(config)
+      config.page_types.register(Pageflow::React.create_page_type('rainbow'))
+    end
+  end
 
-TODO
+  def self.plugin
+    Plugin.new
+  end
+end
+```
 
-### File Types
+Now the plugin can be used by host applications:
 
-TODO
+```ruby
+# some_pageflow_app/config/initializers/pageflow.rb
+Pageflow.configure do |config|
+  config.plugin(Rainbow.plugin)
 
-### Revision Components
+  # ...
+end
+```
 
-TODO
+There are some advanced customizations:
 
-## Multiple Page Types in a Single Gem
-
-TODO
+* [Defining thumbnail candidates](#)
+* [Defining revision components](#)

--- a/doc/creating_page_types/custom_redux_modules.md
+++ b/doc/creating_page_types/custom_redux_modules.md
@@ -1,0 +1,124 @@
+# Custom Redux Modules
+
+In the context of Pageflow, Redux modules are a way of packaging up
+some Redux reducers and a Redux saga that together form a meaningful
+piece of functionality. They are simple JavaScript objects with two
+optional properties: `reducers` and `saga`. `reducers` is an object of
+the form that one passes to `combineReducers` and `saga` is a
+generator function.
+
+When registering page types, we can pass Redux modules to give the
+page additional functionality. In the
+[guide on displaying background images and videos](displaying_background_images_or_videos.md),
+we have already seen the `mediaPageBackgroundReduxModule` which
+contains reducers and sagas to handle background video playback. In
+this guide we learn how to define our own Redux modules to store page
+state data and handle side effects.
+
+## Managing Page State with Custom Reducers
+
+When defining a page type, we can use Pageflow's Redux store to keep
+track of custom state. As a simple example, let's assume we want to
+display a counter and an increment button on our page. In particular,
+we want each page to have its own counter when there are multiple
+pages using our page type. Pageflow makes it easy, to manage this
+state per page.
+
+As a first step, we define Redux actions and action creators:
+
+```js
+const INCREMENT = 'MY_PLUGIN_INCREMENT';
+
+function increment({pageId}) {
+  return {
+    type: INCREMENT,
+    meta: {
+      collectionName: 'pages',
+      itemId: pageId
+    }
+  };
+}
+```
+Note that we need to pass a special `meta` property inside the action,
+to keep track of which page the action is meant for.
+
+Now we define a reducer to handle the page state:
+
+```js
+function counterReducer(state = 0, action) {
+  switch (action.type) {
+  case INCREMENT:
+    return state + 1;
+  default:
+    return state;
+  }
+}
+```
+
+Then we define a page component to display the counter and increment
+button.
+
+```jsx
+  const {
+    PageWrapper,
+    MediaPageBackground, PageBackgroundImage, PageShadow,
+    PageContent, PageHeader, PageText
+  } = pageflow.react.components;
+
+  function Page(props) {
+    return (
+      <PageWrapper>
+        <MediaPageBackground page={props.page} />
+
+        <PageContent>
+          <PageHeader page={props.page} />
+          <PageText page={props.page} />
+
+          Counter: {props.counter}
+          <button onClick={props.onIncrement}>Increment</button>
+        </PageContent>
+      </PageWrapper>
+    );
+  }
+```
+
+When registering the page type, we can pass the custom page state
+reducer inside the `reducers` property of a Redux Module. In the
+`connectInPage` call, we use a `pageState` selector to retrieve the
+counter from the page's state in the store. Finally, via the second
+argument of the `connectInPage` call, we dispatch the `increment`
+action whenever the `onIncrement` callback is invoked:
+
+```jsx
+  const {registerPageType, connectInPage, combine} = pageflow.react;
+  const {pageAttributes, pageState} = pageflow.react.selectors;
+
+  registerPageType('counter_page', {
+    reduxModules: [
+      {
+        reducers: {
+          counter: counterReducer
+        }
+      }
+    },
+  
+    component: connectInPage(
+      combine({
+        page: pageAttributes(),
+        counter: pageState('counter')
+      }),
+      {
+        onIncrement: increment
+      }
+    )(Page)
+  });
+```
+
+All selectors and actions are automatically scoped to the
+corresponding page. Apart from having to pass the page id in the
+action's `meta` property, Pageflow makes it look as if each page was
+its own little Redux application.
+
+## Handling Side Effects with Custom Sagas
+
+TODO

--- a/doc/creating_page_types/custom_redux_modules.md
+++ b/doc/creating_page_types/custom_redux_modules.md
@@ -8,12 +8,12 @@ the form that one passes to `combineReducers` and `saga` is a
 generator function.
 
 When registering page types, we can pass Redux modules to give the
-page additional functionality. In the
+page additional functionality. For example, in the
 [guide on displaying background images and videos](displaying_background_images_or_videos.md),
-we have already seen the `mediaPageBackgroundReduxModule` which
-contains reducers and sagas to handle background video playback. In
-this guide we learn how to define our own Redux modules to store page
-state data and handle side effects.
+we are using the `mediaPageBackgroundReduxModule` which contains
+reducers and sagas to handle background video playback. In this guide
+we learn how to define our own Redux modules to store page state data
+and handle side effects.
 
 ## Managing Page State with Custom Reducers
 
@@ -21,8 +21,8 @@ When defining a page type, we can use Pageflow's Redux store to keep
 track of custom state. As a simple example, let's assume we want to
 display a counter and an increment button on our page. In particular,
 we want each page to have its own counter when there are multiple
-pages using our page type. Pageflow makes it easy, to manage this
-state per page.
+pages using our page type. Pageflow makes it easy to manage this state
+per page.
 
 As a first step, we define Redux actions and action creators:
 
@@ -39,7 +39,7 @@ function increment({pageId}) {
   };
 }
 ```
-Note that we need to pass a special `meta` property inside the action,
+Note that we need to pass a special `meta` property inside the action
 to keep track of which page the action is meant for.
 
 Now we define a reducer to handle the page state:
@@ -101,7 +101,7 @@ action whenever the `onIncrement` callback is invoked:
         }
       }
     },
-  
+
     component: connectInPage(
       combine({
         page: pageAttributes(),

--- a/doc/creating_page_types/displaying_background_images_or_videos.md
+++ b/doc/creating_page_types/displaying_background_images_or_videos.md
@@ -1,0 +1,79 @@
+# Displaying Background Images or Videos
+
+Most of the page types allow using either a background image or a
+background video as page background. Pageflow provides reusable React
+components and Redux modules which allow easy reuse of these features.
+
+When defining your page component, use the `MediaPageBackground`
+component and register the `mediaPageBackgroundReduxModule` for your
+page type.
+
+```jsx
+// rainbow/app/assets/javascripts/rainbow/components.jsx
+(function() {
+  const {
+    PageWrapper,
+    MediaPageBackground, PageBackgroundImage, PageShadow,
+    PageContent, PageHeader, PageText
+  } = pageflow.react.components;
+
+  function Page(props) {
+    return (
+      <PageWrapper>
+        // Takes care of rendering either an image or a video tag.
+        <MediaPageBackground page={props.page} />
+
+        <PageContent>
+          <PageHeader page={props.page} />
+          <PageText page={props.page} />
+        </PageContent>
+      </PageWrapper>
+    );
+  }
+
+  const {registerPageType, connectInPage, combine} = pageflow.react;
+  const {pageAttributes} = pageflow.react.selectors;
+
+  registerPageType('rainbow', {
+    component: connectInPage(
+      combine({
+        page: pageAttributes()
+      })
+    )(Page),
+
+    // Enable page state reducers and sagas to handle playback
+    reduxModules: [
+      pageflow.react.mediaPageBackgroundReduxModule
+    ]
+  });
+}());
+```
+
+In the configuration editor we can use a predefined group of inputs
+for the background.
+
+```ruby
+pageflow.editor.pageTypes.register('rainbow', {
+  configurationEditorView: pageflow.ConfigurationEditorView.extend({
+    configure: function() {
+      this.tab('general', function() {
+        this.group('general');
+      });
+
+      this.tab('files', function() {
+        // Renders background type select box and file input views
+        this.group('background');
+
+        this.input('thumbnail_image_id', pageflow.FileInputView, {
+          collection: 'image_files',
+          positioning: false
+        });
+      });
+
+      this.tab('options', function() {
+        this.group('options');
+      });
+    }
+  })
+});
+```

--- a/doc/creating_page_types/editor_integration.md
+++ b/doc/creating_page_types/editor_integration.md
@@ -1,0 +1,43 @@
+# Page Type Editor Integration
+
+## Defining the Page Configuration Editor
+
+Configuration editor views are used to build forms inside the Pageflow
+editor. Forms consist of one or more tabs that contain inputs. There
+are a couple of predefined groups of inputs that can reused
+
+```js
+// rainbow/app/assets/javascripts/rainbow/editor.js
+pageflow.editor.pageTypes.register('rainbow', {
+  configurationEditorView: pageflow.ConfigurationEditorView.extend({
+    configure: function() {
+      this.tab('general', function() {
+        this.group('general');
+      });
+
+      this.tab('files', function() {
+        this.group('background');
+        this.input('thumbnail_image_id', pageflow.FileInputView, {
+          collection: 'image_files',
+          positioning: false
+        });
+      });
+
+      this.tab('options', function() {
+        this.group('options');
+      });
+    }
+  });
+});
+```
+For a each input the following translation keys are used.
+
+```yml
+en:
+  pageflow:
+    rainbow:
+      page_attributes:
+        some_input_key:
+          label: This is the actual label text
+          inline_help: This text is displayed in the inline help displayed via a small "?" next to the field
+```

--- a/doc/creating_page_types/using_separate_scroller_and_foreground.md
+++ b/doc/creating_page_types/using_separate_scroller_and_foreground.md
@@ -1,0 +1,40 @@
+# Using Separate Scroller and Foreground
+
+In the default setup, the `PageContent` component wraps the content of
+the page into a scroller. For some page types it might be necessary to
+place elements in the page foreground, but outside of the
+scroller. The most common case involves the display of player
+controls. For this case, you can use separate `PageForeground` and
+`PageScroller` components instead of the `PageContent` component:
+
+```jsx
+const {
+  PageWrapper,
+  PageBackground, PageBackgroundImage, PageShadow,
+  PageForeground, PageScroller, PageHeader, PageText
+} = pageflow.react.components;
+
+function Page(props) {
+  return (
+    <PageWrapper>
+      <PageBackground>
+        <PageBackgroundImage page={props.page} />
+        <PageShadow page={props.page} />
+      </PageBackground>
+
+      <PageForeground>
+        <SomeCustomPlayerControls />
+
+        <PageScroller>
+          <PageHeader page={props.page} />
+          <PageText page={props.page} />
+        </PageScroller>
+      </PageForeground>
+    </PageWrapper>
+  );
+}
+```
+
+That way the player controls can be part of the page foreground, which
+is animated when the current page changes, but are still outside of
+the scroller.

--- a/doc/creating_widget_types.md
+++ b/doc/creating_widget_types.md
@@ -1,200 +1,34 @@
-# @title Creating Widget Types
+# Creating Widget Types
 
-Pageflow provides an interface to let extensions define new types of
+Pageflow provides an interface to let plugins define new types of
 widgets such as navigation bars, headers or analytics snippets to be
 used in entries.
 
 Once a widget type is registered, it can either be enabled on a
 theming or per-entry basis. Each widget type defines which roles its
 instances play in the context of an entry. By default Pagflow knows
-the roles `'navigation'`, `'head'` and `'overview'`. For each role only
-one widget will be rendered in the entry. Widgets associated with an
-entry override those with the same role defined on the theming level.
+the roles `'navigation'`, `'head'` and `'overview'`, but arbitrary new
+roles can be specified by a widget type. For each role only one widget
+will be rendered in the entry. Widgets associated with an entry
+override those with the same role defined on the theming level.
 
-## The Basic Setup
+* [Creating Widget Types with ERB Templates](creating_widget_types/with_erb_templates.md)
 
-A widget type is a ruby object that implements the following methods:
+  Mostly recommended for statically rendered widgets that do not
+  require a lot of JavaScript interactivity. A lot of the existing
+  widget types (navigation bars etc.) still rely on this approach.
 
-    module Pageflow
-      module ProgressNaviationBar
-        class WidgetType < Pageflow::WidgetType
-          def name
-            'pageflow_progress_navigation_bar'
-          end
+* [Creating Widget Types with React Components](creating_widget_types/with_react_components.md)
 
-          def roles
-            ['navigation']
-          end
+  The recommended approach for widgets that include client side
+  logic. Does not support server side rendering at the moment.
 
-          def render(template, entry)
-            # return html representation. For example:
-            template.render('pageflow/progress_navigation_bar/widget.html.erb'
-                            entry: entry)
-          end
-        end
 
-        def self.widget_type
-          WidgetType.new
-        end
-      end
-    end
 
-It is good practice to define a static factory method for the widget
-type as above to be used in the Pageflow initializer:
 
-    # config/initializers/pageflow.rb
-    Pageflow.configure do |config|
-      config.widget_types.register(Pageflow::ProgressNavigationBar.widget_type)
-    end
 
-At this point widgets of the new type can be associated with entries
-and will be rendered.
 
-## Enhancing Widgets with Javascript
 
-Most of the time the HTML of a widget has to be brought to live with
-the help of some javascript. Pageflow allows a javascript function to
-be registered which shall be executed to enhance the rendered HTML
-snippet of a widget.
 
-    # app/assets/javascript/pageflow/progress_navigation_bar.js
-    pageflow.widgetTypes.register('pageflow_progress_navigation_bar', {
-      enhance: function(element) {
-        // some jQuery magic
-      }
-    });
 
-The name supplied to the register function has to match the one
-returned by the `name` method of the widget type. Finally, to
-determine which DOM element shall be passed to the `enhance` function,
-mark up an element in the widget template with a `data-widget`
-attribute matching the widget name.
 
-    # app/views/pageflow/progress_navigation_bar/widget.html.erb
-    <div data-widget="pageflow_progress_navigation_bar">
-    </div>
-
-## Theme Integration
-
-It is recommended to provide a
-`pageflow/<widget_name>/themes/default.scss` file that can be imported
-in themes. Use SCSS variables with default values to give custom
-themes the opportunity to customize the default appearance. Prefix all
-variables with your plugin name and provide SassDoc inline
-documentation.
-
-    # app/assets/stylesheets/pageflow/my_widget/themes/default.scss
-    /// Describe the variable here
-    $my-widget-icon-color: #fff !default;
-
-### Specifying Widget Margins
-
-If the widget covers space along one of the window margins (i.e. a
-vertical navigation bar), it can be desirable to prevent page content
-from being hidden by the widget. By declaring widget margins, you can
-ensure that page elements like videos leave a safe area for your
-widget.
-
-For example, if your widget covers an `80px` wide area along the right
-page margin, you can specify this using the `pageflow-widget-margin`
-mixin:
-
-    # app/assets/stylesheets/pageflow/my_widget/themes/default.scss
-    @include pageflow-widget-margin("my_widget", "right") {
-      margin-right: 80px;
-    }
-
-Now the margin is applied to all page elements that align along the
-right side of window. If your widget changes its size responsively,
-you can use media queries inside the mixin block:
-
-    # app/assets/stylesheets/pageflow/my_widget/themes/default.scss
-    @include pageflow-widget-margin("my_widget", "right") {
-      @include desktop {
-        margin-right: 80px;
-      }
-    
-      @include pad_portrait {
-        margin-right: 30px;
-      }
-    }
-
-In addition to the widget margin positions `top`, `left`, `bottom` and
-`right`, there are also the positions `top_max`, `left_max`,
-`bottom_max` and `right_max`. These can be used to specify the maximal
-size of a widget that, for example, expands on hover. Page elements
-like player controls, can use this informationto prevent the expanded
-widget from overlapping.
-
-    @include pageflow-widget-margin("my_widget", "right") {
-      margin-right: 80px;
-    }
-
-    @include pageflow-widget-margin("my_widget", "right_max") {
-      margin-right: 200px;
-    }
-
-### Applying Widget Margin
-
-If you would like to control the position of your widget, according to
-widget margins defined by other present widgets, you can extend one of
-the `pageflow_widget_margin` placeholders:
-
-    # app/assets/stylesheets/pageflow/my_widget/themes/default.scss
-    .my_widget {
-      @extend pageflow_widget_margin_right !optional;
-    }
-
-This will cause the corresponding margin to be applied to your
-element, whenever one of the present widget specifies a widget
-margin. The `!optional` suffix is required, to prevent compilation
-errors if no widget defines a margin with the given position.
-
-## Advanced Options
-
-### Excluding Widgets from Being Rendered in certain Scopes
-
-Some widgets do not make sense in the context of the editor or the
-preview, i.e. analytics snippets. Simply override `enabled_in_editor?`
-or `enabled_in_preview?` inside your widget type and return `false`.
-
-    module Pageflow
-      module MyAnalytics
-        class WidgetType < Pageflow::WidgetType
-          # ...
-
-          def enabled_in_editor?
-            false
-          end
-        end
-      end
-    end
-
-### Enable Widgets by Default
-
-Sometimes it can be desirable to define a default widget type to be
-used for a speficic role. That way no manual configuration of entry or
-theming is required for a widget to be rendered in all entries:
-
-    config.widget_types.register(Pageflow::MyAnalytics::WidgetType.new, default: true)
-
-The default option registers the widget type as default choice for all
-roles supported by the widget type.
-
-### Adding Content to the Page Head
-
-Widget types can contribute to the head of a published entry to add
-script or meta tags.
-
-    module Pageflow
-      module ProgressNaviationBar
-        class WidgetType < Pageflow::WidgetType
-          # ...
-
-          def render_head_fragment(template, entry)
-            # return html representation. For example:
-            template.content_tag(:script, '', src: '//example.com/script.js')
-          end
-        end
-      end
-    end

--- a/doc/creating_widget_types.md
+++ b/doc/creating_widget_types.md
@@ -6,7 +6,7 @@ used in entries.
 
 Once a widget type is registered, it can either be enabled on a
 theming or per-entry basis. Each widget type defines which roles its
-instances play in the context of an entry. By default Pagflow knows
+instances play in the context of an entry. By default, Pageflow knows
 the roles `'navigation'`, `'head'` and `'overview'`, but arbitrary new
 roles can be specified by a widget type. For each role only one widget
 will be rendered in the entry. Widgets associated with an entry
@@ -22,13 +22,3 @@ override those with the same role defined on the theming level.
 
   The recommended approach for widgets that include client side
   logic. Does not support server side rendering at the moment.
-
-
-
-
-
-
-
-
-
-

--- a/doc/creating_widget_types/editor_integration.md
+++ b/doc/creating_widget_types/editor_integration.md
@@ -1,0 +1,39 @@
+# Widget Type Editor Integration
+
+## Configurable Widgets
+
+Widget type plugins can provide a Backbone view which can be used to
+configure a widget for an entry. Extending
+`pageflow.ConfigurationEditorView` and overriding the `configure`
+method, allows defining the structure of the edit form.
+
+```js
+// rainbow/app/assets/javascripts/rainbow/editor.js
+pageflow.editor.widgetTypes.register('rainbow_widget', {
+  configurationEditorView: pageflow.ConfigurationEditorView.extend({
+    configure: function() {
+      this.tab('general', function() {
+        this.input('name', pageflow.TextInputView);
+      });
+    }
+  })
+});
+```
+
+An edit button is displayed next to the widget type select box on the
+appearance tab inside the editor.
+
+## Optional Widget Type Roles
+
+By default, no select box is displayed for roles that are only used by
+one widget type. That way widget types that are
+[enabled by default](enabling_widgets_by_default.md) and have no
+alternative candidate do not clutter the list. To make the select
+visible, the corresponding role has to be marked as optional:
+
+```js
+// rainbow/app/assets/javascripts/rainbow/editor.js
+pageflow.editor.widgetTypes.registerRole('rainbow_widget', {
+  isOptional: true
+});
+```

--- a/doc/creating_widget_types/enabling_widgets_by_default.md
+++ b/doc/creating_widget_types/enabling_widgets_by_default.md
@@ -1,8 +1,8 @@
 # Enabling Widgets by Default
 
 Sometimes it can be desirable to define a default widget type to be
-used for a speficic role. That way no manual configuration of entry or
-theming is required for a widget to be rendered in all entries:
+used for a specific role. This way, no manual configuration of entry
+or theming is required for a widget to be rendered in all entries:
 
     config.widget_types.register(Rainbow::WidgetType.new, default: true)
 

--- a/doc/creating_widget_types/enabling_widgets_by_default.md
+++ b/doc/creating_widget_types/enabling_widgets_by_default.md
@@ -1,0 +1,10 @@
+# Enabling Widgets by Default
+
+Sometimes it can be desirable to define a default widget type to be
+used for a speficic role. That way no manual configuration of entry or
+theming is required for a widget to be rendered in all entries:
+
+    config.widget_types.register(Rainbow::WidgetType.new, default: true)
+
+The default option registers the widget type as default choice for all
+roles supported by the widget type.

--- a/doc/creating_widget_types/theme_integration.md
+++ b/doc/creating_widget_types/theme_integration.md
@@ -1,0 +1,12 @@
+# Theme Integration
+
+It is recommended to provide a `<widget_name>/themes/default.scss`
+file that can be imported in themes. Use SCSS variables with default
+values to give custom themes the opportunity to customize the default
+appearance. Prefix all variables with your plugin name and provide
+SassDoc inline documentation.
+
+    # app/assets/stylesheets/my_widget/themes/default.scss
+    /// Describe the variable here
+    $my-widget-icon-color: #fff !default;
+

--- a/doc/creating_widget_types/widget_margins.md
+++ b/doc/creating_widget_types/widget_margins.md
@@ -1,0 +1,64 @@
+# Wiget Margins
+
+## Specifying Widget Margins
+
+If the widget covers space along one of the window margins (i.e. a
+vertical navigation bar), it can be desirable to prevent page content
+from being hidden by the widget. By declaring widget margins, you can
+ensure that page elements like videos leave a safe area for your
+widget.
+
+For example, if your widget covers an `80px` wide area along the right
+page margin, you can specify this using the `pageflow-widget-margin`
+mixin:
+
+    # app/assets/stylesheets/my_widget/themes/default.scss
+    @include pageflow-widget-margin("my_widget", "right") {
+      margin-right: 80px;
+    }
+
+Now the margin is applied to all page elements that align along the
+right side of window. If your widget changes its size responsively,
+you can use media queries inside the mixin block:
+
+    # app/assets/stylesheets/my_widget/themes/default.scss
+    @include pageflow-widget-margin("my_widget", "right") {
+      @include desktop {
+        margin-right: 80px;
+      }
+
+      @include pad_portrait {
+        margin-right: 30px;
+      }
+    }
+
+In addition to the widget margin positions `top`, `left`, `bottom` and
+`right`, there are also the positions `top_max`, `left_max`,
+`bottom_max` and `right_max`. These can be used to specify the maximal
+size of a widget that, for example, expands on hover. Page elements
+like player controls, can use this informationto prevent the expanded
+widget from overlapping.
+
+    @include pageflow-widget-margin("my_widget", "right") {
+      margin-right: 80px;
+    }
+
+    @include pageflow-widget-margin("my_widget", "right_max") {
+      margin-right: 200px;
+    }
+
+## Applying Widget Margin
+
+If you would like to control the position of your widget, according to
+widget margins defined by other present widgets, you can extend one of
+the `pageflow_widget_margin` placeholders:
+
+    # app/assets/stylesheets/my_widget/themes/default.scss
+    .my_widget {
+      @extend pageflow_widget_margin_right !optional;
+    }
+
+This will cause the corresponding margin to be applied to your
+element, whenever one of the present widget specifies a widget
+margin. The `!optional` suffix is required, to prevent compilation
+errors if no widget defines a margin with the given position.

--- a/doc/creating_widget_types/with_erb_templates.md
+++ b/doc/creating_widget_types/with_erb_templates.md
@@ -1,0 +1,210 @@
+# Creating Widget Types with ERB Templates
+
+## Ingredients of a Widget Type
+
+ERB template based widget types are
+[packaged as Rails engines](../creating_a_pageflow_plugin_rails_engine.md)
+that commonly contain the following elements:
+
+* A Ruby class defining a Pageflow plugin that can be registered in
+  a host application's Pageflow initializer.
+
+* An ERB template to render the widget.
+
+* JavaScript for the front end that progressively enhances the HTML.
+
+* Locale files containing translations for the editor and admin UI.
+
+* SCSS to be imported in Pageflow themes.
+
+Optionally:
+
+* JavaScript defining the editor integration for the widget type,
+  e.g. available inputs to configure the widget.
+
+In the following sections, we build an imaginary plugin called
+`rainbow`. You can choose whatever name you like for your plugin
+instead. Only be sure to name your root folder something other than
+`pageflow` to prevent namespace conflicts with existing or future
+Pageflow files.
+
+## Creating the Plugin class
+
+We strart by creating a plugin class in our engine's Ruby code
+that users of our plugin can reference in their Pageflow initializer:
+
+```ruby
+module Rainbow
+  class Plugin < Pageflow::Plugin
+    def configure(config)
+      config.widget_types.register(Rainbow::WidgetType.new)
+    end
+  end
+
+  class WidgetType < Pageflow::WidgetType
+    def name
+      'rainbow_bar'
+    end
+
+    def roles
+      ['navigation']
+    end
+
+    def render(template, entry)
+      # return html representation. For example:
+      template.render('rainbow/widget.html.erb'
+                      entry: entry)
+    end
+  end
+
+  def self.plugin
+    Plugin.new
+  end
+end
+```
+
+It is good practice to define a static factory method for the plugin
+as above to be used in the Pageflow initializer:
+
+```ruby
+# config/initializers/pageflow.rb
+Pageflow.configure do |config|
+  config.plugin(Rainbow.plugin)
+end
+```
+
+The following translations will be used as display names for the
+widget type and its role in the admin and editor UI:
+
+```
+en:
+  pageflow:
+    widgets:
+      roles:
+        some_custom_role: "Display name of role"
+    rainbow_bar:
+      widget_type_name: "Rainbow Bar"
+```
+
+At this point widgets of the new type can be associated with entries
+and will be rendered.
+
+## Enhancing Widgets with Javascript
+
+Most of the time the HTML of a widget has to be brought to live with
+the help of some javascript. Pageflow allows a javascript function to
+be registered which shall be executed to enhance the rendered HTML
+snippet of a widget.
+
+```ruby
+// app/assets/javascript/rainbow.js
+pageflow.widgetTypes.register('rainbow_bar', {
+  enhance: function(element) {
+    // some jQuery magic
+  }
+});
+```
+
+The name supplied to the register function has to match the one
+returned by the `name` method of the widget type. Finally, to
+determine which DOM element shall be passed to the `enhance` function,
+mark up an element in the widget template with a `data-widget`
+attribute matching the widget name.
+
+```ruby
+# app/views/rainbow/widget.html.erb
+<div data-widget="rainbow_bar">
+</div>
+```
+
+IMPORTANT: Widgets should only ever perform DOM manipulations inside of the
+`element` passed to `enhance`. Making changes to DOM elements in other
+widgets or pages breaks encapsulation, does not play well with widget
+reloading inside the editor and might break React based functionality
+of other pages or widgets.
+
+## Adding Content to the Page Head
+
+Widget types can contribute to the head of a published entry to add
+script or meta tags.
+
+```ruby
+module Rainbow
+  class WidgetType < Pageflow::WidgetType
+    # ...
+
+    def render_head_fragment(template, entry)
+      # return html representation. For example:
+      template.content_tag(:script, '', src: '//example.com/script.js')
+    end
+  end
+end
+```
+
+## Excluding Widgets from Being Rendered in certain Scopes
+
+Some widgets do not make sense in the context of the editor or the
+preview, i.e. analytics snippets. Simply override `enabled_in_editor?`
+or `enabled_in_preview?` inside your widget type and return `false`.
+
+```ruby
+module Rainbow
+  class WidgetType < Pageflow::WidgetType
+    # ...
+
+    def enabled_in_editor?
+      false
+    end
+  end
+end
+```
+
+## Accessing Widget Configuration Data
+
+For widget types that can be
+[configured inside the editor](editor_integration.md), the configured
+attributes can be accessed by overriding the `_with_configuration`
+variants of the render methods.
+
+Assume the following configuration editor has been registered for the
+widget type:
+
+```js
+// rainbow/app/assets/javascripts/rainbow/editor.js
+pageflow.editor.widgetTypes.register('rainbow_bar', {
+  configurationEditorView: pageflow.ConfigurationEditorView.extend({
+    configure: function() {
+      this.tab('general', function() {
+        this.input('name', pageflow.TextInputView);
+      });
+    }
+  })
+});
+```
+
+Then the widget type can be defined as:
+
+```ruby
+module Rainbow
+  class WidgetType < Pageflow::WidgetType
+    # ...
+
+    def render_with_configuration(template, entry, configuration)
+      configuration['name'] # => Configured text
+      # ...
+    end
+
+    def render_head_fragment_with_configuration(template, entry, configuration)
+      configuration['name'] # => Configured text
+      # ...
+    end
+  end
+end
+```
+
+## Further Steps
+
+* [Theme Integration](theme_integration.md)
+* [Widget Margins](widget_margins.md)
+* [Enabling Widgets By Default](enabling_widgets_by_default.md)
+* [Editor Integration](editor_integration.md)

--- a/doc/creating_widget_types/with_erb_templates.md
+++ b/doc/creating_widget_types/with_erb_templates.md
@@ -30,7 +30,7 @@ Pageflow files.
 
 ## Creating the Plugin class
 
-We strart by creating a plugin class in our engine's Ruby code
+We start by creating a plugin class in our engine's Ruby code
 that users of our plugin can reference in their Pageflow initializer:
 
 ```ruby

--- a/doc/creating_widget_types/with_react_components.md
+++ b/doc/creating_widget_types/with_react_components.md
@@ -2,7 +2,7 @@
 
 ## Ingredients of a Widget Type
 
-React based widget type are
+React-based widget types are
 [packaged as Rails engines](../creating_a_pageflow_plugin_rails_engine.md)
 that commonly contain the following elements:
 
@@ -117,7 +117,7 @@ end
 The first argument passed to `create_widget_type` has to match the
 widget type name passed to `registerWidgetType` in the JavaScript
 code. The second parameter is the role of the widget type. For every
-entry there can only ever be one widget of each role.
+entry there can only be one widget of each role at a time.
 
 Now the plugin can be used by host applications:
 

--- a/doc/creating_widget_types/with_react_components.md
+++ b/doc/creating_widget_types/with_react_components.md
@@ -1,0 +1,204 @@
+# Creating Widget Types with React Components
+
+## Ingredients of a Widget Type
+
+React based widget type are
+[packaged as Rails engines](../creating_a_pageflow_plugin_rails_engine.md)
+that commonly contain the following elements:
+
+* JavaScript for the front end that provides React components and other
+  functionality that make up the widget.
+
+* Locale files containing translations for the editor and admin UI.
+
+* SCSS to be imported in Pageflow themes.
+
+* A Ruby class defining a Pageflow plugin that can be registered in
+  a host application's Pageflow initializer.
+
+Optionally:
+
+* JavaScript defining the editor integration for the widget type,
+  e.g. available inputs to configure the widget.
+
+In the following sections, we build an imaginary plugin called
+`rainbow`. You can choose whatever name you like for your plugin
+instead. Only be sure to name your root folder something other than
+`pageflow` to prevent namespace conflicts with existing or future
+Pageflow files.
+
+## JavaScript Directory Layout
+
+Let's create the minimal required JavaScript code for our page
+type. The resulting directory structure inside our engine will look
+like this:
+
+```
+rainbow/
+  app/
+    assets/
+      javascripts/
+        rainbow.js
+        rainbow/
+          components.jsx
+          editor.js
+```
+
+The three files are used in different contexts:
+
+* The main `rainbow.js` JavaScript file is supposed to be required in
+  the `pageflow/application.js` file of host applications using our
+  plugin. It provides everything that is needed for the page type to
+  run inside the browser.
+
+* `rainbow/components.js` is meant to be required from the host
+  application's `components.js` file, which is loaded for server side
+  rendering. At the moment, server side rendering of React based
+  widgets is not yet supported. It is recommended, though, to follow
+  the above convention for forward compatibility.
+
+* Finally, the optional `editor.js` file contains code required to
+  integrate the page type with the Pageflow editor and will be
+  required in the host application's `pageflow/editor.js` file.
+
+In the simplest case, `rainbow.js` only contains a `require` directive
+to include `rainbow/components.js`
+
+```js
+// rainbow/app/assets/javascripts/rainbow.js
+//= require ./rainbow/components
+```
+
+## Defining the Widget Component
+
+To render the contents of our widget, we define a React component and
+pass it to the `pageflow.react.createWidget` function. Note that we
+can use ES6 syntax inside of `jsx` files:
+
+```jsx
+// rainbow/app/assets/javascripts/rainbow/components.jsx
+(function() {
+  function RainbowWidget(props) {
+    return (
+      <div>
+        Render whatever you like here
+      </div>
+    );
+  }
+
+  const {registerWidgetType} = pageflow.react;
+
+  registerWidgetType('rainbow_widget', {
+    component: RainbowWidget
+  });
+}());
+```
+
+## Creating the Plugin Class
+
+Finally, we need to create a plugin class in our engine's Ruby code
+that users of our plugin can reference in their Pageflow initializer:
+
+```ruby
+# rainbow/lib/rainbow/some_plugin.rb
+module Rainbow
+  class Plugin < Pageflow::Plugin
+    def configure(config)
+      config.widget_types.register(Pageflow::React.create_widget_type('rainbow_widget', 'info_box'))
+    end
+  end
+
+  def self.plugin
+    Plugin.new
+  end
+end
+```
+
+The first argument passed to `create_widget_type` has to match the
+widget type name passed to `registerWidgetType` in the JavaScript
+code. The second parameter is the role of the widget type. For every
+entry there can only ever be one widget of each role.
+
+Now the plugin can be used by host applications:
+
+```ruby
+# some_pageflow_app/config/initializers/pageflow.rb
+Pageflow.configure do |config|
+  config.plugin(Rainbow.plugin)
+
+  # ...
+end
+```
+
+The following translations will be used as display names for the
+widget type and its role in the admin and editor UI:
+
+```
+en:
+  pageflow:
+    widgets:
+      roles:
+        some_custom_role: "Display name of role"
+    rainbow_bar:
+      widget_type_name: "Rainbow Bar"
+```
+
+At this point widgets of the new type can be associated with entries
+and will be rendered.
+
+## Accessing Widget Configuration Data
+
+For widget types that can be
+[configured inside the editor](editor_integration.md), the configured
+attributes can be accessed by connecting the component to the Redux
+store.
+
+Assume the following configuration editor has been registered for the
+widget type:
+
+```js
+// rainbow/app/assets/javascripts/rainbow/editor.js
+pageflow.editor.widgetTypes.register('rainbow_widget', {
+  configurationEditorView: pageflow.ConfigurationEditorView.extend({
+    configure: function() {
+      this.tab('general', function() {
+        this.input('name', pageflow.TextInputView);
+      });
+    }
+  })
+});
+```
+
+Then the `widgetAttributes` selector can be used to retrieve the
+corresponding data:
+
+```js
+(function() {
+  function RainbowWidget(props) {
+    return (
+      <div>
+        Hello {props.widget.name}!
+      </div>
+    );
+  }
+
+  const {registerWidgetType, connect, combine} = pageflow.react;
+  const {widgetAttributes} = pageflow.react.selectors;
+
+  registerWidgetType('rainbow_widget', {
+    component: connect(combine({
+      widget: widgetAttributes({role: 'info_box'})
+    }))(RainbowWidget);
+  });
+}());
+```
+
+See [the guide on using selectors](../using_redux_selectors.md) for more
+information.
+
+## Further Steps
+
+* [Theme Integration](theme_integration.md)
+* [Widget Margins](widget_margins.md)
+* [Enabling Widgets By Default](enabling_widgets_by_default.md)
+* [Editor Integration](editor_integration.md)

--- a/doc/index.md
+++ b/doc/index.md
@@ -10,6 +10,7 @@ extend Pageflow.
 ### Plugin Development
 
 * [Understanding Plugins and Features](./understanding_plugins_and_features.md)
+* [Creating a Rails Engine for a Pageflow Plugin](creating_a_pageflow_plugin_rails_engine.md)
 * [Creating File Types](./creating_file_types.md)
 * [Creating Page types](./creating_page_types.md)
 * [Creating Widget types](./creating_widget_types.md)

--- a/doc/using_redux_selectors.md
+++ b/doc/using_redux_selectors.md
@@ -102,8 +102,9 @@ connectInPage(combine({
 ```
 
 Whenever we now render an instance of `HugeTitle` inside a page, it
-will display the title of that page. This also works for the outer
-most component that is passed to `registerPageType`:
+will display the title of that page. This works up to and including
+the outermost component that is passed to `registerPageType` (`Page`,
+in the following example):
 
 ```jsx
 // rainbow/app/assets/javascripts/rainbow/components.jsx

--- a/doc/using_redux_selectors.md
+++ b/doc/using_redux_selectors.md
@@ -1,0 +1,144 @@
+# Using Redux Selectors
+
+This guide assumes a solid understanding of React and Redux.
+
+Pageflow stores all data about an entry and its current view state in
+a Redux store. To access this information from React components in
+pages and widgets, the components need to be connected to the
+store. To decouple components from the internal structure of the
+store, Pageflow provides selector functions which can be used to
+extract the desired piece of information from the store. So instead of
+accessing the store directly:
+
+```jsx
+const {connect} = pageflow.react;
+
+connect(
+  state => {
+    return {
+      someCustomSetting: state.settings.whatever.someCustomSetting
+    };
+  }
+)(MyWidget);
+```
+
+We use a function from `pageflow.react.selectors` to create a
+selector:
+
+```jsx
+const {connect} = pageflow.react;
+const settingSelector = pageflow.react.selectors.setting({
+  property: 'someCustomSetting'
+});
+
+connect(
+  state => {
+    return {
+      comeCustomSetting: settingSelector(state)
+    };
+  }
+)(MyWidget);
+```
+
+To make the above code more concise, Pageflow gives us a `combine`
+method:
+
+```jsx
+const {connect, combine} = pageflow.react
+const {setting} = pageflow.react.selectors;
+
+connect(combine({
+  comeCustomSetting: setting({
+    property: 'someCustomSetting'
+  })
+}))(MyWidget);
+```
+
+## Connecting Page Components
+
+The `pageAttribute` selector can be used to access configuration
+attributes of pages, for example its title or some other option that
+can be configured inside the editor. So if we want to create a
+component that renders the title of the page with id 5, we can write:
+
+```jsx
+const {connect, combine} = pageflow.react
+const {pageAttribute} = pageflow.react.selectors;
+
+function HugeTitle(props) {
+  return (
+    <h4>{props.title}</h4>
+  );
+}
+
+connect(combine({
+  title: pageAttribute('title', {
+    id: 5
+  })
+}))(HugeTitle);
+```
+
+For components that are rendered inside a page, though, we are mostly
+interested in accessing attributes of the containing page. But how can
+we know the id of the current page, so we can pass it to the selector?
+
+To make this easy, Pageflow provides a specialized connect function
+called `connectInPage`, which evaluates selectors in the context of
+the page the component is rendered in:
+
+```jsx
+const {connectInPage, combine} = pageflow.react
+const {pageAttribute} = pageflow.react.selectors;
+
+function HugeTitle(props) {
+  return (
+    <h4>{props.title}</h4>
+  );
+}
+
+connectInPage(combine({
+  title: pageAttribute('title')
+}))(HugeTitle);
+```
+
+Whenever we now render an instance of `HugeTitle` inside a page, it
+will display the title of that page. This also works for the outer
+most component that is passed to `registerPageType`:
+
+```jsx
+// rainbow/app/assets/javascripts/rainbow/components.jsx
+(function() {
+  const {
+    PageWrapper,
+    PageBackground, PageBackgroundImage, PageShadow,
+    PageContent, PageHeader, PageText
+  } = pageflow.react.components;
+
+  function Page(props) {
+    return (
+      <PageWrapper>
+        <PageBackground>
+          <PageBackgroundImage page={props.page} />
+          <PageShadow page={props.page} />
+        </PageBackground>
+
+        <PageContent>
+          <PageHeader page={props.page} />
+          <PageText page={props.page} />
+        </PageContent>
+      </PageWrapper>
+    );
+  }
+
+  const {registerPageType, connectInPage, combine} = pageflow.react;
+  const {pageAttributes} = pageflow.react.selectors;
+
+  registerPageType('rainbow', {
+    component: connectInPage(
+      combine({
+        page: pageAttributes()
+      })
+    )(Page)
+  });
+}());
+```


### PR DESCRIPTION
* Describe the recommended React based approach to create page types

* Describe both the ERB and React based approach to create widget
  types

* Give an overview of the Redux related concepts in Pageflow

* Incorporate steps to create Rails engine written by @tilsammans 

This still needs a bit of proof reading, but I guess it's an okay starting point.