### PR TITLE
Extend user management permissions in single account mode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,4 +35,4 @@ Style/LambdaCall:
 
 # Ignore long RSpec describe blocks
 Metrics/BlockLength:
-  ExcludedMethods: ['describe', 'context']
+  ExcludedMethods: ['describe', 'context', 'feature']

--- a/admins/pageflow/user.rb
+++ b/admins/pageflow/user.rb
@@ -149,7 +149,9 @@ module Pageflow
     end
 
     member_action :resend_invitation, method: :post do
-      InvitedUser.find(params[:id]).send_invitation!
+      user = InvitedUser.find(params[:id])
+      authorize!(:read, user)
+      user.send_invitation!
       redirect_to :back, notice: I18n.t('pageflow.admin.users.resent_invitation')
     end
 

--- a/admins/pageflow/user.rb
+++ b/admins/pageflow/user.rb
@@ -154,12 +154,16 @@ module Pageflow
     end
 
     member_action :suspend, method: :post do
-      User.find(params[:id]).suspend!
+      user = User.find(params[:id])
+      authorize!(:suspend, user)
+      user.suspend!
       redirect_to :back, notice: I18n.t('pageflow.admin.users.suspended')
     end
 
     member_action :unsuspend, method: :post do
-      User.find(params[:id]).unsuspend!
+      user = User.find(params[:id])
+      authorize!(:suspend, user)
+      user.unsuspend!
       redirect_to :back, notice: I18n.t('pageflow.admin.users.unsuspended')
     end
 

--- a/app/policies/pageflow/user_policy.rb
+++ b/app/policies/pageflow/user_policy.rb
@@ -66,11 +66,11 @@ module Pageflow
     end
 
     def suspend?
-      if Pageflow.config.allow_multiaccount_users
-        user.admin?
-      else
-        AccountRoleQuery.new(user, managed_user.accounts.first).has_at_least_role?(:manager)
-      end
+      deny_sign_in?
+    end
+
+    def destroy?
+      deny_sign_in?
     end
 
     def admin?
@@ -96,5 +96,13 @@ module Pageflow
     private
 
     attr_reader :managed_user
+
+    def deny_sign_in?
+      if Pageflow.config.allow_multiaccount_users
+        user.admin?
+      else
+        AccountRoleQuery.new(user, managed_user.accounts.first).has_at_least_role?(:manager)
+      end
+    end
   end
 end

--- a/app/policies/pageflow/user_policy.rb
+++ b/app/policies/pageflow/user_policy.rb
@@ -65,6 +65,14 @@ module Pageflow
       read?
     end
 
+    def suspend?
+      if Pageflow.config.allow_multiaccount_users
+        user.admin?
+      else
+        AccountRoleQuery.new(user, managed_user.accounts.first).has_at_least_role?(:manager)
+      end
+    end
+
     def admin?
       @user.admin?
     end
@@ -84,5 +92,9 @@ module Pageflow
     def delete_own_user?
       Pageflow.config.authorize_user_deletion.call(@managed_user) == true
     end
+
+    private
+
+    attr_reader :managed_user
   end
 end

--- a/lib/pageflow/ability_mixin.rb
+++ b/lib/pageflow/ability_mixin.rb
@@ -235,6 +235,10 @@ module Pageflow
             UserPolicy::Scope.new(user, ::User).resolve do |managed_user|
           UserPolicy.new(user, managed_user).redirect_to_user?
         end
+
+        can :suspend, ::User do |managed_user|
+          UserPolicy.new(user, managed_user).suspend?
+        end
       end
 
       can :delete_own_user, ::User do |user_to_delete|

--- a/lib/pageflow/ability_mixin.rb
+++ b/lib/pageflow/ability_mixin.rb
@@ -239,6 +239,10 @@ module Pageflow
         can :suspend, ::User do |managed_user|
           UserPolicy.new(user, managed_user).suspend?
         end
+
+        can :destroy, ::User do |managed_user|
+          UserPolicy.new(user, managed_user).destroy?
+        end
       end
 
       can :delete_own_user, ::User do |user_to_delete|

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -478,6 +478,30 @@ module Pageflow
       end
     end
 
+    describe '#resend_invitation' do
+      it 'allows account manager to resend invitation' do
+        account = create(:account)
+        user = create(:user, :member, on: account)
+
+        sign_in(create(:user, :manager, on: account))
+        request.env['HTTP_REFERER'] = admin_users_path
+        post :resend_invitation, id: user
+
+        expect(ActionMailer::Base.deliveries).not_to be_empty
+      end
+
+      it 'does not allow account publisher to resend invitiation' do
+        account = create(:account)
+        user = create(:user, :member, on: account)
+
+        sign_in(create(:user, :publisher, on: account))
+        request.env['HTTP_REFERER'] = admin_users_path
+        post :resend_invitation, id: user
+
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+    end
+
     describe '#suspend' do
       it 'allows admin to suspend user' do
         account = create(:account)

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -590,6 +590,62 @@ module Pageflow
       end
     end
 
