### PR TITLE
Add view to display unfinished file stages

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/file_stage.js
+++ b/app/assets/javascripts/pageflow/editor/models/file_stage.js
@@ -56,6 +56,11 @@ pageflow.FileStage = Backbone.Model.extend({
   },
 
   localizedDescription: function() {
-    return I18n.t('pageflow.editor.files.stages.' + this.get('name') + '.' + this.get('state'));
+    var prefix = 'pageflow.editor.files.stages.';
+    var suffix = this.get('name') + '.' + this.get('state');
+
+    return I18n.t(prefix + this.file.i18nKey + '.' + suffix, {
+      defaultValue: I18n.t(prefix + suffix)
+    });
   }
 });

--- a/app/assets/javascripts/pageflow/editor/models/mixins/stage_provider.js
+++ b/app/assets/javascripts/pageflow/editor/models/mixins/stage_provider.js
@@ -14,6 +14,15 @@ pageflow.stageProvider = {
 
       return fileStage;
     }, this).reverse().value());
+
+    this.unfinishedStages = new pageflow.SubsetCollection({
+      parent: this.stages,
+      watchAttribute: 'finished',
+
+      filter: function(stage) {
+        return !stage.get('finished');
+      }
+    });
   },
 
   currentStage: function() {

--- a/app/assets/javascripts/pageflow/editor/views/file_stage_item_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/file_stage_item_view.js
@@ -16,6 +16,13 @@ pageflow.FileStageItemView = Backbone.Marionette.ItemView.extend({
   onRender: function() {
     this.update();
     this.$el.addClass(this.model.get('name'));
+
+    if (this.options.standAlone) {
+      this.$el.addClass('stand_alone');
+    }
+    else {
+      this.$el.addClass('indented');
+    }
   },
 
   update: function() {

--- a/app/assets/javascripts/pageflow/editor/views/inputs/file_processing_state_display_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/inputs/file_processing_state_display_view.js
@@ -1,0 +1,60 @@
+pageflow.FileProcessingStateDisplayView = Backbone.Marionette.View.extend({
+  className: 'file_processing_state_display',
+
+  mixins: [pageflow.inputView],
+
+  initialize: function() {
+    if (typeof this.options.collection === 'string') {
+      this.options.collection = pageflow.entry.getFileCollection(
+        pageflow.editor.fileTypes.findByCollectionName(this.options.collection)
+      );
+    }
+
+    this.listenTo(this.model, 'change:' + this.options.propertyName, this._update);
+  },
+
+  render: function() {
+    this._update();
+    return this;
+  },
+
+  _update: function() {
+    if (this.fileStagesView) {
+      this.stopListening(this.file.unfinishedStages);
+
+      this.fileStagesView.close();
+      this.fileStagesView = null;
+    }
+
+    this.file = this._getFile();
+
+    if (this.file) {
+      this.listenTo(this.file.unfinishedStages, 'add remove', this._updateClassNames);
+
+      this.fileStagesView = new pageflow.CollectionView({
+        tagName: 'ul',
+        collection: this.file.unfinishedStages,
+        itemViewConstructor: pageflow.FileStageItemView,
+        itemViewOptions: {
+          standAlone: true
+        }
+      });
+
+      this.appendSubview(this.fileStagesView);
+    }
+
+    this._updateClassNames();
+  },
+
+  _updateClassNames: function() {
+    this.$el.toggleClass('file_processing_state_display-empty', !this._hasItems());
+  },
+
+  _hasItems: function() {
+    return this.file && this.file.unfinishedStages.length;
+  },
+
+  _getFile: function() {
+    return this.model.getReference(this.options.propertyName, this.options.collection);
+  }
+});

--- a/app/assets/javascripts/pageflow/ui/views/mixins/input_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/mixins/input_view.js
@@ -217,11 +217,11 @@ pageflow.inputView = {
     }
 
     function updateVisible(model, value) {
-      view.$el.toggle(isVisible(value));
+      view.$el.toggleClass('input-hidden_via_binding', !isVisible(value));
     }
 
     function isVisible(value) {
-      if (view.options.visibleBindingValue) {
+      if ('visibleBindingValue' in view.options) {
         return value === view.options.visibleBindingValue;
       }
       else if (typeof view.options.visible === 'function') {

--- a/app/assets/stylesheets/pageflow/editor/file_stages.scss
+++ b/app/assets/stylesheets/pageflow/editor/file_stages.scss
@@ -6,10 +6,18 @@
 }
 
 .file_stage_item {
-  @include background-icon-center($left: 20px, $color: #bbb);
-  margin-left: -60px;
-  padding: 10px 0 5px 60px;
   white-space: normal;
+
+  &.indented {
+    @include background-icon-center($left: 20px, $color: #bbb);
+    padding: 10px 0 5px 60px;
+    margin-left: -60px;
+  }
+
+  &.stand_alone {
+    @include background-icon-center($left: 31px, $color: #bbb);
+    padding-left: 70px;
+}
 
   &.action_required,
   &.active {

--- a/app/assets/stylesheets/pageflow/editor/inputs.scss
+++ b/app/assets/stylesheets/pageflow/editor/inputs.scss
@@ -1,2 +1,3 @@
 @import "./inputs/file_input";
+@import "./inputs/file_processing_state_display";
 @import "./inputs/reference";

--- a/app/assets/stylesheets/pageflow/editor/inputs/file_processing_state_display.scss
+++ b/app/assets/stylesheets/pageflow/editor/inputs/file_processing_state_display.scss
@@ -1,0 +1,18 @@
+.file_processing_state_display {
+  position: relative;
+  margin-top: -6px;
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 62px;
+    height: 100%;
+    background-color: #eee;
+  }
+
+  &-empty {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/pageflow/ui/forms.scss
+++ b/app/assets/stylesheets/pageflow/ui/forms.scss
@@ -221,3 +221,7 @@ textarea.short {
 .configuration_editor a {
   text-decoration: underline;
 }
+
+.input-hidden_via_binding {
+  display: none;
+}

--- a/spec/javascripts/models/file_stage_spec.js
+++ b/spec/javascripts/models/file_stage_spec.js
@@ -20,4 +20,26 @@ describe('FileStage', function() {
       expect(fileStage.get('error_message')).to.eq('error message');
     });
   });
+
+  describe('localizedDescription', function() {
+    support.useFakeTranslations({
+      'pageflow.editor.files.stages.uploading.pending': 'Upload pending',
+      'pageflow.editor.files.stages.image_file.uploading.pending': 'Image upload pending'
+    });
+
+    it('constructs translation key from name and state', function() {
+      var file = new Backbone.Model();
+      var fileStage = new pageflow.FileStage({name: 'uploading'}, {file: file});
+
+      expect(fileStage.localizedDescription()).to.eq('Upload pending');
+    });
+
+    it('prefers file model specific translation', function() {
+      var file = new Backbone.Model();
+      file.i18nKey = 'image_file';
+      var fileStage = new pageflow.FileStage({name: 'uploading'}, {file: file});
+
+      expect(fileStage.localizedDescription()).to.eq('Image upload pending');
+    });
+  });
 });

--- a/spec/javascripts/models/mixins/stage_provider_spec.js
+++ b/spec/javascripts/models/mixins/stage_provider_spec.js
@@ -40,6 +40,14 @@ describe('stageProvider', function() {
     expect(model.stages.at(2).finishedStates).to.deep.eq(['finished']);
   });
 
+  it('provides subset collection of unfinished stages', function() {
+    var model = new Model({
+      state: 'check_running'
+    });
+
+    expect(model.unfinishedStages.pluck('name')).to.deep.eq(['checking', 'processing']);
+  });
+
   it('#stages can be function', function() {
     var model = new (Backbone.Model.extend({
       mixins: [pageflow.stageProvider],

--- a/spec/javascripts/pageflow/ui/views/mixins/input_view_spec.js
+++ b/spec/javascripts/pageflow/ui/views/mixins/input_view_spec.js
@@ -223,11 +223,130 @@ describe('pageflow.inputView', function() {
     });
   });
 
-  function createInputView(options) {
-    var view = {options: options};
-    view.model = options.model;
-    _.extend(view, pageflow.inputView);
+  describe('visibleBinding', function() {
+    it('sets hidden class when attribute is false', function() {
+      var view = createInputView({
+        model: new Backbone.Model({active: false}),
+        visibleBinding: 'active'
+      });
 
-    return view;
+      view.render();
+
+      expect(view.$el).to.have.$class('input-hidden_via_binding');
+    });
+
+    it('does not set hidden class when function returns true', function() {
+      var view = createInputView({
+        model: new Backbone.Model({active: true}),
+        visibleBinding: 'active'
+      });
+
+      view.render();
+
+      expect(view.$el).not.to.have.$class('input-hidden_via_binding');
+    });
+
+    it('sets hidden class when attribute changes to false', function() {
+      var view = createInputView({
+        model: new Backbone.Model({active: true}),
+        visibleBinding: 'active'
+      });
+
+      view.render();
+
+      view.model.set('active', false);
+
+      expect(view.$el).to.have.$class('input-hidden_via_binding');
+    });
+
+    describe('with visibleBindingValue option', function() {
+      it('sets hidden class when value of attribute does not match', function() {
+        var view = createInputView({
+          model: new Backbone.Model({hidden: true}),
+          visibleBinding: 'hidden',
+          visibleBindingValue: false
+        });
+
+        view.render();
+
+        expect(view.$el).to.have.$class('input-hidden_via_binding');
+      });
+
+      it('does not set hidden class when value of attribute matches', function() {
+        var view = createInputView({
+          model: new Backbone.Model({hidden: false}),
+          visibleBinding: 'hidden',
+          visibleBindingValue: false
+        });
+
+        view.render();
+
+        expect(view.$el).not.to.have.$class('input-hidden_via_binding');
+      });
+    });
+
+    describe('with function for visible option', function() {
+      it('sets hidden class when function returns false', function() {
+        var view = createInputView({
+          model: new Backbone.Model({hidden: true}),
+          visibleBinding: 'hidden',
+          visible: function(value) { return !value; }
+        });
+
+        view.render();
+
+        expect(view.$el).to.have.$class('input-hidden_via_binding');
+      });
+
+      it('does not set hidden class when function returns true', function() {
+        var view = createInputView({
+          model: new Backbone.Model({hidden: false}),
+          visibleBinding: 'hidden',
+          visible: function(value) { return !value; }
+        });
+
+        view.render();
+
+        expect(view.$el).not.to.have.$class('input-hidden_via_binding');
+      });
+    });
+
+    describe('with boolean for visible option', function() {
+      it('sets hidden class if false', function() {
+        var view = createInputView({
+          model: new Backbone.Model({hidden: true}),
+          visibleBinding: 'hidden',
+          visible: false
+        });
+
+        view.render();
+
+        expect(view.$el).to.have.$class('input-hidden_via_binding');
+      });
+
+      it('does not set hidden if true', function() {
+        var view = createInputView({
+          model: new Backbone.Model({hidden: true}),
+          visibleBinding: 'hidden',
+          visible: true
+        });
+
+        view.render();
+
+        expect(view.$el).not.to.have.$class('input-hidden_via_binding');
+      });
+    });
+  });
+
+  function createInputView(options) {
+    var View = Backbone.Marionette.ItemView.extend({
+      template: function() {
+        return '';
+      }
+    });
+
+    Cocktail.mixin(View, pageflow.inputView);
+
+    return new View(options);
   }
 });

--- a/spec/javascripts/support/dominos/base.js
+++ b/spec/javascripts/support/dominos/base.js
@@ -23,6 +23,15 @@ support.dom.Base.classMethods = function(Constructor) {
       return new Constructor(element);
     },
 
+    findAll: function(view) {
+      var selector = Constructor.prototype.selector;
+      var elements = view.$el.find(selector);
+
+      return elements.map(function() {
+        return new Constructor($(this));
+      }).get();
+    },
+
     findBy: function(predicate, options) {
       var predicateString = options.predicateName ? ' filtered by ' + options.predicateName : '';
       var selector = Constructor.prototype.selector;

--- a/spec/javascripts/support/dominos/editor/file_stage_item_view.js
+++ b/spec/javascripts/support/dominos/editor/file_stage_item_view.js
@@ -1,0 +1,3 @@
+support.dom.FileStageItemView = support.dom.Base.extend({
+  selector: '.file_stage_item'
+});

--- a/spec/javascripts/support/factories.js
+++ b/spec/javascripts/support/factories.js
@@ -148,6 +148,37 @@ support.factories = {
 
   },
 
+  imageFilesFixture: function(options) {
+    var fileTypes = this.fileTypes(function() {
+      this.withImageFileType(options.fileTypeOptions);
+    });
+
+    var fileAttributes = {
+      image_files: [
+        _.extend({
+          id: 1,
+          state: 'processed'
+        }, options.imageFileAttributes)
+      ]
+    };
+
+    var entry = support.factories.entry({}, {
+      files: pageflow.FilesCollection.createForFileTypes(fileTypes,
+                                                         fileAttributes || {}),
+      fileTypes: fileTypes
+    });
+
+    var imageFiles = entry.getFileCollection(
+      fileTypes.findByCollectionName('image_files')
+    );
+
+    return {
+      entry: entry,
+      imageFile: imageFiles.first(),
+      imageFiles: imageFiles
+    };
+  },
+
   imageFile: function(attributes, options) {
     return new pageflow.ImageFile(attributes, _.extend({
       fileType: this.imageFileType()

--- a/spec/javascripts/views/inputs/file_processing_state_display_spec.js
+++ b/spec/javascripts/views/inputs/file_processing_state_display_spec.js
@@ -1,0 +1,45 @@
+describe('pageflow.FileProcessingStateDisplayView', function() {
+  it('displays unfinished file stages', function() {
+    var fixture = support.factories.imageFilesFixture({
+      imageFileAttributes: {
+        id: 5,
+        state: 'processing'
+      }
+    });
+    var model = new pageflow.Configuration({
+      imageFileId: 5
+    });
+    var view = new pageflow.FileProcessingStateDisplayView({
+      collection: fixture.imageFiles,
+      propertyName: 'imageFileId',
+      model: model
+    });
+
+    view.render();
+
+    expect(support.dom.FileStageItemView.findAll(view).length).to.eq(1);
+    expect(view.$el).not.to.have.$class('file_processing_state_display-empty');
+  });
+
+  it('does not display finished file stages', function() {
+    var fixture = support.factories.imageFilesFixture({
+      imageFileAttributes: {
+        id: 5,
+        state: 'processed'
+      }
+    });
+    var model = new pageflow.Configuration({
+      imageFileId: 5
+    });
+    var view = new pageflow.FileProcessingStateDisplayView({
+      collection: fixture.imageFiles,
+      propertyName: 'imageFileId',
+      model: model
+    });
+
+    view.render();
+
+    expect(support.dom.FileStageItemView.findAll(view).length).to.eq(0);
+    expect(view.$el).to.have.$class('file_processing_state_display-empty');
+  });
+});


### PR DESCRIPTION
A view that can be used to display the processing progress of non top
level files inside of configuration editors.

* Adapt CSS of `FileStageItemView` so that the view can be used
  outside of `FileIteView` via a `stand_alone` CSS class.

* Rewrite `inputView` visibility handling to use a CSS class to hide
  the element. This allows views to set additional CSS classes that
  can also hide the element without the inline style overriding
  visibility.

* Create subset collection of unfinished stages in `stageProvider`.

* Add new `FileProcessingStateDisplayView` which displays
  `FileStageItemViews` for all unfinished stages and hides itself if
  there are non left.

* Allow file type specific localized file stage description

REDMINE-15957