### PR TITLE
Allow registering admin attributes table rows

### DIFF
--- a/app/views/admin/accounts/_account_details.html.arb
+++ b/app/views/admin/accounts/_account_details.html.arb
@@ -1,5 +1,7 @@
-attributes_table_for account do
-  row :name, :class => 'name'
-  row :default_file_rights, :class => 'default_file_rights'
+extensible_attributes_table_for(account,
+                                Pageflow.config_for(account)
+                                  .admin_attributes_table_rows.for(:account)) do
+  row :name, class: 'name'
+  row :default_file_rights, class: 'default_file_rights'
   row :created_at
 end

--- a/app/views/admin/accounts/_theming_details.html.arb
+++ b/app/views/admin/accounts/_theming_details.html.arb
@@ -1,6 +1,8 @@
-attributes_table_for account.default_theming do
-  row :cname, :class => 'cname'
-  row :theme, :class => 'theme' do
+extensible_attributes_table_for(account.default_theming,
+                                Pageflow.config_for(account)
+                                  .admin_attributes_table_rows.for(:theming)) do
+  row :cname, class: 'cname'
+  row :theme, class: 'theme' do
     account.default_theming.theme.name
   end
   row :default_author, class: 'default_author'

--- a/app/views/admin/entries/_attributes_table.html.arb
+++ b/app/views/admin/entries/_attributes_table.html.arb
@@ -1,4 +1,6 @@
-attributes_table_for entry do
+extensible_attributes_table_for(entry,
+                                Pageflow.config_for(entry)
+                                  .admin_attributes_table_rows.for(:entry)) do
   row :title, :class => 'title'
   if authorized?(:see_own_role_on, :entries)
     row :own_role do

--- a/app/views/components/pageflow/admin/extensible_attributes_table.rb
+++ b/app/views/components/pageflow/admin/extensible_attributes_table.rb
@@ -1,0 +1,88 @@
+module Pageflow
+  module Admin
+    class ExtensibleAttributesTable < ActiveAdmin::Views::AttributesTable
+      module BuilderMethods
+        def extensible_attributes_table_for(model, additional_rows, &block)
+          attributes_table_for(model) do
+            row_inserter = RowInserter.new(self, additional_rows)
+            RowDelegator.new(self, row_inserter).instance_eval(&block)
+            row_inserter.at_end_of_table
+          end
+        end
+      end
+
+      class RowInserter
+        def initialize(context, additional_rows)
+          @context = context
+          @additional_rows = additional_rows
+          @rendered_rows = []
+        end
+
+        def row(name, options = {}, &block)
+          render_additional_rows(rows_at(:before, name))
+          context.row(name, options, &block)
+          render_additional_rows(rows_at(:after, name))
+        end
+
+        def at_end_of_table
+          render_additional_rows(not_yet_rendered_rows)
+        end
+
+        private
+
+        attr_reader :context, :additional_rows, :rendered_rows
+
+        def render_additional_rows(additional_rows)
+          additional_rows.each do |additional_row|
+            block =
+              additional_row[:block] &&
+              ->(*args) { context.instance_exec(*args, &additional_row[:block]) }
+
+            context.row(additional_row[:name],
+                        additional_row[:options],
+                        &block)
+          end
+
+          rendered_rows.concat(additional_rows)
+        end
+
+        def rows_at(position, name)
+          additional_rows.select { |additional_row| additional_row[position] == name }
+        end
+
+        def not_yet_rendered_rows
+          additional_rows - rendered_rows
+        end
+      end
+
+      class RowDelegator
+        def initialize(context, row_handler)
+          @context = context
+          @row_handler = row_handler
+        end
+
+        def row(name, options = {}, &block)
+          @row_handler.row(name, options, &block)
+        end
+
+        private
+
+        def respond_to_missing?(name, _include_private = false)
+          @context.respond_to?(name)
+        end
+
+        # rubocop:disable Style/MethodMissing
+        # Normally we would delegate to super if context does not
+        # respond_to? method. But Arbre appears to report not to
+        # repond to helpers like authorized? even if it does.
+        #
+        # This is also the reason we can not use SimpleDelegator here
+        # and also delegate_missing in Rails 5 would not work.
+        def method_missing(method, *args, &block)
+          @context.public_send(method, *args, &block)
+        end
+        # rubocop:enable Style/MethodMissing
+      end
+    end
+  end
+end

