### PR TITLE
Custom params for file types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,8 @@ Metrics/AbcSize:
 # Ignore long RSpec describe blocks
 Metrics/BlockLength:
   ExcludedMethods: ['describe', 'context', 'feature']
+  Exclude:
+    - spec/factories/*.rb
 
 # In specs methods using RSpec DSL often become long
 Metrics/MethodLength:

--- a/app/controllers/pageflow/editor/files_controller.rb
+++ b/app/controllers/pageflow/editor/files_controller.rb
@@ -81,6 +81,7 @@ module Pageflow
         file_attachment_params
           .merge(file_configuration_params)
           .merge(file_parent_file_params)
+          .merge(file_custom_params)
       end
 
       def file_reuse_params
@@ -107,6 +108,10 @@ module Pageflow
 
       def file_parent_file_params
         file_params.permit(:parent_file_id, :parent_file_model_type)
+      end
+
+      def file_custom_params
+        file_params.permit(file_type.custom_attributes)
       end
 
       def file_params

--- a/app/models/concerns/pageflow/hosted_file.rb
+++ b/app/models/concerns/pageflow/hosted_file.rb
@@ -71,15 +71,6 @@ module Pageflow
       url
     end
 
-    def cache_key
-      # Ensure the cache key changes when the state changes. There are
-      # cases during processing where the state is updated multiple
-      # times in a single second. Since `cache_key` relies on
-      # `updated_at`, which only is acurate to the second, we need to
-      # prevent caching outdated information.
-      "#{super}-#{state}"
-    end
-
     # @deprecated Write a migration instead
     def self.columns(t)
       t.belongs_to(:entry, index: true)

--- a/app/models/concerns/pageflow/uploaded_file.rb
+++ b/app/models/concerns/pageflow/uploaded_file.rb
@@ -46,5 +46,14 @@ module Pageflow
     def file_type
       Pageflow.config.file_types.find_by_model!(self.class)
     end
+
+    def cache_key
+      # Ensure the cache key changes when the state changes. There are
+      # cases during processing where the state is updated multiple
+      # times in a single second. Since `cache_key` relies on
+      # `updated_at`, which only is acurate to the second, we need to
+      # prevent caching outdated information.
+      "#{super}-#{state}"
+    end
   end
 end

--- a/lib/pageflow/file_type.rb
+++ b/lib/pageflow/file_type.rb
@@ -29,6 +29,10 @@ module Pageflow
     # @return [#call]
     attr_reader :url_templates
 
+    # Attributes that are custom to this file type.
+    # @return {Array<Symbol>}
+    attr_reader :custom_attributes
+
     # Create file type to be returned in {PageType#file_types}.
     #
     # @example
@@ -53,6 +57,9 @@ module Pageflow
     # @option options [#call] :url_templates
     #   Optional. Callable returning a hash of url template strings
     #   indexed by their names.
+    # @option options [Array<Symbol>] :custom_attributes
+    #   Optional. Array of strings containing attribute names that are
+    #   custom to this file type
     def initialize(options)
       @model_string_or_reference = options.fetch(:model)
       @partial = options[:partial]
@@ -61,6 +68,7 @@ module Pageflow
       @nested_file_types = options.fetch(:nested_file_types, [])
       @top_level_type = options.fetch(:top_level_type, false)
       @url_templates = options.fetch(:url_templates, ->() { {} })
+      @custom_attributes = options.fetch(:custom_attributes, [])
     end
 
     # ActiveRecord model that represents the files of this type.

--- a/spec/factories/hosted_files.rb
+++ b/spec/factories/hosted_files.rb
@@ -1,11 +1,14 @@
 module Pageflow
-  class TestHostedFile < ActiveRecord::Base
-    self.table_name = 'test_hosted_files'
-    include HostedFile
-  end
-
   FactoryBot.define do
-    factory :hosted_file, class: TestHostedFile do
+    factory :hosted_file, class: 'Pageflow::TestHostedFile' do
+      transient do
+        used_in { nil }
+      end
+
+      after(:create) do |file, evaluator|
+        create(:file_usage, file: file, revision: evaluator.used_in) if evaluator.used_in
+      end
+
       trait :on_filesystem do
         attachment_on_filesystem { File.open(Engine.root.join('spec', 'fixtures', 'image.png')) }
         attachment_on_s3 { nil }

--- a/spec/pageflow/file_type_spec.rb
+++ b/spec/pageflow/file_type_spec.rb
@@ -71,5 +71,14 @@ module Pageflow
         expect(file_type.editor_partial).to eq('pageflow/editor/image_files/image_file')
       end
     end
+
+    describe '#custom_attributes' do
+      it 'returns passed custom_attributes' do
+        file_type = FileType.new(model: ImageFile,
+                                 custom_attributes: [:neural_network_analysis])
+
+        expect(file_type.custom_attributes).to eq([:neural_network_analysis])
+      end
+    end
   end
 end

--- a/spec/support/helpers/test_file_type.rb
+++ b/spec/support/helpers/test_file_type.rb
@@ -1,0 +1,14 @@
+require 'pageflow/test_page_type'
+
+module Pageflow
+  class TestFileType
+    def self.register(config, options)
+      file_type = FileType.new(model: TestHostedFile, **options)
+
+      page_type = TestPageType.new(name: :test,
+                                   file_types: [file_type])
+
+      config.page_types.register(page_type)
+    end
+  end
+end

--- a/spec/support/helpers/test_hosted_file.rb
+++ b/spec/support/helpers/test_hosted_file.rb
@@ -1,0 +1,6 @@
+module Pageflow
+  class TestHostedFile < ActiveRecord::Base
+    self.table_name = :test_hosted_files
+    include HostedFile
+  end
+end

--- a/spec/support/pageflow/dummy/templates/create_test_hosted_file.rb
+++ b/spec/support/pageflow/dummy/templates/create_test_hosted_file.rb
@@ -1,7 +1,28 @@
 class CreateTestHostedFile < ActiveRecord::Migration[4.2]
   def change
     create_table :test_hosted_files do |t|
-      Pageflow::HostedFile.columns(t)
+      t.belongs_to(:entry, index: true)
+      t.belongs_to(:uploader, index: true)
+
+      t.integer(:parent_file_id)
+      t.string(:parent_file_model_type)
+
+      t.string(:state)
+      t.string(:rights)
+
+      t.string(:attachment_on_filesystem_file_name)
+      t.string(:attachment_on_filesystem_content_type)
+      t.integer(:attachment_on_filesystem_file_size, limit: 8)
+      t.datetime(:attachment_on_filesystem_updated_at)
+
+      t.string(:attachment_on_s3_file_name)
+      t.string(:attachment_on_s3_content_type)
+      t.integer(:attachment_on_s3_file_size, limit: 8)
+      t.datetime(:attachment_on_s3_updated_at)
+
+      t.timestamps
+
+      t.string :custom
     end
   end
 end


### PR DESCRIPTION
Also, file types can now define custom attributes. Custom attributes
serve a different purpose than configuration attributes: Their values
do not change after a file is created. Thus, we can persist them
directly on the file as opposed to on file usages, since constant
attributes need no versioning.

REDMINE-15957