### PR TITLE
Replace FactoryGirl with FactoryBot

### DIFF
--- a/lib/pageflow/engine.rb
+++ b/lib/pageflow/engine.rb
@@ -66,9 +66,9 @@ module Pageflow
       Pageflow.configure!
     end
 
-    initializer "pageflow.factories", :after => "factory_girl.set_factory_paths" do
-      if Pageflow.configured? && defined?(FactoryGirl)
-        FactoryGirl.definition_file_paths.unshift(Engine.root.join('spec', 'factories'))
+    initializer 'pageflow.factories', after: 'factory_bot.set_factory_paths' do
+      if Pageflow.configured? && defined?(FactoryBot)
+        FactoryBot.definition_file_paths.unshift(Engine.root.join('spec', 'factories'))
       end
     end
 

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -143,7 +143,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'domino', '~> 0.7.0'
 
   # Fixture replacement
-  s.add_development_dependency 'factory_girl_rails', '~> 4.5'
+  s.add_development_dependency 'factory_bot_rails', '~> 4.8'
 
   # Matchers for Pundit policies
   s.add_development_dependency 'pundit-matchers', '~> 1.0'

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :account, class: Pageflow::Account do
     name 'Account Name'
 

--- a/spec/factories/audio_files.rb
+++ b/spec/factories/audio_files.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :audio_file, :class => AudioFile do
       entry
       uploader { create(:user) }

--- a/spec/factories/chapters.rb
+++ b/spec/factories/chapters.rb
@@ -1,7 +1,5 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
-
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :chapter, :class => Chapter do
       storyline
 

--- a/spec/factories/edit_locks.rb
+++ b/spec/factories/edit_locks.rb
@@ -1,7 +1,5 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
-
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :edit_lock, :class => EditLock do
       user nil
       entry { build(:entry) }

--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     sequence :title do |n|
       "Entry #{n}"
     end

--- a/spec/factories/feature_targets.rb
+++ b/spec/factories/feature_targets.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :feature_target, parent: :account do
   end
 end

--- a/spec/factories/file_usages.rb
+++ b/spec/factories/file_usages.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :file_usage, :class => FileUsage do
       revision nil
       file nil

--- a/spec/factories/folders.rb
+++ b/spec/factories/folders.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :folder, :class => Folder do
       name "some folder"
       account

--- a/spec/factories/hosted_files.rb
+++ b/spec/factories/hosted_files.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     hosted_file_model = Class.new(ActiveRecord::Base) do
       self.table_name = 'test_hosted_files'
       include HostedFile

--- a/spec/factories/image_files.rb
+++ b/spec/factories/image_files.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :image_file, :class => ImageFile do
       entry
       uploader { create(:user) }

--- a/spec/factories/invited_user.rb
+++ b/spec/factories/invited_user.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :invited_user, class: InvitedUser do
       email
       first_name 'Edison'

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :membership, class: Membership do
       user
       association :entity, factory: :entry

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :page, :class => Page do
       chapter
       template "background_image"

--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :revision, :class => Revision do
       entry
 

--- a/spec/factories/storylines.rb
+++ b/spec/factories/storylines.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :storyline, class: Storyline do
       revision
     end

--- a/spec/factories/text_track_files.rb
+++ b/spec/factories/text_track_files.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :text_track_file, class: TextTrackFile do
       entry
       uploader { create(:user) }

--- a/spec/factories/themings.rb
+++ b/spec/factories/themings.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :theming, :class => Pageflow::Theming do
       account
       theme_name 'default'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     sequence :email do |n|
       "person#{n}@example.com"
     end

--- a/spec/factories/video_files.rb
+++ b/spec/factories/video_files.rb
@@ -1,5 +1,5 @@
 module Pageflow
-  FactoryGirl.define do
+  FactoryBot.define do
     factory :video_file, :class => VideoFile do
       entry
       uploader { create(:user) }

--- a/spec/factories/widgets.rb
+++ b/spec/factories/widgets.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :widget, :class => Pageflow::Widget do
     role 'navigation'
     type_name 'test_widget'

--- a/spec/support/config/factory_girl.rb
+++ b/spec/support/config/factory_girl.rb
@@ -1,14 +1,14 @@
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 
 RSpec.configure do |config|
-  # Allow to use build and create methods without FactoryGirl prefix.
-  config.include FactoryGirl::Syntax::Methods
+  # Allow to use build and create methods without FactoryBot prefix.
+  config.include FactoryBot::Syntax::Methods
 
   # Make sure factories are up to date when using spring. Skip in CI
   # since reloading causes factories to be excluded in test coverage.
   unless ENV['CI']
     config.before(:all) do
-      FactoryGirl.reload
+      FactoryBot.reload
     end
   end
 end

--- a/spec/support/pageflow/dom/admin/page.rb
+++ b/spec/support/pageflow/dom/admin/page.rb
@@ -23,13 +23,13 @@ module Pageflow
         def self.sign_in_as(role, options = {})
           email = "#{role}@example.com"
           password = '!Pass123'
-          user = FactoryGirl.create(:user, options.reverse_merge(email: email, password: password))
+          user = FactoryBot.create(:user, options.reverse_merge(email: email, password: password))
 
           if role.to_sym == :admin
             user.admin = true
             user.save
           else
-            FactoryGirl.create(:membership, user: user, role: role, entity: options[:on])
+            FactoryBot.create(:membership, user: user, role: role, entity: options[:on])
           end
 
           visit '/admin/login'


### PR DESCRIPTION
The gem has been renamed. Since plugin specs reuse factories this is a breaking change since it basically forces plugins to upgrade to FactoryBot as well. 