--- a/config/initializers/admin_attributes_table_rows.rb
+++ b/config/initializers/admin_attributes_table_rows.rb
@@ -1,0 +1,3 @@
+Rails.application.config.to_prepare do
+  Arbre::Context.include(Pageflow::Admin::ExtensibleAttributesTable::BuilderMethods)
+end

--- a/doc/extending_admin_resources.md
+++ b/doc/extending_admin_resources.md
@@ -1,0 +1,159 @@
+# Extending Admin Resources
+
+Pageflow plugins can add additional elements to the admin pages of
+entries and accounts. This can be used to allow displaying and editing
+custom entry or account attributes.
+
+As an example, we create an imaginary plugin that stores ISSN
+information with entries and accounts.
+
+First, we create a migration to add the new fields:
+
+```ruby
+# rainbow/db/migrate/xxx_add_attributes_to_entries_and_accounts.rb
+class AddAttributesToEntriesAndAccounts < ActiveRecord::Migration
+  def change
+    add_column(:pageflow_accounts, :issn, :string)
+    add_column(:pageflow_entries, :issn, :string)
+  end
+end
+```
+
+## Adding Fields to Edit Forms
+
+To let the user edit the new fields, we add fields to the entry and
+account forms:
+
+```ruby
+# rainbow/lib/rainbow/plugin.rb
+module Rainbow
+  class Plugin < Pageflow::Plugin
+    def configure(config)
+      config.admin_form_inputs.register(:entry, :issn, as: :string)
+      config.admin_form_inputs.register(:account, :issn, as: :string)
+    end
+  end
+end
+```
+
+All options supported by Formtastic can be used in the third
+parameter. To use localized strings, the options need to be generated
+in the request cycle. We can pass a proc instead:
+
+```ruby
+def configure(config)
+  config.admin_form_inputs.register(:entry, :issn, -> {
+    { as: :string, hint: I18n.t('some.key') }
+  })
+end
+```
+
+Follow ActiveRecord's conventions to define translations for human
+attribute names.
+
+## Adding Rows to Attributes Tables
+
+We can display the value of the new attributes inside the resources'
+attributes tables:
+
+```ruby
+# rainbow/lib/rainbow/plugin.rb
+module Rainbow
+  class Plugin < Pageflow::Plugin
+    def configure(config)
+      config.admin_attributes_table_rows.register(:entry, :issn, after: :title)
+      config.admin_attributes_table_rows.register(:account, :issn, before: :updated_at)
+    end
+  end
+end
+```
+
+Apart from the `before` and `after` options, all options are passed to
+the `row` method of the `ActiveAdmin::Views::AttributesTable`:
+
+```ruby
+def configure(config)
+  config.admin_attributes_table_rows.register(:entry, :issn, class: 'custom_class')
+end
+```
+
+To use custom Arbre rendering logic, we can pass a block:
+
+```ruby
+def configure(config)
+  config.admin_attributes_table_rows.register(:entry, :issn, after: :title) do |entry|
+    span(entry.issn, class: 'some_custom_class')
+  end
+end
+```
+
+## Guarding Admin Extensions behind a Feature Flag
+
+Both form inputs and attributes table rows can be wrapped in a
+feature:
+
+```ruby
+# rainbow/lib/rainbow/plugin.rb
+module Rainbow
+  class Plugin < Pageflow::Plugin
+    def configure(config)
+      config.features.register('configurable_entry_teaser') do |feature_config|
+        feature_config.admin_form_inputs.register(:entry, :issn)
+        feature_config.admin_attributes_table_rows.register(:entry, :issn)
+      end
+    end
+  end
+end
+```
+
+## Adding Tabs
+
+By default the entry's admin page contains tabs listing members and
+revisions. The account's admin page provides tabs with user and entry
+lists. Plugins can add custom tabs which are implemented via Arbre
+components:
+
+```ruby
+# rainbow/lib/rainbow/plugin.rb
+module Rainbow
+  class Plugin < Pageflow::Plugin
+    def configure(config)
+      config.admin_resource_tabs.register(:entry,
+                                          name: :my_custom_tab,
+                                          component: SomeTab)
+    end
+  end
+
+  class SomeTab < Arbre::Component
+    def build(entry)
+      span 'Arbre code to render tab contents'
+    end
+  end
+end
+```
+
+To display a tab on the account's page it needs to be registered for
+themings:
+
+```ruby
+# rainbow/lib/rainbow/plugin.rb
+module Rainbow
+  class Plugin < Pageflow::Plugin
+    def configure(config)
+      config.admin_resource_tabs.register(:theming,
+                                          name: :my_custom_tab,
+                                          component: SomeTab)
+    end
+  end
+
+  class SomeTab < Arbre::Component
+    def build(theming)
+      # Use theming.account to access the account
+    end
+  end
+end
+```
+
+See documentation of `Pageflow::Admin::Tabs#register` for
+authorization options to display tabs only to users with certain
+roles and rights.

