### PR TITLE
Allow integrating with Krant app news

### DIFF
--- a/doc/adding_app_news.md
+++ b/doc/adding_app_news.md
@@ -1,0 +1,25 @@
+# Adding App News
+
+Pageflow supports being used together with the
+[Krant engine](https://github.com/codevise/krant) to display app news
+inside the admin interface.
+
+Pageflow plugins can use the `Pageflow.news_item` method to add news
+item without depending directly on Krant. News item are conventionally
+stored in a `config/initializers/news` directory containing one file
+per news item. This prevents merge conflicts when several pull
+requests each include news items. Namespace the news item with the
+name of your plugin:
+
+```ruby
+# rainbow/config/initializers/news/some_new_feature.rb
+Pageflow.news_item('rainbow.some_new_feature',
+                   title: {
+                     de: 'Ein neues Feature',
+                     en: 'Some New Feature'
+                   },
+                   text: {
+                     de: 'Eine mit *Markdown* formatierte Beschreibung.' ,
+                     en: 'A description formatted using *Markdown*.'
+                   })
+```

--- a/doc/index.md
+++ b/doc/index.md
@@ -14,6 +14,12 @@ extend Pageflow.
 * [Creating File Types](./creating_file_types.md)
 * [Creating Page types](./creating_page_types.md)
 * [Creating Widget types](./creating_widget_types.md)
+* [Adding app news](./adding_app_news.md)
+
+### Integrations
+
+* [Using Krant to display broadcast messages and news](./using_krant_to_display_broadcast_messages_and_news.md)
+* [Using the Nginx upload module](./using_the_nginx_upload_module.md)
 
 ### Contributing
 

--- a/doc/using_krant_to_display_broadcast_messages_and_news.md
+++ b/doc/using_krant_to_display_broadcast_messages_and_news.md
@@ -1,0 +1,32 @@
+# Displaying Broadcast Messages and News
+
+Pageflow supports being used together with the
+[Krant engine](https://github.com/codevise/krant) to display broadcast
+messages and app news inside the admin interface.
+
+Follow the installation steps in Krant's readme. Assuming the
+following news collection:
+
+```ruby
+# config/applications.rb
+module MyPageflowApp
+  def self.news
+    @news ||= Krant::News.about(MyPageflowApp)
+  end
+end
+```
+
+Then add the following line to your Pageflow initializer:
+
+```ruby
+# config/initializers/pageflow.rb
+Pageflow.configure do |config|
+  config.news = MyPageflowApp.news
+
+  # ...
+end
+```
+
+This will cause Pageflow and its plugins to add news items to your
+collection which will then be displayed on your admin news page using
+Krant's view components.

--- a/lib/pageflow.rb
+++ b/lib/pageflow.rb
@@ -1,8 +1,10 @@
-require "pageflow/engine"
-require "pageflow/global_config_api"
+require 'pageflow/engine'
+require 'pageflow/global_config_api'
+require 'pageflow/news_item_api'
 
 module Pageflow
   extend GlobalConfigApi
+  extend NewsItemApi
 
   def self.routes(router)
     router.instance_eval do

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -271,6 +271,12 @@ module Pageflow
     # @since 12.1
     attr_accessor :edit_lock_polling_interval
 
+    # News collection to add items to. Can be used to integrate
+    # Pageflow with Krant (see https://github.com/codevise/krant).
+    # @return [#item]
+    # @since edge
+    attr_accessor :news
+
     def initialize
       @paperclip_filesystem_default_options = {validate_media_type: false}
       @paperclip_s3_default_options = {validate_media_type: false}

--- a/lib/pageflow/news_item_api.rb
+++ b/lib/pageflow/news_item_api.rb
@@ -1,0 +1,18 @@
+module Pageflow
+  # Api for plugins to contribute news items for the news collection
+  # configured via `config.news`.  Included in the Pageflow module to
+  # provide `news_item` class method.
+  module NewsItemApi
+    # Add a item to the news collection configured via
+    # `Configuration#news`. Intended to be used with Krant (see
+    # https://github.com/codevise/krant). See Krant's readme for
+    # details on the supported parameters.
+    #
+    # @since edge
+    def news_item(name, options)
+      after_global_configure do |config|
+        config.news.item(name, options) if config.news
+      end
+    end
+  end
+end

--- a/spec/pageflow/news_item_api_spec.rb
+++ b/spec/pageflow/news_item_api_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Pageflow
+  describe NewsItemApi do
+    let(:pageflow_module) do
+      Module.new do
+        extend GlobalConfigApi
+        extend NewsItemApi
+      end
+    end
+
+    describe '.news_item' do
+      it 'calls config.news.item after global configuration' do
+        news = double('news', item: nil)
+
+        pageflow_module.news_item(:some_news_item, message: '')
+        pageflow_module.configure do |config|
+          config.news = news
+        end
+        pageflow_module.finalize!
+
+        expect(news).to have_received(:item).with(:some_news_item, message: '')
+      end
+
+      it 'does not fail if config.news is not set' do
+        pageflow_module.news_item(:some_news_item, {})
+
+        expect {
+          pageflow_module.finalize!
+        }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provide api for plugins to register news items to be added to the
configured news collection.

See https://github.com/codevise/krant