### PR TITLE
Fallback to page title in overview page description

### DIFF
--- a/app/helpers/pageflow/overview_helper.rb
+++ b/app/helpers/pageflow/overview_helper.rb
@@ -1,0 +1,11 @@
+module Pageflow
+  module OverviewHelper
+    def overview_page_description(page)
+      if page.configuration['description'].present?
+        raw(page.configuration['description'])
+      else
+        page.title
+      end
+    end
+  end
+end

--- a/app/views/pageflow/entries/overview/_page.html.erb
+++ b/app/views/pageflow/entries/overview/_page.html.erb
@@ -1,6 +1,8 @@
 <%= link_to "##{page.perma_id}", :class => "ov_page #{page.template}", :data => {:link => page.id} do %>
     <div class="ov_page_description">
-      <p><%= raw(page.configuration['description']) unless page.configuration.blank? %></p>
+      <p>
+        <%= overview_page_description(page) %>
+      </p>
     </div>
     <%= image_tag("#{page.thumbnail_url(:thumbnail_overview_desktop)}") %>
     <div class="pictogram"></div>

--- a/spec/helpers/pageflow/overview_helper_spec.rb
+++ b/spec/helpers/pageflow/overview_helper_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module Pageflow
+  describe OverviewHelper do
+    describe '#overview_page_description' do
+      it 'uses page description if present' do
+        page = build(:page, configuration: {
+                       title: 'Some title',
+                       description: 'Some page'
+                     })
+
+        result = helper.overview_page_description(page)
+
+        expect(result).to eq('Some page')
+      end
+
+      it 'falls back to page title' do
+        page = build(:page, configuration: {title: 'Some title'})
+
+        result = helper.overview_page_description(page)
+
+        expect(result).to eq('Some title')
+      end
+
+      it 'permits HTML in description' do
+        page = build(:page, configuration: {description: 'Some <b>page</b>'})
+
+        result = helper.overview_page_description(page)
+
+        expect(result).to be_html_safe
+      end
+
+      it 'escapes HTML in title' do
+        page = build(:page, configuration: {title: 'Some <b>title</b>'})
+
+        result = helper.overview_page_description(page)
+
+        expect(result).not_to be_html_safe
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prevent displaying a blank overlay for page items.