--- a/doc/index.md
+++ b/doc/index.md
@@ -14,6 +14,7 @@ extend Pageflow.
 * [Creating File Types](./creating_file_types.md)
 * [Creating Page types](./creating_page_types.md)
 * [Creating Widget types](./creating_widget_types.md)
+* [Extending Admin Resources](./extending_admin_resources.md)
 * [Adding app news](./adding_app_news.md)
 
 ### Integrations

--- a/lib/pageflow/admin/attributes_table_rows.rb
+++ b/lib/pageflow/admin/attributes_table_rows.rb
@@ -1,0 +1,47 @@
+module Pageflow
+  # A registry of additional rows to display in attribute tables on
+  # admin pages.
+  #
+  # @since edge
+  module Admin
+    class AttributesTableRows
+      # @api private
+      def initialize
+        @rows = {}
+      end
+
+      # Insert an additional row into an attribute table.
+      #
+      # @param resource_name [Symbol] Either :entry, :account or :theming.
+      #
+      # @param name [Symbol] Name of the attribute to display.
+      #
+      # @param options [Hash] Supports same options as
+      #   ActiveAdmin::Views::AttributesTable#row, in addition to:
+      #
+      # @option options [Symbol] :before Insert row before row with
+      #   given name. Append to table if not found.
+      #
+      # @option options [Symbol] :after Insert row after row with
+      #   given name. Append to table if not found.
+      #
+      # @yieldparam resource [ActiveRecord::Base] A block which is
+      #   evaluated in the context of the Arbre template to render the
+      #   contents of the cell.
+      def register(resource_name, name, options = {}, &block)
+        @rows[resource_name] ||= []
+        @rows[resource_name] << {
+          name: name,
+          block: block,
+          options: options.except(:before, :after),
+          **options.slice(:before, :after)
+        }
+      end
+
+      # @api private
+      def for(resource_name)
+        @rows.fetch(resource_name, [])
+      end
+    end
+  end
+end

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -192,13 +192,29 @@ module Pageflow
     #
     # @example
     #
-    #     config.admin_form_inputs.register(:entry) do |form|
-    #       form.input(:custom_field)
-    #     end
+    #     config.admin_form_inputs.register(:entry, :custom_field) do
     #
     # @since 0.9
     # @return [Admin::FormInputs]
     attr_reader :admin_form_inputs
+
+    # Insert additional rows into admin attributes tables.
+    #
+    # @example
+    #
+    #     config.admin_attributes_table_rows.register(:entry, :custom)
+    #     config.admin_attributes_table_rows.register(:entry, :my_attribute, after: :title)
+    #     config.admin_attributes_table_rows.register(:entry, :some_attribute, before: :updated_at)
+    #
+    # @example Custom content
+    #
+    #     config.admin_attributes_table_rows.register(:entry, :custom) do |entry|
+    #       span(entry.custom_attribute)
+    #     end
+    #
+    # @since edge
+    # @return [Admin::AttributesTableRows]
+    attr_reader :admin_attributes_table_rows
 
     # Array of locales which can be chosen as interface language by a
     # user. Defaults to `[:en, :de]`.
