### PR TITLE
Improve content links to pages of entry

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/page_preview_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/page_preview_view.js
@@ -67,7 +67,6 @@ pageflow.PagePreviewView = Backbone.Marionette.View.extend({
     pageflow.events.trigger('page:update', this.model);
 
     this.refreshScroller();
-    this.ensureTargetBlankForContentLinks();
     this.updateChapterBeginningClass();
   },
 
@@ -86,10 +85,6 @@ pageflow.PagePreviewView = Backbone.Marionette.View.extend({
 
   refreshScroller: function() {
     this.$el.page('refreshScroller');
-  },
-
-  ensureTargetBlankForContentLinks: function() {
-    pageflow.links.ensureTargetBlankForContentLinks(this.el);
   },
 
   initEmbeddedViews: function() {

--- a/app/assets/javascripts/pageflow/links.js
+++ b/app/assets/javascripts/pageflow/links.js
@@ -2,7 +2,6 @@ pageflow.links = {
   setup: function() {
     this.ensureClickOnEnterKeyPress();
     this.setupContentSkipLinks();
-    this.ensureTargetBlankForContentLinks();
   },
 
   ensureClickOnEnterKeyPress: function() {
@@ -25,11 +24,5 @@ pageflow.links = {
       e.preventDefault();
       return false;
     });
-  },
-
-  // There was a time when the rich text editor did not add target
-  // attributes to inline links even though it should have.
-  ensureTargetBlankForContentLinks: function(context) {
-    $('.contentText p a', context).attr('target', '_blank');
   }
 };

--- a/app/assets/javascripts/pageflow/slideshow/page_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/page_widget.js
@@ -6,6 +6,7 @@
       this.index = this.options.index;
 
       this._setupNearBoundaryCssClasses();
+      this._setupContentLinkTargetHandling();
 
       this.reinit();
     },
@@ -202,6 +203,27 @@
         element.on('scrollernotnear' + boundary, function() {
           element.removeClass('is_near_' + boundary);
         });
+      });
+    },
+
+    _setupContentLinkTargetHandling: function() {
+      this._on({
+        'click .contentText p a': function(event) {
+          var href = $(event.currentTarget).attr('href');
+
+          if (href[0] === '#') {
+            pageflow.slides.goToByPermaId(href.substr(1));
+          }
+          else {
+            // There was a time when the rich text editor did not add
+            // target attributes to inline links even though it should
+            // have. Ensure all content links to external urls open in
+            // new tab.
+            window.open(href, '_blank');
+          }
+
+          event.preventDefault();
+        }
       });
     }
   });


### PR DESCRIPTION
* Ensure page perma id links do not open new tab

* Make page perma id links work in editor by preventing default and
  using slideshow navigation

* Move existing link target fix to page widget