### PR TITLE
Fix filtering in searchable theming select in entry form

### DIFF
--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -93,10 +93,12 @@ module Pageflow
                               text_attribute: :name,
                               scope: lambda do |params|
                                 entry = Entry.find(params[:entry_id])
-
                                 ThemingPolicy::Scope
                                   .new(current_user, Theming)
                                   .themings_allowed_for(entry.account)
+                              end,
+                              filter: lambda do |term, scope|
+                                scope.ransack(account_name_cont: term).result
                               end)
 
     form do |f|

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -71,6 +71,22 @@ describe Admin::EntriesController do
     end
   end
 
+  describe '#eligible_themings_options' do
+    it 'can be filtered by account name' do
+      current_user = create(:user, :admin)
+      account = create(:account, name: 'one')
+      create(:account, name: 'two')
+      entry = create(:entry, account: account)
+
+      sign_in(current_user)
+      get(:eligible_themings_options, entry_id: entry.id, term: 'one')
+      option_texts = json_response(path: ['results', '*', 'text'])
+
+      expect(option_texts).to include('one')
+      expect(option_texts).not_to include('two')
+    end
+  end
+
   describe '#show' do
     describe 'built in admin tabs' do
       it 'entry editor sees members and revisions tabs' do


### PR DESCRIPTION
The name we want to filter by comes from the account model.