### PR TITLE
Variable for watermark logo opacity

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/logo/variant/watermark.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/logo/variant/watermark.scss
@@ -12,6 +12,9 @@ $logo-watermark-variant-fade-in-near-top: "first-page" !default;
 /// is displayed while the header is active.
 $logo-watermark-variant-fade-in-with-header: false !default;
 
+/// Set opacity value of watermark logos
+$logo-watermark-variant-opacity: 0.3 !default;
+
 @mixin logo-variant-watermark(
   $top,
   $width,
@@ -30,7 +33,7 @@ $logo-watermark-variant-fade-in-with-header: false !default;
     z-index: 1;
 
     pointer-events: none;
-    opacity: 0.3;
+    opacity: $logo-watermark-variant-opacity;
     @include transition(opacity 500ms);
 
     @include phone {


### PR DESCRIPTION
The opacity value of the watermark logo variant can now be determined by the variable: 

`$logo-watermark-variant-opacity`

Default value is still 0.3