### PR TITLE
Fix page transition effects in Chrome 66 and above

### DIFF
--- a/app/assets/stylesheets/pageflow/page_transitions/fade.scss
+++ b/app/assets/stylesheets/pageflow/page_transitions/fade.scss
@@ -18,7 +18,6 @@ section.fade {
   .backgroundArea {
     background-color: black;
     -webkit-backface-visibility: hidden;
-    @include transition (opacity 1s ease);
   }
 
   &.invert .backgroundArea {
@@ -29,25 +28,28 @@ section.fade {
     opacity: 0;
   }
   &.animate-out-forwards .backgroundArea{
+    @include transition (opacity 1s ease);
     opacity: 1;
   }
   &.animate-in-backwards .backgroundArea{
     opacity: 0;
   }
   &.animate-out-backwards .backgroundArea{
+    @include transition (opacity 1s ease);
     opacity: 1;
   }
 
   &.active .backgroundArea {
+    @include transition (opacity 1s ease);
     opacity: 1;
   }
 
   .content {
-    @include transition(1s ease);
     -webkit-backface-visibility: hidden;
   }
 
   &.active div.content {
+    @include transition(1s ease);
     @include transform(translate3d(0,0,0));
   }
 
@@ -60,6 +62,7 @@ section.fade {
   }
   &.animate-out-forwards {
     .content {
+      @include transition(1s ease);
       @include transform(translate3d(0,-100%,0));
     }
   }
@@ -72,6 +75,7 @@ section.fade {
   }
   &.animate-out-backwards {
     .content {
+      @include transition(1s ease);
       @include transform(translate3d(0,100%,0));
     }
   }

--- a/app/assets/stylesheets/pageflow/page_transitions/fade_to_black.scss
+++ b/app/assets/stylesheets/pageflow/page_transitions/fade_to_black.scss
@@ -37,7 +37,6 @@ section.fade_to_black {
     opacity: 0;
     background-color: black;
     -webkit-backface-visibility: hidden;
-    @include transition(opacity 1s ease 1s);
   }
 
   &.invert .backgroundArea {
@@ -53,7 +52,6 @@ section.fade_to_black {
   }
   &.animate-in-backwards .backgroundArea{
     opacity: 0;
-    @include transition(1s ease 1s);
   }
   &.animate-out-backwards .backgroundArea{
     opacity: 0;
@@ -66,14 +64,8 @@ section.fade_to_black {
   }
 
   .content {
-    @include transition(1s ease);
     -webkit-backface-visibility: hidden;
     opacity: 0;
-  }
-
-  &.active .backgroundArea {
-    opacity: 1;
-    @include transition(1s ease 1s);
   }
 
   &.active div.content {
@@ -95,7 +87,6 @@ section.fade_to_black {
   &.animate-in-backwards {
     .content {
       opacity: 0;
-      @include transition(1s ease 1s);
     }
   }
   &.animate-out-backwards {

--- a/app/assets/stylesheets/pageflow/slideshow.scss
+++ b/app/assets/stylesheets/pageflow/slideshow.scss
@@ -63,7 +63,6 @@
 
     z-index: 2;
     overflow: hidden;
-    @include transition(0.5s ease);
   }
 
   .page.hidden_by_overlay .content {

--- a/app/assets/stylesheets/pageflow/themes/default/player_controls/slim/container.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/player_controls/slim/container.scss
@@ -7,7 +7,7 @@ $slim-player-controls-typography: $player-controls-typography !default;
 
 %player_controls {
   &-container,
-  &-background {
+  &-background::after {
     @include transition(opacity 0.2s linear, visibility 0.2s linear);
   }
 


### PR DESCRIPTION
Ensure `content` and `backgroundArea` only have transitions applied
when they are actually being animated. Otherwise they might be visible
when we want to move them out of the view quickly.

For page transitions CSS this means only applying `transition` when

- the `active` class is present (for animating a page into view)

- an `animate-out-*` class is present (for animating a page out of
  view when it no longer has the `active` class.

`animate-in-*` classes are applied before the `active` class and are
used to move the page out of the viewport before the animation
begins. This needs to happen immediately.

For historic reasons, a redundant transition declaration was applied
in `slideshow.scss` that had to be removed. The different page
transitions need to handle this themselves.

Also the slim player controls applied a transition to the page
background to fade the pseudo element that is used as a shadow behind
the player controls. It is enough to apply the transition to the
pseudo element itself.