### PR TITLE
Mute background videos to fix autoplay on Safari 11

### DIFF
--- a/app/assets/javascripts/pageflow/browser/agent.js
+++ b/app/assets/javascripts/pageflow/browser/agent.js
@@ -16,19 +16,26 @@ pageflow.browser.agent = {
   },
 
   matchesSafari9: function() {
-    var matchers = [/Safari\//i, /Version\/9/i];
-
-    return _.all(matchers, function(matcher) {
-      return navigator.userAgent.match(matcher);
-    });
+    return this.matchesSafari() &&
+      this._matches(/Version\/9/i);
   },
 
   matchesSafari10: function() {
-    var matchers = [/Safari\//i, /Version\/10/i];
+    return this.matchesSafari() &&
+      this._matches(/Version\/10/i);
+  },
 
-    return _.all(matchers, function(matcher) {
-      return navigator.userAgent.match(matcher);
-    });
+  matchesSafari11: function() {
+    return this.matchesSafari() &&
+      this._matches(/Version\/11/i);
+  },
+
+  matchesSafari: function() {
+    // - Chrome also reports to be a Safari
+    // - Safari does not report to be a Chrome
+    // - Edge also reports to be a Safari, but also reports to be Chrome
+    return this._matches(/Safari\//i) &&
+      !this._matches(/Chrome/i);
   },
 
   /**
@@ -69,5 +76,9 @@ pageflow.browser.agent = {
    */
   matchesFacebookInAppBrowser: function() {
     return navigator.userAgent.match(/FBAN/) && navigator.userAgent.match(/FBAV/);
+  },
+
+  _matches: function(exp) {
+    return navigator.userAgent.match(exp);
   }
 };

--- a/app/assets/javascripts/pageflow/browser/autoplay_support.js
+++ b/app/assets/javascripts/pageflow/browser/autoplay_support.js
@@ -1,3 +1,4 @@
 pageflow.browser.feature('autoplay support', function(has) {
-  return has.not('mobile platform');
+  return !pageflow.browser.agent.matchesSafari11() &&
+    !pageflow.browser.agent.matchesMobilePlatform();
 });

--- a/node_package/src/media/components/PageBackgroundVideo.jsx
+++ b/node_package/src/media/components/PageBackgroundVideo.jsx
@@ -18,7 +18,7 @@ export function PageBackgroundVideo(props) {
     return (
       <PageVideoPlayer loop={true}
                        fit="cover"
-                       muted={props.hasMobilePlatform}
+                       muted={!props.hasAutoplaySupport}
                        playsInline={true}
                        textTracksEnabled={false}
                        {...props} />
@@ -33,5 +33,6 @@ function mobilePosterExists(props) {
 
 export default connect(combineSelectors({
   fileExists: fileExists(),
-  hasMobilePlatform: has('mobile platform')
+  hasMobilePlatform: has('mobile platform'),
+  hasAutoplaySupport: has('autoplay support')
 }))(PageBackgroundVideo);

--- a/node_package/src/media/components/__spec__/PageBackgroundVideo-spec.jsx
+++ b/node_package/src/media/components/__spec__/PageBackgroundVideo-spec.jsx
@@ -14,6 +14,7 @@ describe('PageBackgroundVideo', () => {
           mobilePosterImageId: 5
         },
         hasMobilePlatform: true,
+        hasAutoplaySupport: false,
         fileExists: fileExistsFn({
           imageFiles: [5]
         })
@@ -28,6 +29,7 @@ describe('PageBackgroundVideo', () => {
       const props = {
         page: {},
         hasMobilePlatform: true,
+        hasAutoplaySupport: false,
         fileExists: fileExistsFn({
           imageFiles: []
         })
@@ -47,7 +49,7 @@ describe('PageBackgroundVideo', () => {
           mobilePosterImageId: 5
         },
         hasMobilePlatform: false,
-        hasMuteVideoAutoplaySupport: true,
+        hasAutoplaySupport: true,
         fileExists: fileExistsFn({
           imageFiles: [5]
         })


### PR DESCRIPTION
Same restrictions apply as on mobile devices.