### PR TITLE
Improve transient references

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/mixins/transient_references.js
+++ b/app/assets/javascripts/pageflow/editor/models/mixins/transient_references.js
@@ -38,9 +38,18 @@ pageflow.transientReferences = {
 
   _setIdOnceSynced: function(attribute, record) {
     record.once('change:id', function() {
-      delete this.transientReferences[attribute];
-      this.set(attribute, record.id);
+      this._onceRecordCanBeFoundInCollection(record, function() {
+        delete this.transientReferences[attribute];
+        this.set(attribute, record.id);
+      });
     }, this);
+  },
+
+  _onceRecordCanBeFoundInCollection: function(record, callback) {
+    // Backbone collections update their modelsById map in the change
+    // event which is dispatched after the `change:<attribute>`
+    // events.
+    record.once('change', _.bind(callback, this));
   },
 
   _listenForReady: function(attribute, record) {
@@ -51,6 +60,7 @@ pageflow.transientReferences = {
         if (record.isReady()) {
           this._cleanUpReadyListener(attribute);
           this.trigger('change');
+          this.trigger('change:' + attribute + ':ready');
         }
       });
     }

--- a/spec/javascripts/models/mixins/transient_references_spec.js
+++ b/spec/javascripts/models/mixins/transient_references_spec.js
@@ -56,6 +56,18 @@ describe('transientReferences', function() {
       expect(changeListener.called).to.be.ok;
     });
 
+    it('triggers change:<attribute>:ready event once the file is ready', function() {
+      var record = new Model(),
+          imageFile = new pageflow.ImageFile(),
+          changeListener = sinon.spy();
+
+      record.setReference('image_file_id', imageFile);
+      record.on('change:image_file_id:ready', changeListener);
+      imageFile.set('state', 'processed');
+
+      expect(changeListener.called).to.be.ok;
+    });
+
     it('does not trigger change event if reference was updated before ready', function() {
       var record = new Model(),
           imageFile = new pageflow.ImageFile(),
@@ -68,6 +80,22 @@ describe('transientReferences', function() {
       imageFile.set('state', 'processed');
 
       expect(changeListener.called).to.equal(false);
+    });
+
+    it('when change event triggers record can already be looked up in collection', function() {
+      var record = new Model(),
+          imageFiles = new Backbone.Collection(),
+          imageFile = new pageflow.ImageFile(),
+          imageFileFromCollection;
+
+      imageFiles.add(imageFile);
+      record.setReference('image_file_id', imageFile);
+      record.on('change', function() {
+        imageFileFromCollection = imageFiles.get(5);
+      });
+      imageFile.set('id', 5);
+
+      expect(imageFileFromCollection).to.equal(imageFile);
     });
   });
 });


### PR DESCRIPTION
* Dispatch event when referenced record becomes ready.

* Prevent updating the foreign key before the referenced record can be
  looked up by id in its collection. This prevents edge cases where
  the updated foreign key is used by an event handler which tries to
  look up the referenced file for further processing.

REDMINE-15957