@@ -306,6 +322,7 @@ module Pageflow
 
       @admin_resource_tabs = Pageflow::Admin::Tabs.new
       @admin_form_inputs = Pageflow::Admin::FormInputs.new
+      @admin_attributes_table_rows = Pageflow::Admin::AttributesTableRows.new
 
       @available_locales = [:en, :de]
       @available_public_locales = PublicI18n.available_locales
@@ -375,6 +392,7 @@ module Pageflow
       delegate :widget_types, to: :config
       delegate :help_entries, to: :config
       delegate :admin_form_inputs, to: :config
+      delegate :admin_attributes_table_rows, to: :config
       delegate :themes, to: :config
     end
   end

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -136,6 +136,114 @@ module Admin
           end
         end
       end
+
+      describe 'additional attributes table rows' do
+        it 'renders additional rows registered for account' do
+          user = create(:user)
+          account = create(:account, with_manager: user)
+
+          pageflow_configure do |config|
+            config.admin_attributes_table_rows.register(:account, :custom) { 'custom attribute' }
+          end
+
+          sign_in(user)
+          get(:show, id: account.id)
+
+          expect(response.body).to have_text('custom attribute')
+        end
+
+        it 'renders additional rows registered for account in enabled feature' do
+          user = create(:user)
+          account = create(:account,
+                           with_manager: user,
+                           with_feature: :custom_account_attribute)
+
+          pageflow_configure do |config|
+            config.features.register('custom_account_attribute') do |feature_config|
+              feature_config.admin_attributes_table_rows.register(:account, :custom) do
+                'custom attribute'
+              end
+            end
+          end
+
+          sign_in(user)
+          get(:show, id: account.id)
+
+          expect(response.body).to have_text('custom attribute')
+        end
+
+        it 'does not render additional rows registered for account in disabled feature' do
+          user = create(:user)
+          account = create(:account,
+                           with_manager: user)
+
+          pageflow_configure do |config|
+            config.features.register('custom_account_attribute') do |feature_config|
+              feature_config.admin_attributes_table_rows.register(:account, :custom) do
+                'custom attribute'
+              end
+            end
+          end
+
+          sign_in(user)
+          get(:show, id: account.id)
+
+          expect(response.body).not_to have_text('custom attribute')
+        end
+
+        it 'renders additional rows registered for theming' do
+          user = create(:user)
+          account = create(:account, with_manager: user)
+
+          pageflow_configure do |config|
+            config.admin_attributes_table_rows.register(:theming, :custom) { 'custom attribute' }
+          end
+
+          sign_in(user)
+          get(:show, id: account.id)
+
+          expect(response.body).to have_text('custom attribute')
+        end
+
+        it 'renders additional rows registered for theming in enabled feature' do
+          user = create(:user)
+          account = create(:account,
+                           with_manager: user,
+                           with_feature: :custom_theming_attribute)
+
+          pageflow_configure do |config|
+            config.features.register('custom_theming_attribute') do |feature_config|
+              feature_config.admin_attributes_table_rows.register(:theming, :custom) do
+                'custom attribute'
+              end
+            end
+          end
+
+          sign_in(user)
+          get(:show, id: account.id)
+
+          expect(response.body).to have_text('custom attribute')
+        end
+
+        it 'does not render additional rows registered for account in disabled feature' do
+          user = create(:user)
+          account = create(:account,
+                           with_manager: user)
+
+          pageflow_configure do |config|
+            config.features.register('custom_theming_attribute') do |feature_config|
+              feature_config.admin_attributes_table_rows.register(:theming, :custom) do
+                'custom attribute'
+              end
+            end
+          end
+
+          sign_in(user)
+          get(:show, id: account.id)
+
+          expect(response.body).not_to have_text('custom attribute')
+        end
+      end
     end
 
     describe '#create' do

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -299,6 +299,61 @@ describe Admin::EntriesController do
         end
       end
     end
