### PR TITLE
Fix "hide text" swipe gesture for React page types

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/hide_text_on_swipe.js
+++ b/app/assets/javascripts/pageflow/slideshow/hide_text_on_swipe.js
@@ -2,18 +2,23 @@
   $.widget('pageflow.hideTextOnSwipe', {
     _create: function() {
       this.element.swipeGesture({
-        orientation: 'x'
+        orientation: 'x',
+        eventTargetSelector: this.options.eventTargetSelector
       });
 
       this.element.on('swipegestureleft', function() {
         pageflow.hideText.activate();
       });
 
-      this.element.on('touchstart MSPointerDown pointerdown mousedown', function() {
-        if (pageflow.hideText.isActive()) {
-          pageflow.hideText.deactivate();
+      this.element.on(
+        'touchstart MSPointerDown pointerdown mousedown',
+        this.options.eventTargetSelector,
+        function() {
+          if (pageflow.hideText.isActive()) {
+            pageflow.hideText.deactivate();
+          }
         }
-      });
+      );
 
       this.element.on('scrollermove', function() {
         if (pageflow.hideText.isActive()) {

--- a/app/assets/javascripts/pageflow/slideshow/page_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/page_widget.js
@@ -185,7 +185,9 @@
     _setupHideTextOnSwipe: function() {
       if (pageflow.entryData.getThemingOption('hide_text_on_swipe') &&
           !this.pageType.noHideTextOnSwipe) {
-        this.content.hideTextOnSwipe();
+        this.element.hideTextOnSwipe({
+          eventTargetSelector: '.content > .scroller'
+        });
       }
     },
 

--- a/app/assets/javascripts/pageflow/slideshow/swipe_gesture.js
+++ b/app/assets/javascripts/pageflow/slideshow/swipe_gesture.js
@@ -11,7 +11,9 @@
         maxDuration: 500
       }, this.options);
 
-      this.element.on('touchstart MSPointerDown pointerdown', _.bind(function(event) {
+      var selector = this.options.eventTargetSelector;
+
+      this.element.on('touchstart MSPointerDown pointerdown', selector, _.bind(function(event) {
         if (isNonTouchPointer(event)) { return; }
         var point = event.originalEvent.touches ? event.originalEvent.touches[0] : event.originalEvent;
 
@@ -24,7 +26,7 @@
         startTime = new Date().getTime();
       }, this));
 
-      this.element.on('touchmove MSPointerMove pointermove', _.bind(function(event) {
+      this.element.on('touchmove MSPointerMove pointermove', selector, _.bind(function(event) {
         if (isNonTouchPointer(event)) { return; }
         var point = event.originalEvent.touches ? event.originalEvent.touches[0] : event.originalEvent;
 
@@ -32,7 +34,7 @@
         distY = point.pageY - startY;
       }, this));
 
-      this.element.on('touchend MSPointerUp pointerup', _.bind(function(event) {
+      this.element.on('touchend MSPointerUp pointerup', selector, _.bind(function(event) {
         if (isNonTouchPointer(event)) { return; }
         var elapsedTime = new Date().getTime() - startTime;
 


### PR DESCRIPTION
Reaching inside the page's DOM from the page widget to attach event
listeners does not work when React re-renders the page. Use event
delegation on the page's element which never changes during the page
life cycle.