### PR TITLE
Prevent redefining constants by loading files multiple times

### DIFF
--- a/config/initializers/zencoder.rb
+++ b/config/initializers/zencoder.rb
@@ -1,5 +1,4 @@
 require 'zencoder'
-require 'pageflow/zencoder_api'
 
 Pageflow.after_global_configure do |config|
   zencoder_options = config.zencoder_options

--- a/lib/pageflow.rb
+++ b/lib/pageflow.rb
@@ -1,6 +1,7 @@
 require 'pageflow/engine'
 require 'pageflow/global_config_api'
 require 'pageflow/news_item_api'
+require 'pageflow/version'
 
 module Pageflow
   extend GlobalConfigApi

--- a/lib/pageflow/engine.rb
+++ b/lib/pageflow/engine.rb
@@ -64,8 +64,16 @@ module Pageflow
       lib_path = config.root.join('lib')
       matcher = %r{\A#{Regexp.escape(lib_path.to_s)}/(.*)\.rb\Z}
 
+      already_required_files = [
+        'pageflow/engine',
+        'pageflow/global_config_api',
+        'pageflow/news_item_api',
+        'pageflow/version'
+      ]
+
       Dir.glob("#{lib_path}/pageflow/**/*.rb").sort.each do |file|
-        require_dependency(file.sub(matcher, '\1'))
+        logical_path = file.sub(matcher, '\1')
+        require_dependency(logical_path) unless already_required_files.include?(logical_path)
       end
     end
 

--- a/lib/pageflow/zencoder_api.rb
+++ b/lib/pageflow/zencoder_api.rb
@@ -1,7 +1,3 @@
-require 'pageflow/zencoder_output_definition'
-require 'pageflow/zencoder_video_output_definition'
-require 'pageflow/zencoder_audio_output_definition'
-
 module Pageflow
   class ZencoderApi
     class Error < StandardError; end


### PR DESCRIPTION
Remove `require` calls for files that can be auto loaded during
initialization and will be eager loaded in engine.

Do not use `require_dependency` to load files that have
already been required in gemspec or `lib/pageflow.rb`.