### PR TITLE
File type background image rules for generated css

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,10 @@ Style/FrozenStringLiteralComment:
 Style/LambdaCall:
   Enabled: false
 
+  # Do not use %i for symbol arrays
+Style/SymbolArray:
+  EnforcedStyle: brackets
+
 # In specs methods using RSpec DSL often become complex
 Metrics/AbcSize:
   Exclude:

--- a/app/assets/javascripts/pageflow/editor/views/embedded/background_image_embedded_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/embedded/background_image_embedded_view.js
@@ -9,25 +9,60 @@ pageflow.BackgroundImageEmbeddedView = Backbone.Marionette.View.extend({
   },
 
   update: function() {
+    if (this.options.useInlineStyles !== false){
+      this.updateInlineStyle();
+    }
+    else {
+      this.updateClassName();
+    }
+
+    if (this.options.dataSizeAttributes) {
+      this.updateDataSizeAttributes();
+    }
+  },
+
+  updateClassName: function() {
+    this.$el.addClass('load_image');
+
+    var propertyName = this.options.propertyName.call ?
+      this.options.propertyName() :
+      this.options.propertyName;
+    var id = this.model.get(propertyName);
+    var prefix = this.options.backgroundImageClassNamePrefix.call ?
+      this.options.backgroundImageClassNamePrefix() :
+      this.options.backgroundImageClassNamePrefix;
+
+    prefix = prefix || 'image';
+    var backgroundImageClassName = id && prefix + '_' + id;
+
+    if (this.currentBackgroundImageClassName !== backgroundImageClassName) {
+      this.$el.removeClass(this.currentBackgroundImageClassName);
+      this.$el.addClass(backgroundImageClassName);
+
+      this.currentBackgroundImageClassName = backgroundImageClassName;
+    }
+  },
+
+  updateInlineStyle: function() {
     this.$el.css({
       backgroundImage: this.imageValue(),
       backgroundPosition: this.model.getFilePosition(this.options.propertyName, 'x') + '% ' +
         this.model.getFilePosition(this.options.propertyName, 'y') + '%'
     });
+  },
 
-    if (this.options.dataSizeAttributes) {
-      var imageFile = this.model.getImageFile(this.options.propertyName);
+  updateDataSizeAttributes: function() {
+    var imageFile = this.model.getImageFile(this.options.propertyName);
 
-      if (imageFile && imageFile.isReady()) {
-        this.$el.attr('data-width',  imageFile.get('width'));
-        this.$el.attr('data-height',  imageFile.get('height'));
-      }
-      else {
-        this.$el.attr('data-width', '16');
-        this.$el.attr('data-height', '9');
-      }
-      this.$el.css({backgroundPosition:'0 0'});
+    if (imageFile && imageFile.isReady()) {
+      this.$el.attr('data-width',  imageFile.get('width'));
+      this.$el.attr('data-height',  imageFile.get('height'));
     }
+    else {
+      this.$el.attr('data-width', '16');
+      this.$el.attr('data-height', '9');
+    }
+    this.$el.css({backgroundPosition:'0 0'});
   },
 
   imageValue: function() {

--- a/app/helpers/pageflow/background_image_helper.rb
+++ b/app/helpers/pageflow/background_image_helper.rb
@@ -22,11 +22,6 @@ module Pageflow
     end
 
     class Div
-      FILE_TYPE_CSS_CLASS_PREFIXES = {
-        'image_file' => 'image',
-        'video_file' => 'video_poster',
-      }
-
       attr_reader :configuration, :property_base_name, :options
 
       delegate :content_tag, :to => :@template
@@ -67,12 +62,17 @@ module Pageflow
       end
 
       def image_css_class_prefix
-        FILE_TYPE_CSS_CLASS_PREFIXES.fetch(options.fetch(:file_type, 'image_file'))
+        file_type.css_background_image_class_prefix
       end
 
       def background_position(coord)
         property_name = "#{property_base_name}_#{coord}"
         configuration.key?(property_name) ? "#{configuration[property_name]}%" : "50%"
+      end
+
+      def file_type
+        collection_name = options.fetch(:file_type, 'image_file').pluralize
+        Pageflow.config.file_types.find_by_collection_name!(collection_name)
       end
     end
 
@@ -110,10 +110,6 @@ module Pageflow
 
       def find_file
         file_type.model.find_by_id(file_id)
-      end
-
-      def file_type
-        Pageflow.config.file_types.find_by_collection_name!(options.fetch(:file_type, 'image_file').pluralize)
       end
     end
   end

--- a/app/helpers/pageflow/file_background_images_helper.rb
+++ b/app/helpers/pageflow/file_background_images_helper.rb
@@ -1,0 +1,78 @@
+module Pageflow
+  # @api private
+  module FileBackgroundImagesHelper
+    include BackgroundImageHelper
+
+    ALLOWED_BREAKPOINTS = [:mobile, :desktop].freeze
+
+    def file_background_images_css(entry, breakpoint_name)
+      render(partial: 'pageflow/file_background_images/rule',
+             collection: Rules.new(Pageflow.config.file_types.with_css_background_image_support,
+                                   entry,
+                                   breakpoint_name).to_a)
+    end
+
+    # @api private
+    class Rules
+      def initialize(file_types, entry, breakpoint_name)
+        @file_types = file_types
+        @entry = entry
+        @breakpoint_name = breakpoint_name
+      end
+
+      def to_a
+        file_types.flat_map do |file_type|
+          rules_for_file_type(file_type)
+        end
+      end
+
+      private
+
+      attr_reader :entry, :file_types, :breakpoint_name
+
+      def rules_for_file_type(file_type)
+        entry.find_files(file_type.model).flat_map do |file|
+          exclude_rules_with_blank_url(rules_for_file(file_type, file))
+        end
+      end
+
+      def rules_for_file(file_type, file)
+        file_type.css_background_image_urls.call(file).map do |name, url|
+          {
+            prefix: rule_prefix(file_type, name),
+            file: file,
+            url: url_for_breakpoint(file_type, url)
+          }
+        end
+      end
+
+      def url_for_breakpoint(file_type, url)
+        if url.is_a?(Hash)
+          unknown_breakpoint_names = url.keys - ALLOWED_BREAKPOINTS
+
+          if unknown_breakpoint_names.any?
+            raise("Unknown breakpoints #{unknown_breakpoint_names.join(', ')} used in " \
+                  "css_background_image_urls of file type #{file_type.collection_name}.")
+          end
+
+          url[breakpoint_name]
+        else
+          url
+        end
+      end
+
+      def rule_prefix(file_type, name)
+        [
+          file_type.css_background_image_class_prefix,
+          name == :default ? nil : name
+        ].compact.join('_')
+      end
+
+      def exclude_rules_with_blank_url(rules)
+        rules.reject do |rule|
+          rule[:url].blank?
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/pageflow/pages_helper.rb
+++ b/app/helpers/pageflow/pages_helper.rb
@@ -50,8 +50,8 @@ module Pageflow
 
     def page_media_breakpoints
       {
-        :large => :default,
-        :medium => 'max-width: 900px'
+        desktop: :default,
+        mobile: 'max-width: 900px'
       }
     end
 

--- a/app/models/pageflow/image_file_css_background_image_urls.rb
+++ b/app/models/pageflow/image_file_css_background_image_urls.rb
@@ -1,0 +1,17 @@
+module Pageflow
+  # @api private
+  class ImageFileCssBackgroundImageUrls
+    def call(image_file)
+      {
+        default: {
+          desktop: image_file.attachment.url(:large),
+          mobile: image_file.attachment.url(:medium)
+        },
+        panorama: {
+          desktop: image_file.attachment.url(:panorama_large),
+          mobile: image_file.attachment.url(:panorama_medium)
+        }
+      }
+    end
+  end
+end

--- a/app/models/pageflow/video_file_css_background_image_urls.rb
+++ b/app/models/pageflow/video_file_css_background_image_urls.rb
@@ -1,0 +1,13 @@
+module Pageflow
+  # @api private
+  class VideoFileCssBackgroundImageUrls
+    def call(video_file)
+      {
+        default: {
+          desktop: video_file.poster.url(:large),
+          mobile: video_file.poster.url(:medium)
+        }
+      }
+    end
+  end
+end

--- a/app/views/pageflow/entries/show.css.erb
+++ b/app/views/pageflow/entries/show.css.erb
@@ -1,24 +1,10 @@
 <%= cache @entry do %>
-
-    <% page_media_breakpoints.each do |style, condition| %>
-      <%= media_query(condition) do %>
-        <% @entry.image_files.each do |image_file| %>
-          <%= background_image_lazy_loading_css_class('image', image_file) %> {
-            background-image: url('<%= image_file.attachment.url(style) %>');
-          }
-          <%= background_image_lazy_loading_css_class('image_panorama', image_file) %> {
-            background-image: url('<%= image_file.attachment.url("panorama_#{style}") %>');
-          }
-        <% end %>
-
-        <% @entry.video_files.each do |video_file| %>
-          <%= background_image_lazy_loading_css_class('video_poster', video_file) %> {
-            background-image: url('<%= video_file.poster.url(style) %>');
-          }
-        <% end %>
-      <% end %>
+  <% page_media_breakpoints.each do |breakpoint_name, condition| %>
+    <%= media_query(condition) do %>
+      <%= file_background_images_css(@entry, breakpoint_name) %>
     <% end %>
+  <% end %>
 
-    <%= file_thumbnails_css(@entry) %>
-    <%= render 'pageflow/entries/theming' %>
+  <%= file_thumbnails_css(@entry) %>
+  <%= render 'pageflow/entries/theming' %>
 <% end %>

--- a/app/views/pageflow/file_background_images/_rule.css.erb
+++ b/app/views/pageflow/file_background_images/_rule.css.erb
@@ -1,0 +1,3 @@
+<%= background_image_lazy_loading_css_class(rule[:prefix], rule[:file]) %> {
+  background-image: url('<%= rule[:url] %>');
+}

--- a/lib/pageflow/built_in_file_type.rb
+++ b/lib/pageflow/built_in_file_type.rb
@@ -8,6 +8,8 @@ module Pageflow
                    editor_partial: 'pageflow/editor/image_files/image_file',
                    collection_name: 'image_files',
                    url_templates: ImageFileUrlTemplates.new,
+                   css_background_image_urls: ImageFileCssBackgroundImageUrls.new,
+                   css_background_image_class_prefix: 'image',
                    top_level_type: true)
     end
 
@@ -17,6 +19,8 @@ module Pageflow
                    editor_partial: 'pageflow/editor/video_files/video_file',
                    collection_name: 'video_files',
                    url_templates: VideoFileUrlTemplates.new,
+                   css_background_image_urls: VideoFileCssBackgroundImageUrls.new,
+                   css_background_image_class_prefix: 'video_poster',
                    top_level_type: true,
                    nested_file_types: [BuiltInFileType.text_track])
     end

--- a/lib/pageflow/file_type.rb
+++ b/lib/pageflow/file_type.rb
@@ -24,6 +24,28 @@ module Pageflow
     # @return {Boolean}
     attr_reader :top_level_type
 
+    # Callable that receives a file record and returns a hash of one
+    # of the following forms:
+    #
+    #     {
+    #       poster: "url/of/image"
+    #     }
+    #
+    # where `poster` is an arbitrary css class infix. Use `default` to
+    # skip the infix in the generated css class name. Or
+    #
+    #     {
+    #       poster: {
+    #         desktop: "desktop/url/of/image",
+    #         mobile: "mobile/url/of/image"
+    #       }
+    #     }
+    #
+    # to provide different urls for the two media breakpoints.
+    #
+    # @return [#call]
+    attr_reader :css_background_image_urls
+
     # Callable that returns a hash of url template strings indexed by
     # their names.
     # @return [#call]
@@ -54,6 +76,8 @@ module Pageflow
     #   model `Pageflow::Rainbow::File`.
     # @option options [Array<FileType>] :nested_file_types
     #   Optional. Array of FileTypes allowed for nested files. Defaults to [].
+    # @option options [#call] :css_background_image_urls
+    #   Optional. See {#css_background_image_urls}
     # @option options [#call] :url_templates
     #   Optional. Callable returning a hash of url template strings
     #   indexed by their names.
@@ -67,6 +91,8 @@ module Pageflow
       @collection_name_or_blank = options[:collection_name]
       @nested_file_types = options.fetch(:nested_file_types, [])
       @top_level_type = options.fetch(:top_level_type, false)
+      @css_background_image_urls = options[:css_background_image_urls]
+      @css_background_image_class_prefix = options[:css_background_image_class_prefix]
       @url_templates = options.fetch(:url_templates, ->() { {} })
       @custom_attributes = options.fetch(:custom_attributes, [])
     end
@@ -90,6 +116,11 @@ module Pageflow
       else
         @collection_name_or_blank
       end
+    end
+
+    # @api private
+    def css_background_image_class_prefix
+      @css_background_image_class_prefix || model.model_name.singular
     end
 
     # @api private

--- a/lib/pageflow/file_types.rb
+++ b/lib/pageflow/file_types.rb
@@ -31,6 +31,12 @@ module Pageflow
       end
     end
 
+    def with_css_background_image_support
+      select do |file_type|
+        file_type.css_background_image_urls.present?
+      end
+    end
+
     private
 
     def search_for_nested_file_types(higher_level_file_types)

--- a/spec/helpers/pageflow/background_image_helper_spec.rb
+++ b/spec/helpers/pageflow/background_image_helper_spec.rb
@@ -42,6 +42,20 @@ module Pageflow
         expect(html).to have_selector('div.video_poster_6')
       end
 
+      it 'supports custom file types' do
+        pageflow_configure do |config|
+          TestFileType.register(config,
+                                collection_name: 'test_hosted_files',
+                                css_background_image_urls: lambda do |file|
+                                  {default: file.attachment.url}
+                                end)
+        end
+        configuration = {'file_id' => 6}
+        html = helper.background_image_div(configuration, 'file', file_type: 'test_hosted_file')
+
+        expect(html).to have_selector('div.pageflow_test_hosted_file_6')
+      end
+
       it 'sets inline style for background position' do
         configuration = {'background_image_x' => 45, 'background_image_y' => 35}
         html = helper.background_image_div(configuration, 'background_image')

--- a/spec/helpers/pageflow/file_background_images_helper_spec.rb
+++ b/spec/helpers/pageflow/file_background_images_helper_spec.rb
@@ -1,0 +1,141 @@
+require 'spec_helper'
+
+module Pageflow
+  describe FileBackgroundImagesHelper do
+    describe '#file_background_images_css' do
+      it 'generates css rules with given names' do
+        pageflow_configure do |config|
+          TestFileType.register(config,
+                                model: TestHostedFile,
+                                css_background_image_urls: lambda do |file|
+                                  {poster: file.attachment.url}
+                                end)
+        end
+
+        entry = PublishedEntry.new(create(:entry, :published))
+        hosted_file = create(:hosted_file, used_in: entry.revision)
+
+        result = helper.file_background_images_css(entry, :desktop)
+
+        expect(result).to include(".pageflow_test_hosted_file_poster_#{hosted_file.id}")
+      end
+
+      it 'generates css rules using given urls' do
+        pageflow_configure do |config|
+          TestFileType.register(config,
+                                model: TestHostedFile,
+                                css_background_image_urls: lambda do |_file|
+                                  {poster: 'some/url'}
+                                end)
+        end
+
+        entry = PublishedEntry.new(create(:entry, :published))
+        create(:hosted_file, used_in: entry.revision)
+
+        result = helper.file_background_images_css(entry, :desktop)
+
+        expect(result).to include("background-image: url('some/url')")
+      end
+
+      it 'omits prefix if name equals "default"' do
+        pageflow_configure do |config|
+          TestFileType.register(config,
+                                model: TestHostedFile,
+                                css_background_image_urls: lambda do |file|
+                                  {default: file.attachment.url}
+                                end)
+        end
+
+        entry = PublishedEntry.new(create(:entry, :published))
+        hosted_file = create(:hosted_file, used_in: entry.revision)
+
+        result = helper.file_background_images_css(entry, :desktop)
+
+        expect(result).to include(".pageflow_test_hosted_file_#{hosted_file.id}")
+      end
+
+      it 'supports urls index by breakpoint name' do
+        pageflow_configure do |config|
+          TestFileType.register(config,
+                                model: TestHostedFile,
+                                css_background_image_urls: lambda do |file|
+                                  {
+                                    poster: {
+                                      desktop: file.attachment.url
+                                    }
+                                  }
+                                end)
+        end
+
+        entry = PublishedEntry.new(create(:entry, :published))
+        hosted_file = create(:hosted_file, used_in: entry.revision)
+
+        result = helper.file_background_images_css(entry, :desktop)
+
+        expect(result).to include(".pageflow_test_hosted_file_poster_#{hosted_file.id}")
+      end
+
+      it 'fails with helpful error when unknown breakpoint is used' do
+        pageflow_configure do |config|
+          TestFileType.register(config,
+                                model: TestHostedFile,
+                                css_background_image_urls: lambda do |file|
+                                  {
+                                    poster: {
+                                      plesktop: file.attachment.url
+                                    }
+                                  }
+                                end)
+        end
+
+        entry = PublishedEntry.new(create(:entry, :published))
+        create(:hosted_file, used_in: entry.revision)
+
+        expect {
+          helper.file_background_images_css(entry, :desktop)
+        }.to raise_error(/Unknown breakpoints plesktop/)
+      end
+
+      it 'skips rules for other breakpoint' do
+        pageflow_configure do |config|
+          TestFileType.register(config,
+                                model: TestHostedFile,
+                                css_background_image_urls: lambda do |file|
+                                  {
+                                    poster: {
+                                      desktop: file.attachment.url
+                                    }
+                                  }
+                                end)
+        end
+
+        entry = PublishedEntry.new(create(:entry, :published))
+        create(:hosted_file, used_in: entry.revision)
+
+        result = helper.file_background_images_css(entry, :mobile)
+
+        expect(result).to be_blank
+      end
+
+      it 'supports custom css class prefix' do
+        pageflow_configure do |config|
+          TestFileType.register(config,
+                                model: TestHostedFile,
+                                css_background_image_class_prefix: 'custom',
+                                css_background_image_urls: lambda do |file|
+                                  {
+                                    poster: file.attachment.url
+                                  }
+                                end)
+        end
+
+        entry = PublishedEntry.new(create(:entry, :published))
+        hosted_file = create(:hosted_file, used_in: entry.revision)
+
+        result = helper.file_background_images_css(entry, :desktop)
+
+        expect(result).to include(".custom_poster_#{hosted_file.id}")
+      end
+    end
+  end
+end

--- a/spec/pageflow/file_types_spec.rb
+++ b/spec/pageflow/file_types_spec.rb
@@ -106,5 +106,26 @@ module Pageflow
         expect(result).not_to include(file_type)
       end
     end
+
+    describe '#with_css_background_image_support' do
+      it 'includes file types with css_background_image_urls attribute set' do
+        file_type = FileType.new(model: ImageFile,
+                                 css_background_image_urls: -> {})
+        file_types = FileTypes.new([page_type_class.new(file_types: [file_type])])
+
+        result = file_types.with_css_background_image_support
+
+        expect(result).to include(file_type)
+      end
+
+      it 'does not include file types without css_background_image_urls attribute set' do
+        file_type = FileType.new(model: ImageFile)
+        file_types = FileTypes.new([page_type_class.new(file_types: [file_type])])
+
+        result = file_types.with_css_background_image_support
+
+        expect(result).not_to include(file_type)
+      end
+    end
   end
 end

--- a/spec/support/pageflow/lint.rb
+++ b/spec/support/pageflow/lint.rb
@@ -62,6 +62,14 @@ module Pageflow
                           file_type: file_type
                         })
         end
+
+        it 'provides css_background_image_urls that returns hash if present' do
+          if file_type.css_background_image_urls
+            result = file_type.css_background_image_urls.call(file)
+
+            expect(result).to be_a(Hash)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
So far the generated entry stylesheet only included rules to apply
background images based on image and video files.

Extend the file type API to allow providing background image urls for
generated rules. To ensure uniqueness, CSS class names are built from
file type name and an infix provided by the file type. Add private API
to let built in file types choose their own prefix to stay backward
compatible.

REDMINE-15957