### PR TITLE
Fix jQuery error in node_package specs on Travis

### DIFF
--- a/node_package/src/pages/__spec__/createPageType-spec.jsx
+++ b/node_package/src/pages/__spec__/createPageType-spec.jsx
@@ -49,8 +49,7 @@ describe('createPageType', () => {
           return pageElement.find('span')[0];
         }
       });
-      const element = pageElement();
-      element.append('<span></span>');
+      const element = pageElement({innerHTML: '<span></span>'});
 
       pageType.enhance(element);
 
@@ -128,10 +127,13 @@ describe('createPageType', () => {
     });
   });
 
-  function pageElement() {
-    const element = jQuery(document.createElement('div'));
-    element.page = function() {};
+  function pageElement({innerHTML} = {innerHTML: ''}) {
+    const element = document.createElement('div');
+    element.innerHTML = innerHTML;
 
-    return element;
+    const result = jQuery(element);
+    result.page = function() {};
+
+    return result;
   }
 });


### PR DESCRIPTION
Calling jQuery's `append` method started to cause an error of the
form

    'undefined' is not a function (evaluating 'elem.getAttribute( "type" )')

in a jQuery function called `disableScript` which tries to change the
`type` attribute of script tags while parsing HTML. I could not
reproduce the error locally. Also it is not clear to me why there
should be `script` elements inside the newly created div element.

As a workaround we can use DOM API instead of jQuery to setup the
fixture page element.