+    describe '#destroy' do
+      it 'allows admin to destroy user' do
+        account = create(:account)
+        user = create(:user, :member, on: account)
+
+        sign_in(create(:user, :admin))
+
+        expect {
+          delete :destroy, id: user
+        }.to(change { User.count })
+      end
+
+      it 'does not allow account manager to destroy user' do
+        account = create(:account)
+        user = create(:user, :member, on: account)
+
+        sign_in(create(:user, :manager, on: account))
+
+        expect {
+          delete :destroy, id: user
+        }.not_to(change { User.count })
+      end
+
+      context 'when config.allow_multiaccount_users is false' do
+        it 'allows account manager to destroy user' do
+          pageflow_configure do |config|
+            config.allow_multiaccount_users = false
+          end
+
+          account = create(:account)
+          user = create(:user, :member, on: account)
+
+          sign_in(create(:user, :manager, on: account))
+
+          expect {
+            delete :destroy, id: user
+          }.to(change { User.count })
+        end
+
+        it 'does not allow account publisher to destroy user' do
+          pageflow_configure do |config|
+            config.allow_multiaccount_users = false
+          end
+
+          account = create(:account)
+          user = create(:user, :member, on: account)
+
+          sign_in(create(:user, :publisher, on: account))
+
+          expect {
+            delete :destroy, id: user
+          }.not_to(change { User.count })
+        end
+      end
+    end
+
     describe '#me' do
       render_views
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -478,6 +478,118 @@ module Pageflow
       end
     end
 
+    describe '#suspend' do
+      it 'allows admin to suspend user' do
+        account = create(:account)
+        user = create(:user, :member, on: account)
+
+        sign_in(create(:user, :admin))
+        request.env['HTTP_REFERER'] = admin_users_path
+        post :suspend, id: user
+
+        expect(user.reload).to be_suspended
+      end
+
+      it 'does not allow account manager to suspend user' do
+        account = create(:account)
+        user = create(:user, :member, on: account)
+
+        sign_in(create(:user, :manager, on: account))
+        request.env['HTTP_REFERER'] = admin_users_path
+        post :suspend, id: user
+
+        expect(user.reload).not_to be_suspended
+      end
+
+      context 'when config.allow_multiaccount_users is false' do
+        it 'allows account manager to suspend user' do
+          pageflow_configure do |config|
+            config.allow_multiaccount_users = false
+          end
+
+          account = create(:account)
+          user = create(:user, :member, on: account)
+
+          sign_in(create(:user, :manager, on: account))
+          request.env['HTTP_REFERER'] = admin_users_path
+          post :suspend, id: user
+
+          expect(user.reload).to be_suspended
+        end
+
+        it 'does not allow account publisher to suspend user' do
+          pageflow_configure do |config|
+            config.allow_multiaccount_users = false
+          end
+
+          account = create(:account)
+          user = create(:user, :member, on: account)
+
+          sign_in(create(:user, :publisher, on: account))
+          request.env['HTTP_REFERER'] = admin_users_path
+          post :suspend, id: user
+
+          expect(user.reload).not_to be_suspended
+        end
+      end
+    end
+
+    describe '#unsuspend' do
+      it 'allows admin to unsuspend user' do
+        account = create(:account)
+        user = create(:user, :suspended, :member, on: account)
+
+        sign_in(create(:user, :admin))
+        request.env['HTTP_REFERER'] = admin_users_path
+        post :unsuspend, id: user
+
+        expect(user.reload).not_to be_suspended
+      end
+
+      it 'does not allow account manager to unsuspend user' do
+        account = create(:account)
+        user = create(:user, :suspended, :member, on: account)
+
+        sign_in(create(:user, :manager, on: account))
+        request.env['HTTP_REFERER'] = admin_users_path
+        post :unsuspend, id: user
+
+        expect(user.reload).to be_suspended
+      end
+
+      context 'when config.allow_multiaccount_users is false' do
+        it 'allows account manager to unsuspend user' do
+          pageflow_configure do |config|
+            config.allow_multiaccount_users = false
+          end
+
+          account = create(:account)
+          user = create(:user, :suspended, :member, on: account)
+
+          sign_in(create(:user, :manager, on: account))
+          request.env['HTTP_REFERER'] = admin_users_path
+          post :unsuspend, id: user
+
+          expect(user.reload).not_to be_suspended
+        end
+
+        it 'does not allow account publisher to unsuspend user' do
+          pageflow_configure do |config|
+            config.allow_multiaccount_users = false
+          end
+
+          account = create(:account)
+          user = create(:user, :suspended, :member, on: account)
+
+          sign_in(create(:user, :publisher, on: account))
+          request.env['HTTP_REFERER'] = admin_users_path
+          post :unsuspend, id: user
+
+          expect(user.reload).to be_suspended
+        end
+      end
+    end
+
     describe '#me' do
       render_views
 

