### PR TITLE
Hyphenate narrow headers by default

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/page.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page.scss
@@ -84,6 +84,7 @@ $page-content-text-font-size: 1.2em !default;
 $page-content-text-line-height: 1.5em !default;
 
 @import "./page/anchors";
+@import "./page/hyphenate";
 @import "./page/paddings";
 @import "./page/scroller";
 @import "./page/shadow";

--- a/app/assets/stylesheets/pageflow/themes/default/page/hyphenate.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/hyphenate.scss
@@ -1,0 +1,24 @@
+/// Let browser break words in header.
+///
+/// - `"narrow"`: Only allow hyphenating words when header is narrow,
+///   i.e. in portrait phone layout.
+///
+/// - `"always"`: Always break words
+///
+/// - `"never"`: Never break words
+$page-hyphenate-header: "narrow" !default;
+
+.page {
+  h2 {
+    @if $page-hyphenate-header == "always" {
+
+      hyphens: auto;
+
+    } @else if $page-hyphenate-header == "narrow" {
+
+      @include phone_portrait {
+        hyphens: auto;
+      }
+    }
+  }
+}


### PR DESCRIPTION
In portrait phone layout, the most problems with long words in headers
come up. Allow browser to break words.