### PR TITLE
Require resque in initializer

### DIFF
--- a/lib/generators/pageflow/resque/templates/resque.rb
+++ b/lib/generators/pageflow/resque/templates/resque.rb
@@ -1,3 +1,6 @@
+require 'resque'
+require 'resque_scheduler'
+
 # Change to use your favorite method of configuration. Consider the
 # dotenv gem to setup your environment with a .env file.
 

--- a/spec/support/pageflow/support.rb
+++ b/spec/support/pageflow/support.rb
@@ -1,5 +1,2 @@
-require 'resque'
-require 'resque_scheduler'
-
 require 'pageflow/dummy'
 require 'pageflow/dom'


### PR DESCRIPTION
This ensures presence of the `Resque` constant during generation
of the dummy app when using `pageflow-support`.