+
+    describe 'additional attributes table rows' do
+      it 'renders additional rows registered for entry' do
+        user = create(:user)
+        entry = create(:entry, with_previewer: user)
+
+        pageflow_configure do |config|
+          config.admin_attributes_table_rows.register(:entry, :custom) { 'custom attribute' }
+        end
+
+        sign_in(user)
+        get(:show, id: entry.id)
+
+        expect(response.body).to have_text('custom attribute')
+      end
+
+      it 'renders additional rows registered for entry in enabled feature' do
+        user = create(:user)
+        entry = create(:entry,
+                       with_previewer: user,
+                       with_feature: :custom_entry_attribute)
+
+        pageflow_configure do |config|
+          config.features.register('custom_entry_attribute') do |feature_config|
+            feature_config.admin_attributes_table_rows.register(:entry, :custom) do
+              'custom attribute'
+            end
+          end
+        end
+
+        sign_in(user)
+        get(:show, id: entry.id)
+
+        expect(response.body).to have_text('custom attribute')
+      end
+
+      it 'does not render additional rows registered for entry in disabled feature' do
+        user = create(:user)
+        entry = create(:entry,
+                       with_previewer: user)
+
+        pageflow_configure do |config|
+          config.features.register('custom_entry_attribute') do |feature_config|
+            feature_config.admin_attributes_table_rows.register(:entry, :custom) do
+              'custom attribute'
+            end
+          end
+        end
+
+        sign_in(user)
+        get(:show, id: entry.id)
+
+        expect(response.body).not_to have_text('custom attribute')
+      end
+    end
   end
 
   describe '#new' do

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -6,14 +6,14 @@ FactoryGirl.define do
       account.default_theming ||= build(:theming, account: account)
     end
 
-    # inline membership creation
-
     transient do
       with_member nil
       with_previewer nil
       with_editor nil
       with_publisher nil
       with_manager nil
+
+      with_feature nil
     end
 
     after(:create) do |account, evaluator|
@@ -37,6 +37,11 @@ FactoryGirl.define do
              entity: account,
              user: evaluator.with_manager,
              role: :manager) if evaluator.with_manager
+    end
+
+    after(:build) do |entry, evaluator|
+      entry.features_configuration =
+        entry.features_configuration.merge(evaluator.with_feature => true)
     end
   end
 end

--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -13,13 +13,13 @@ module Pageflow
         entry.theming ||= entry.account.default_theming
       end
 
-      # inline membership creation
-
       transient do
         with_previewer nil
         with_editor nil
         with_publisher nil
         with_manager nil
+
+        with_feature nil
       end
 
       after(:create) do |entry, evaluator|
@@ -39,6 +39,11 @@ module Pageflow
                entity: entry,
                user: evaluator.with_manager,
                role: :manager) if evaluator.with_manager
+      end
+
+      after(:build) do |entry, evaluator|
+        entry.features_configuration =
+          entry.features_configuration.merge(evaluator.with_feature => true)
       end
 
       trait :published do

