### PR TITLE
Improve initial password workflow for invitations

### DIFF
--- a/app/controllers/pageflow/admin/initial_passwords_controller.rb
+++ b/app/controllers/pageflow/admin/initial_passwords_controller.rb
@@ -1,0 +1,8 @@
+module Pageflow
+  module Admin
+    class InitialPasswordsController < Devise::PasswordsController
+      layout 'active_admin_logged_out'
+      helper ActiveAdmin::ViewHelpers
+    end
+  end
+end

--- a/app/views/pageflow/admin/initial_passwords/edit.html.erb
+++ b/app/views/pageflow/admin/initial_passwords/edit.html.erb
@@ -1,0 +1,16 @@
+<div id="login">
+  <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> - <%= title t('pageflow.initial_password.title') %></h2>
+
+  <%= devise_error_messages! %>
+  <%= active_admin_form_for(resource, as: resource_name, url: admin_initial_password_path, html: { method: :put }) do |f|
+    f.inputs do
+      f.input :password
+      f.input :password_confirmation
+      f.input :reset_password_token, as: :hidden, input_html: { value: resource.reset_password_token }
+    end
+    f.actions do
+      f.action :submit, label: t('pageflow.initial_password.submit'), button_html: { value: t('pageflow.initial_password.submit') }
+    end
+  end
+  %>
+</div>

--- a/app/views/pageflow/user_mailer/invitation.html.erb
+++ b/app/views/pageflow/user_mailer/invitation.html.erb
@@ -2,8 +2,8 @@
 
 <p><%= t('.instruction') %></p>
 
-<p><%= link_to main_app.edit_user_password_url(@user, reset_password_token: @password_token),
-               main_app.edit_user_password_url(@user, reset_password_token: @password_token) %></p>
+<p><%= link_to edit_admin_initial_password_url(reset_password_token: @password_token),
+               edit_admin_initial_password_url(reset_password_token: @password_token) %></p>
 
 <p><%= t('.ending') %></p>
 

--- a/app/views/pageflow/user_mailer/invitation.text.erb
+++ b/app/views/pageflow/user_mailer/invitation.text.erb
@@ -2,7 +2,7 @@
 
 <%= t('.instruction') %>
 
-<%= main_app.edit_user_password_url(@user, reset_password_token: @password_token) %>
+<%= edit_admin_initial_password_url(reset_password_token: @password_token) %>
 
 <%= t('.ending') %>
 

--- a/config/locales/new/initial_password.de.yml
+++ b/config/locales/new/initial_password.de.yml
@@ -1,0 +1,5 @@
+de:
+  pageflow:
+    initial_password:
+      title: "Passwort festlegen"
+      submit: "Speichern und anmelden"

--- a/config/locales/new/initial_password.en.yml
+++ b/config/locales/new/initial_password.en.yml
@@ -1,0 +1,5 @@
+en:
+  pageflow:
+    initial_password:
+      title: "Set your password"
+      submit: "Save and sign in"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,12 @@ Pageflow::Engine.routes.draw do
       resource :edit_lock
     end
 
+    namespace :admin do
+      devise_scope :user do
+        resource :initial_password, only: [:edit, :update]
+      end
+    end
+
     namespace :editor do
       resources :entries, :only => :index, :shallow => true do
         get :seed, :on => :member


### PR DESCRIPTION
When a user clicks the link in an invitation mail, we used to send
them to the edit password page. The wording of that page is tailored
to the case when users actually want to recover their password - not
for setting a password while accepting an invitation.

In particular the view contained a "Sign in" link which lead to the
normal sign in page. Invited users sometimes clicked the link instead
of saving the password.

Subclass `Devise::PasswordsController` to use a customized view. Adapt
the wording. Remove the "Sign in" link.

REDMINE-15682