### PR TITLE
Remove TODO comments

### DIFF
--- a/app/assets/javascripts/pageflow/editor/initializers/setup_collections.js
+++ b/app/assets/javascripts/pageflow/editor/initializers/setup_collections.js
@@ -33,7 +33,6 @@ pageflow.app.addInitializer(function(options) {
 
   pageflow.pages.sort();
 
-  // TODO
   pageflow.storylines.on('sort', _.debounce(function() {
     pageflow.storylines.saveOrder();
   }, 100));

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
-# TODO
-ActionView::TestCase::TestController.send(:include, Pageflow::Engine.routes.url_helpers)
-
 module Pageflow
   describe EntriesHelper do
+    before(:each) do
+      helper.extend(Pageflow::Engine.routes.url_helpers)
+    end
+
     describe '#pretty_entry_title' do
       it 'equals the entry title by default' do
         entry = PublishedEntry.new(build(:entry, title: 'test'), build(:revision))

--- a/spec/helpers/pageflow/themings_helper_spec.rb
+++ b/spec/helpers/pageflow/themings_helper_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
-# TODO
-ActionView::TestCase::TestController.send(:include, Pageflow::Engine.routes.url_helpers)
-
 module Pageflow
   describe ThemingsHelper do
+    before(:each) do
+      helper.extend(Pageflow::Engine.routes.url_helpers)
+    end
+
     describe '#pretty_theming_url' do
       it 'uses default host' do
         theming = create(:theming, cname: '')


### PR DESCRIPTION
* Remove unneeded TODO from Backbone initializer. Code has worked like
  this for a long time. No intention to change it.

* Move url helpers include in spec to before block to align with other
  helper specs.