### PR TITLE
Fix handling of null object in presence validation

### DIFF
--- a/app/models/pageflow/null_user.rb
+++ b/app/models/pageflow/null_user.rb
@@ -11,5 +11,9 @@ module Pageflow
     def blank?
       true
     end
+
+    def to_ary
+      []
+    end
   end
 end

--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -43,13 +43,11 @@ module Pageflow
     scope :user_snapshots, -> { where(snapshot_type: 'user') }
     scope :auto_snapshots, -> { where(snapshot_type: 'auto') }
 
-    validates :entry, :presence => true
+    validates :entry, presence: true
+    validates :creator, presence: true, if: :published?
 
-    # Workaround for https://github.com/rails/rails/issues/33445
-    validates_with ActiveModel::Validations::PresenceValidator, attributes: [:creator], if: :published?
-
-    validate :published_until_unchanged, :if => :published_until_was_in_past?
-    validate :published_until_blank, :if => :published_at_blank?
+    validate :published_until_unchanged, if: :published_until_was_in_past?
+    validate :published_until_blank, if: :published_at_blank?
 
     def main_storyline_chapters
       main_storyline = storylines.first


### PR DESCRIPTION
Implement `to_ary` to make it behave like `nil` when being passed to
`Array.wrap`.