### PR TITLE
Add percent inputs to background positioning view

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/configuration.js
+++ b/app/assets/javascripts/pageflow/editor/models/configuration.js
@@ -40,25 +40,25 @@ pageflow.Configuration = Backbone.Model.extend({
   },
 
   getFilePosition: function(attribute, coord) {
-    var propertyName = this._filePositionProperty(attribute, coord);
+    var propertyName = this.filePositionProperty(attribute, coord);
     return this.has(propertyName) ? this.get(propertyName) : 50;
   },
 
   setFilePosition: function(attribute, coord, value) {
-    var propertyName = this._filePositionProperty(attribute, coord);
+    var propertyName = this.filePositionProperty(attribute, coord);
     this.set(propertyName, value);
   },
 
   setFilePositions: function(attribute, x, y) {
     var attributes = {};
 
-    attributes[this._filePositionProperty(attribute, 'x')] = x;
-    attributes[this._filePositionProperty(attribute, 'y')] = y;
+    attributes[this.filePositionProperty(attribute, 'x')] = x;
+    attributes[this.filePositionProperty(attribute, 'y')] = y;
 
     this.set(attributes);
   },
 
-  _filePositionProperty: function(attribute, coord) {
+  filePositionProperty: function(attribute, coord) {
     return attribute.replace(/_id$/, '_' + coord);
   },
 

--- a/app/assets/javascripts/pageflow/editor/templates/background_positioning_sliders.jst.ejs
+++ b/app/assets/javascripts/pageflow/editor/templates/background_positioning_sliders.jst.ejs
@@ -3,4 +3,12 @@
   </div>
   <div class="slider vertical">
   </div>
+  <div class="percent horizontal">
+    <input type="number" min="0" max="100">
+    %
+  </div>
+  <div class="percent vertical">
+    <input type="number" min="0" max="100">
+    %
+  </div>
 </div>

--- a/app/assets/javascripts/pageflow/editor/views/background_positioning_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/background_positioning_view.js
@@ -63,5 +63,5 @@ pageflow.BackgroundPositioningView = Backbone.Marionette.ItemView.extend({
 });
 
 pageflow.BackgroundPositioningView.open = function(options) {
-  pageflow.app.dialogRegion.show(new pageflow.BackgroundPositioningView(options).render());
+  pageflow.app.dialogRegion.show(new pageflow.BackgroundPositioningView(options));
 };

--- a/app/assets/stylesheets/pageflow/editor/background_positioning.scss
+++ b/app/assets/stylesheets/pageflow/editor/background_positioning.scss
@@ -47,7 +47,7 @@
 
   .wrapper {
     text-align: center;
-    margin: 20px;
+    margin: 35px;
   }
 
   .previews {
@@ -96,6 +96,7 @@
   .slider {
     position: absolute;
     border: none;
+    background: #ddd;
 
     a {
       @include background-icon-center($font-size: 20px);
@@ -113,10 +114,10 @@
     }
 
     &.horizontal {
-      bottom: 0;
-      left: 40px;
-      right: 40px;
-      height: 0;
+      bottom: -10px;
+      left: 9px;
+      right: 11px;
+      height: 2px;
 
       a {
         @include transform(rotate(90deg));
@@ -126,16 +127,39 @@
     }
 
     &.vertical {
-      right: 0;
-      top: 40px;
-      bottom: 40px;
-      width: 0;
+      right: -10px;
+      top: 12px;
+      bottom: 11px;
+      width: 2px;
       height: auto;
 
       a {
         margin-left: -20px;
         margin-bottom: -20px;
       }
+    }
+  }
+
+  .percent {
+    position: absolute;
+    font-size: 12px;
+    white-space: nowrap;
+
+    input {
+      width: 45px;
+      height: 25px;
+      box-sizing: border-box;
+      text-align: right;
+    }
+
+    &.horizontal {
+      left: -65px;
+      bottom: -26px;
+    }
+
+    &.vertical {
+      left: 100%;
+      top: -30px;
     }
   }
 


### PR DESCRIPTION
Allow giving exact values. This is useful to ensure background positions are the same on subsequent pages that use the same image.