### PR TITLE
Limit number of prepared pages

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/adjacent_preparer.js
+++ b/app/assets/javascripts/pageflow/slideshow/adjacent_preparer.js
@@ -1,8 +1,10 @@
 //= require ./adjacent_pages
 
 pageflow.AdjacentPreparer = pageflow.Object.extend({
-  initialize: function(adjacentPages) {
+  initialize: function(adjacentPages, settings, debugMode) {
     this.adjacentPages = adjacentPages;
+    this.settings = settings || new Backbone.Model();
+    this.debugMode = debugMode;
   },
 
   attach: function(events) {
@@ -17,7 +19,10 @@ pageflow.AdjacentPreparer = pageflow.Object.extend({
   },
 
   prepareAdjacent: function(page) {
-    var adjacentPages = this.adjacentPages.of(page);
+    var max = this.settings.has('max_prepared_adjacent_pages') && this.debugMode ?
+              this.settings.get('max_prepared_adjacent_pages') :
+              5;
+    var adjacentPages = _.first(this.adjacentPages.of(page), max);
     var noLongerPreparedPages = _.difference(this.lastPreparedPages, adjacentPages, [page]);
     var newAdjacentPages = _.difference(adjacentPages, this.lastPreparedPages);
 
@@ -41,6 +46,8 @@ pageflow.AdjacentPreparer.create = function(pages, scrollNavigator) {
     new pageflow.AdjacentPages(
       pages,
       scrollNavigator
-    )
+    ),
+    pageflow.settings,
+    pageflow.debugMode()
   );
 };

--- a/spec/javascripts/pageflow/slideshow/adjacent_preparer_spec.js
+++ b/spec/javascripts/pageflow/slideshow/adjacent_preparer_spec.js
@@ -13,6 +13,47 @@ describe('pageflow.AdjacentPreparer', function() {
       expect(adjacentPage.prepare).to.have.been.called;
     });
 
+    it('limits maximal number of prepared pages', function() {
+      var page = fakePage({id: 'current'});
+      var pages = _.times(10, function() { return fakePage() });
+      var adjacentPages = fakeAdjacentPages([page, pages]);
+      var adjacentPreparer = new p.AdjacentPreparer(adjacentPages);
+
+      adjacentPreparer.prepareAdjacent(page);
+
+      expect(pages[0].prepare).to.have.been.called;
+      expect(pages[1].prepare).to.have.been.called;
+      expect(pages[9].prepare).not.to.have.been.called;
+    });
+
+    it('supports configuring limit via setting in debugMode', function() {
+      var page = fakePage({id: 'current'});
+      var pages = _.times(2, function() { return fakePage() });
+      var adjacentPages = fakeAdjacentPages([page, pages]);
+      var settings = new Backbone.Model();
+      var adjacentPreparer = new p.AdjacentPreparer(adjacentPages, settings, true);
+
+      settings.set('max_prepared_adjacent_pages', 1);
+      adjacentPreparer.prepareAdjacent(page);
+
+      expect(pages[0].prepare).to.have.been.called;
+      expect(pages[1].prepare).not.to.have.been.called;
+    });
+
+    it('ignores setting when not in debugMode', function() {
+      var page = fakePage({id: 'current'});
+      var pages = _.times(2, function() { return fakePage() });
+      var adjacentPages = fakeAdjacentPages([page, pages]);
+      var settings = new Backbone.Model();
+      var adjacentPreparer = new p.AdjacentPreparer(adjacentPages, settings);
+
+      settings.set('max_prepared_adjacent_pages', 1);
+      adjacentPreparer.prepareAdjacent(page);
+
+      expect(pages[0].prepare).to.have.been.called;
+      expect(pages[1].prepare).to.have.been.called;
+    });
+
     it('does not call prepare for previously prepared pages which are also adjacent of current page', function() {
       var lastPage = fakePage();
       var page = fakePage();


### PR DESCRIPTION
Requests can queue up when preparing too many video pages at once.

REDMINE-15823