--- a/spec/features/account_manager/deleting_a_user_spec.rb
+++ b/spec/features/account_manager/deleting_a_user_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+feature 'as system admin, deleting a user' do
+  context 'with multiaccount uses forbidden' do
+    scenario 'deleted user can no longer sign in' do
+      pageflow_configure do |config|
+        config.allow_multiaccount_users = false
+      end
+
+      account = create(:account)
+      user = create(:user,
+                    :member,
+                    on: account,
+                    email: 'john@example.com',
+                    password: '!Pass123')
+
+      Dom::Admin::Page.sign_in_as(:manager, on: account)
+      visit(admin_user_path(user))
+      Dom::Admin::UserPage.first.delete_user_link.click
+
+      expect(Dom::Admin::Page).not_to be_accessible_with(email: 'john@example.com',
+                                                         password: '!Pass123')
+    end
+  end
+end

--- a/spec/features/account_manager/suspending_a_user_spec.rb
+++ b/spec/features/account_manager/suspending_a_user_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+feature 'as account manager, suspending a user' do
+  context 'with multiaccount users forbidden' do
+    scenario 'suspended user can not sign in' do
+      pageflow_configure do |config|
+        config.allow_multiaccount_users = false
+      end
+
+      account = create(:account)
+      user = create(:user,
+                    :member,
+                    on: account,
+                    email: 'john@example.com',
+                    password: '!Pass123')
+
+      Dom::Admin::Page.sign_in_as(:manager, on: account)
+      visit(admin_user_path(user))
+      Dom::Admin::UserPage.first.suspend_user_link.click
+
+      expect(Dom::Admin::Page).not_to be_accessible_with(email: 'john@example.com',
+                                                         password: '!Pass123')
+    end
+
+    scenario 'unsuspended user can sign in' do
+      pageflow_configure do |config|
+        config.allow_multiaccount_users = false
+      end
+
+      account = create(:account)
+      user = create(:user,
+                    :suspended,
+                    :member,
+                    on: account,
+                    email: 'john@example.com',
+                    password: '!Pass123')
+
+      Dom::Admin::Page.sign_in_as(:manager, on: account)
+      visit(admin_user_path(user))
+      Dom::Admin::UserPage.first.unsuspend_user_link.click
+
+      expect(Dom::Admin::Page).to be_accessible_with(email: 'john@example.com',
+                                                     password: '!Pass123')
+    end
+  end
+end

--- a/spec/policies/pageflow/user_policy_spec.rb
+++ b/spec/policies/pageflow/user_policy_spec.rb
@@ -9,6 +9,27 @@ module Pageflow
                     to: :read,
                     topic: -> { create(:user, :member, on: create(:account)) }
 
+    it_behaves_like 'an admin permission that',
+                    allows_admins_but_forbids_even_managers: true,
+                    of_account: ->(topic) { topic.accounts.first },
+                    to: :suspend,
+                    topic: -> { create(:user, :member, on: create(:account)) }
+
+    context 'when allow_multiaccount_users is false' do
+      before do
+        pageflow_configure do |config|
+          config.allow_multiaccount_users = false
+        end
+      end
+
+      it_behaves_like 'a membership-based permission that',
+                      allows: :manager,
+                      but_forbids: :publisher,
+                      of_account: ->(topic) { topic.accounts.first },
+                      to: :suspend,
+                      topic: -> { create(:user, :member, on: create(:account)) }
+    end
+
     context 'without only_admins_may_see_admin_boolean' do
       before do
         pageflow_configure do |config|

--- a/spec/policies/pageflow/user_policy_spec.rb
+++ b/spec/policies/pageflow/user_policy_spec.rb
@@ -15,6 +15,12 @@ module Pageflow
                     to: :suspend,
                     topic: -> { create(:user, :member, on: create(:account)) }
 
+    it_behaves_like 'an admin permission that',
+                    allows_admins_but_forbids_even_managers: true,
+                    of_account: ->(topic) { topic.accounts.first },
+                    to: :destroy,
+                    topic: -> { create(:user, :member, on: create(:account)) }
+
     context 'when allow_multiaccount_users is false' do
       before do
         pageflow_configure do |config|
@@ -27,6 +33,13 @@ module Pageflow
                       but_forbids: :publisher,
                       of_account: ->(topic) { topic.accounts.first },
                       to: :suspend,
+                      topic: -> { create(:user, :member, on: create(:account)) }
+
+      it_behaves_like 'a membership-based permission that',
+                      allows: :manager,
+                      but_forbids: :publisher,
+                      of_account: ->(topic) { topic.accounts.first },
+                      to: :destroy,
                       topic: -> { create(:user, :member, on: create(:account)) }
     end
 


### PR DESCRIPTION
Account managers need a way to revoke member access. When multi
account users are disabled, the sole account membership cannot be
deleted. In this case, it makes sense to allow account managers to
suspend or even destroy users since they cannot be members of any
other account anyway.

Moreover, this PR adds missing authorization logic for the admin
controller actions used to suspend users or resend invitation mails.