### PR TITLE
Fix background color of form buttons in admin action items

### DIFF
--- a/app/assets/stylesheets/pageflow/admin.scss
+++ b/app/assets/stylesheets/pageflow/admin.scss
@@ -1,5 +1,10 @@
 @import "active_admin/searchable_select";
 
+// Needs to be imported before bourbon which redefines functions used
+// by active admin mixins (i.e. `linear-gradient` used by
+// `light-button`)
+@import "pageflow/admin/active_admin_patches";
+
 @import "bourbon";
 @import "pageflow/mixins";
 
@@ -19,25 +24,3 @@
 @import "pageflow/admin/status_tags";
 @import "pageflow/admin/tabs_view";
 @import "pageflow/admin/tooltip_bubble";
-
-#wrapper {
-  overflow: hidden;
-  position: relative;
-}
-
-.action_items {
-  form, div {
-    display: inline;
-  }
-
-  input[type="submit"] {
-    @include light-button;
-    padding: 12px 17px 10px;
-    span.icon { vertical-align: bottom; margin-right: 4px;}
-    margin: 0px;
-  }
-}
-
-.blank_slate_container {
-  margin: 10px 0;
-}

--- a/app/assets/stylesheets/pageflow/admin/active_admin_patches.scss
+++ b/app/assets/stylesheets/pageflow/admin/active_admin_patches.scss
@@ -1,0 +1,21 @@
+#wrapper {
+  overflow: hidden;
+  position: relative;
+}
+
+.action_items {
+  form,
+  div {
+    display: inline;
+  }
+
+  input[type="submit"] {
+    @include light-button;
+    padding: 12px 17px 10px;
+    margin: 0;
+  }
+}
+
+.blank_slate_container {
+  margin: 10px 0;
+}


### PR DESCRIPTION
Extract Active Admin SCSS patches from admin.scss

Ensure patches are imported before Bourbon. We use the `dark-button`
mixin, which in turn uses `linear-gradient`. which is redefined by
Bourbon to do something unrelated.