### PR TITLE
fixed wrong variable for page-header-title

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/page.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page.scss
@@ -170,7 +170,7 @@ $page-content-text-line-height: 1.5em !default;
           font-weight: $page-header-title-font-weight,
           line-height: $page-header-title-line-height,
           margin-top: $page-header-title-margin-top,
-          margin-bottom: $page-header-title-margin-top,
+          margin-bottom: $page-header-title-margin-bottom,
           letter-spacing: 0
         )
       );


### PR DESCRIPTION
The `margin-bottom` value had the same variable as the `margin-top` value. Now it uses the correct variable for the corresponding value how can specified themes.