### PR TITLE
Add factory_bot dependency to pageflow-support

### DIFF
--- a/spec/support/pageflow-support.gemspec
+++ b/spec/support/pageflow-support.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mysql2', '~> 0.5.2'
 
   s.add_runtime_dependency 'domino', '~> 0.7.0'
+  s.add_runtime_dependency 'factory_bot', '~> 4.8'
 
   s.add_runtime_dependency 'listen', '~> 3.0'
   s.add_runtime_dependency 'bootsnap', '~> 1.0'

--- a/spec/support/pageflow/support.rb
+++ b/spec/support/pageflow/support.rb
@@ -1,2 +1,4 @@
+require 'factory_bot'
+
 require 'pageflow/dummy'
 require 'pageflow/dom'


### PR DESCRIPTION
Ensure Factory Bot is loaded before Pageflow engine to make Pageflow
append its factory definitions path.