### PR TITLE
Ensure mobile video poster is displayed on Android

### DIFF
--- a/app/assets/stylesheets/pageflow/page_types/video.scss
+++ b/app/assets/stylesheets/pageflow/page_types/video.scss
@@ -1,4 +1,5 @@
 @import "./video/content_hiding";
+@import "./video/mobile_poster";
 
 .has_native_video_player .page .videoPage .videoWrapper {
   margin-right: 0;
@@ -112,9 +113,5 @@
 }
 
 .js .non_js_video {
-  display: none;
-}
-
-.has_no_native_video_player .videoPage .background_image {
   display: none;
 }

--- a/app/assets/stylesheets/pageflow/page_types/video/mobile_poster.scss
+++ b/app/assets/stylesheets/pageflow/page_types/video/mobile_poster.scss
@@ -1,0 +1,15 @@
+.videoPage .background_image {
+  display: none;
+}
+
+.has_phone_platform {
+  // Show mobile poster only on phone platform
+  .videoPage .background_image {
+    display: block;
+  }
+
+  // But not while playing inline (e.g. on Android)
+  &.has_no_native_video_player .videoPage.should_play .background_image {
+    display: none;
+  }
+}

--- a/node_package/src/media/components/Page.jsx
+++ b/node_package/src/media/components/Page.jsx
@@ -87,6 +87,7 @@ function pageWraperClassName(className, autoplay, textTracks, playerState) {
     'is_control_bar_hovered': playerState.userHoveringControls,
     'is_control_bar_hidden': playerState.controlsHidden,
     'unplayed': playerState.unplayed && !autoplay,
+    'should_play': playerState.shouldPlay,
     'has_played': playerState.hasPlayed
   });
 }


### PR DESCRIPTION
Before the poster was only displayed if the `native_video_player`
feature was present. This is only the case on iPhone.

Now we show the poster on all phone platforms, but hide it while
videos are playing if the `native_video_player` feature is not
present. Otherwise the video being played inline would not be visible.

REDMINE-15810