### PR TITLE
Move page padding from legacy styles to theme

### DIFF
--- a/app/assets/stylesheets/pageflow/page.scss
+++ b/app/assets/stylesheets/pageflow/page.scss
@@ -56,24 +56,12 @@
     height: 100%;
   }
 
-  .scroller > div, .content_and_background > .page_header {
-    padding: 200px 0 5% 8%;
+  .scroller > div {
     pointer-events: none;
     width: 75%;
+
     @include mobile {
-      padding: 85px 12% 5% 8%;
       width: 100%;
-    }
-  }
-
-  .content_and_background > .page_header {
-    position: relative;
-  }
-
-  .videoPage .scroller > div, .audioPage .scroller > div {
-    padding: 0px 0 5% 8%;
-    @include mobile {
-      padding: 0px 12% 5% 8%;
     }
   }
 
@@ -101,14 +89,10 @@
 
   .scroller > div {
     pointer-events: none;
-    padding: 15% 14% 5% 8%;
     width: 100%;
+
     @include mobile {
-      padding: 25% 12% 5% 8%;
       width: 100%;
-      @media (orientation: landscape) {
-        padding: 10% 12% 5% 8%;
-      }
     }
   }
 }

--- a/app/assets/stylesheets/pageflow/themes/default/logo.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/logo.scss
@@ -15,7 +15,7 @@ $logo-variant: "first-page" !default;
 $logo-top: 30px !default;
 
 /// Height of the logo. (Non-watermark variants only)
-$logo-phone-top: nil !default;
+$logo-phone-top: null !default;
 
 /// Width of the logo. (Watermark variant only)
 $logo-width: 100px !default;

--- a/app/assets/stylesheets/pageflow/themes/default/page.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page.scss
@@ -5,18 +5,6 @@
 /// Base typography for page.
 $page-typography: () !default;
 
-/// Space for logo on first page.
-$page-scroller-first-page-padding-top: nil !default;
-
-/// Space for logo on first page in mobile layout.
-$page-scroller-first-page-mobile-padding-top: 110px !default;
-
-/// Space for logo on first page in mobile landscape layout.
-$page-scroller-first-page-mobile-landscape-padding-top: 100px !default;
-
-/// Space for logo on first page in phone layout.
-$page-scroller-first-page-phone-padding-top: nil !default;
-
 /// Typography for header.
 $page-header-typography: () !default;
 
@@ -100,6 +88,8 @@ $page-content-text-font-size: 1.2em !default;
 $page-content-text-line-height: 1.5em !default;
 
 @import "./page/anchors";
+@import "./page/paddings";
+
 @import "./page/line_lengths";
 
 .page {
@@ -215,25 +205,7 @@ $page-content-text-line-height: 1.5em !default;
   }
 }
 
-.js .page:first-child {
-  .scroller > div,
-  .content_and_background > .page_header {
-    padding-top: $page-scroller-first-page-padding-top;
-
-    @include mobile {
-      padding-top: $page-scroller-first-page-mobile-padding-top;
-      width: 100%;
-
-      @media (orientation: landscape) {
-        padding-top: $page-scroller-first-page-mobile-landscape-padding-top;
-      }
-    }
-
-    @include phone {
-      padding-top: $page-scroller-first-page-phone-padding-top;
-    }
-  }
-
+.page:first-child {
   h2 .title {
     @include typography(
       $page-header-first-page-title-typography,

--- a/app/assets/stylesheets/pageflow/themes/default/page/line_lengths.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/line_lengths.scss
@@ -37,9 +37,8 @@ $page-content-width: 60% !default;
     width: 100%;
   }
 
-  // see pageflow/page.scss
-  $page-padding-left: 8%;
-  $page-padding-right: 14%;
+  $page-padding-left: $page-scroller-padding-left;
+  $page-padding-right: $page-scroller-padding-right;
   $page-content-wrapper-width: 100% - $page-padding-left - $page-padding-right;
 
   // On pages that support split layout (i.e. some kind of

--- a/app/assets/stylesheets/pageflow/themes/default/page/paddings.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/paddings.scss
@@ -1,0 +1,72 @@
+////
+/// @group page-typography
+////
+
+/// Space around page text inside scroller.
+$page-scroller-padding-top: 15% !default;
+
+/// Space around page text inside scroller.
+$page-scroller-mobile-padding-top: 25% !default;
+
+/// Space around page text inside scroller.
+$page-scroller-mobile-landscape-padding-top: 10% !default;
+
+/// Space around page text inside scroller.
+$page-scroller-padding-bottom: 5% !default;
+
+/// Space around page text inside scroller.
+$page-scroller-padding-left: 8% !default;
+
+/// Space around page text inside scroller.
+$page-scroller-padding-right: 14% !default;
+
+/// Space around page text inside scroller.
+$page-scroller-mobile-padding-right: 12% !default;
+
+/// Space for logo on first page.
+$page-scroller-first-page-padding-top: null !default;
+
+/// Space for logo on first page in mobile layout.
+$page-scroller-first-page-mobile-padding-top: 110px !default;
+
+/// Space for logo on first page in mobile landscape layout.
+$page-scroller-first-page-mobile-landscape-padding-top: 100px !default;
+
+/// Space for logo on first page in phone layout.
+$page-scroller-first-page-phone-padding-top: null !default;
+
+.page {
+  .scroller > div {
+    padding: $page-scroller-padding-top
+               $page-scroller-padding-right
+               $page-scroller-padding-bottom
+               $page-scroller-padding-left;
+
+    @include mobile {
+      padding-top: $page-scroller-mobile-padding-top;
+      padding-right: $page-scroller-mobile-padding-right;
+
+      @media (orientation: landscape) {
+        padding-top: $page-scroller-mobile-landscape-padding-top;
+      }
+    }
+  }
+}
+
+.page:first-child {
+  .scroller > div {
+    padding-top: $page-scroller-first-page-padding-top;
+
+    @include mobile {
+      padding-top: $page-scroller-first-page-mobile-padding-top;
+
+      @media (orientation: landscape) {
+        padding-top: $page-scroller-first-page-mobile-landscape-padding-top;
+      }
+    }
+
+    @include phone {
+      padding-top: $page-scroller-first-page-phone-padding-top;
+    }
+  }
+}


### PR DESCRIPTION
Mainly motivated by the need to customize the padding top on all pages
to make room for larger logos that are displayed on all pages.

Remove rules for `.content_and_background > .page_header`
selector. Before the React rewrite, video and audio page placed the
page header above the page background in statically rendered HTML and
had JS move the DOM element into the scroller. This alternative DOM
order allowed displaying the media tag below the page header in the
non-js case. Still, statically rendered media tags have long been
removed since they trigger preloading in a lot of browsers. Instead
only a link to a separate video page is present in the non-js
case. The alternative DOM order is no longer needed.

There were also special non-js styles for the video and audio page
removing page padding. It is no longer clear why this was needed.

Remove duplicated padding variables in line lengths styles.