--- a/spec/views/components/pageflow/admin/extensible_attributes_table_spec.rb
+++ b/spec/views/components/pageflow/admin/extensible_attributes_table_spec.rb
@@ -1,0 +1,222 @@
+require 'spec_helper'
+
+module Pageflow
+  module Admin
+    describe ExtensibleAttributesTable, type: :view_component do
+      before do
+        helper.extend(ActiveAdmin::ViewHelpers)
+      end
+
+      it 'renders same output as attributes_table by default' do
+        entry = build(:entry)
+
+        expected_html = render do
+          attributes_table_for(entry) do
+            row(:title)
+            row(:updated_at, class: 'some_class')
+          end
+        end
+
+        html = render do
+          extensible_attributes_table_for(entry, []) do
+            row(:title)
+            row(:updated_at, class: 'some_class')
+          end
+        end
+
+        expect(html).to eq(expected_html)
+      end
+
+      it 'allows appending rows' do
+        entry = build(:entry)
+        rows = AttributesTableRows.new
+
+        rows.register(:entry, :created_at)
+
+        html = render do
+          extensible_attributes_table_for(entry, rows.for(:entry)) do
+            row(:title)
+            row(:updated_at)
+          end
+        end
+
+        expected_html = render do
+          attributes_table_for(entry) do
+            row(:title)
+            row(:updated_at)
+            row(:created_at)
+          end
+        end
+
+        expect(html).to eq(expected_html)
+      end
+
+      it 'allows adding rows with blocks' do
+        entry = build_stubbed(:entry)
+        rows = AttributesTableRows.new
+
+        rows.register(:entry, :custom) { |e| e.created_at.utc }
+
+        html = render do
+          extensible_attributes_table_for(entry, rows.for(:entry)) do
+            row(:title)
+            row(:updated_at)
+          end
+        end
+
+        expected_html = render do
+          attributes_table_for(entry) do
+            row(:title)
+            row(:updated_at)
+            row(:custom) { |e| e.created_at.utc }
+          end
+        end
+
+        expect(html).to eq(expected_html)
+      end
+
+      it 'allows using arbre helpers in blocks' do
+        entry = build_stubbed(:entry)
+        rows = AttributesTableRows.new
+
+        rows.register(:entry, :custom) { span 'custom' }
+
+        html = render do
+          extensible_attributes_table_for(entry, rows.for(:entry)) do
+            row(:title)
+            row(:updated_at)
+          end
+        end
+
+        expected_html = render do
+          attributes_table_for(entry) do
+            row(:title)
+            row(:updated_at)
+            row(:custom) { span 'custom' }
+          end
+        end
+
+        expect(html).to eq(expected_html)
+      end
+
+      it 'allows adding rows with custom block' do
+        entry = build_stubbed(:entry)
+        rows = AttributesTableRows.new
+
+        rows.register(:entry, :custom, class: 'some_class')
+
+        html = render do
+          extensible_attributes_table_for(entry, rows.for(:entry)) do
+            row(:title)
+            row(:updated_at)
+          end
+        end
+
+        expected_html = render do
+          attributes_table_for(entry) do
+            row(:title)
+            row(:updated_at)
+            row(:custom, class: 'some_class')
+          end
+        end
+
+        expect(html).to eq(expected_html)
+      end
+
+      it 'allows inserting rows after certain existing rows' do
+        entry = build_stubbed(:entry)
+        rows = AttributesTableRows.new
+
+        rows.register(:entry, :custom, after: :title)
+
+        html = render do
+          extensible_attributes_table_for(entry, rows.for(:entry)) do
+            row(:title)
+            row(:updated_at)
+          end
+        end
+
+        expected_html = render do
+          attributes_table_for(entry) do
+            row(:title)
+            row(:custom)
+            row(:updated_at)
+          end
+        end
+
+        expect(html).to eq(expected_html)
+      end
+
+      it 'allows inserting rows before certain existing rows' do
+        entry = build_stubbed(:entry)
+        rows = AttributesTableRows.new
+
+        rows.register(:entry, :custom, before: :updated_at)
+
+        html = render do
+          extensible_attributes_table_for(entry, rows.for(:entry)) do
+            row(:title)
+            row(:updated_at)
+          end
+        end
+
+        expected_html = render do
+          attributes_table_for(entry) do
+            row(:title)
+            row(:custom)
+            row(:updated_at)
+          end
+        end
+
+        expect(html).to eq(expected_html)
+      end
+
+      it 'appends rows with unknown insert point at the end' do
+        entry = build_stubbed(:entry)
+        rows = AttributesTableRows.new
+
+        rows.register(:entry, :custom, before: :not_there)
+        rows.register(:entry, :other, after: :not_there)
+
+        html = render do
+          extensible_attributes_table_for(entry, rows.for(:entry)) do
+            row(:title)
+            row(:updated_at)
+          end
+        end
+
+        expected_html = render do
+          attributes_table_for(entry) do
+            row(:title)
+            row(:updated_at)
+            row(:custom)
+            row(:other)
+          end
+        end
+
+        expect(html).to eq(expected_html)
+      end
+
+      it 'using other arbe builder methods works inside block' do
+        entry = build_stubbed(:entry)
+        rows = AttributesTableRows.new
+
+        html = render do
+          extensible_attributes_table_for(entry, rows.for(:entry)) do
+            row(:title) { span('something') }
+            row(:updated_at)
+          end
+        end
+
+        expected_html = render do
+          attributes_table_for(entry) do
+            row(:title) { span('something') }
+            row(:updated_at)
+          end
+        end
+
+        expect(html).to eq(expected_html)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Let plugins add rows to the attributes tables that are displayed on
the admin resource pages.