### PR TITLE
Improve files JS API

### DIFF
--- a/app/assets/javascripts/pageflow/editor/collections/files_collection.js
+++ b/app/assets/javascripts/pageflow/editor/collections/files_collection.js
@@ -24,6 +24,10 @@ pageflow.FilesCollection = Backbone.Collection.extend({
     return Backbone.Collection.prototype.fetch.call(this, options);
   },
 
+  findOrCreateBy: function(attributes) {
+    return this.findWhere(attributes) || this.create(attributes, {fileType: this.fileType});
+  },
+
   getEntry: function() {
     return this.entry || pageflow.entry;
   },

--- a/app/assets/javascripts/pageflow/editor/collections/files_collection.js
+++ b/app/assets/javascripts/pageflow/editor/collections/files_collection.js
@@ -25,7 +25,11 @@ pageflow.FilesCollection = Backbone.Collection.extend({
   },
 
   findOrCreateBy: function(attributes) {
-    return this.findWhere(attributes) || this.create(attributes, {fileType: this.fileType});
+    return this.findWhere(attributes) ||
+      this.create(attributes, {
+        noUpload: true,
+        fileType: this.fileType
+      });
   },
 
   getEntry: function() {

--- a/app/assets/javascripts/pageflow/editor/models/entry.js
+++ b/app/assets/javascripts/pageflow/editor/models/entry.js
@@ -102,8 +102,8 @@ pageflow.Entry = Backbone.Model.extend({
     });
   },
 
-  getFileCollection: function(fileType) {
-    return this.files[fileType.collectionName];
+  getFileCollection: function(fileTypeOrFileTypeName) {
+    return this.files[fileTypeOrFileTypeName.collectionName || fileTypeOrFileTypeName];
   },
 
   pollForPendingFiles: function() {

--- a/app/assets/javascripts/pageflow/editor/models/preview_entry_data.js
+++ b/app/assets/javascripts/pageflow/editor/models/preview_entry_data.js
@@ -10,6 +10,11 @@ pageflow.PreviewEntryData = pageflow.EntryData.extend({
     return this.entry.getTheme().get(name);
   },
 
+  getFile: function(collectionName, id) {
+    var file = this.entry.getFileCollection(collectionName).get(id);
+    return file && file.attributes;
+  },
+
   getStorylineConfiguration: function(id) {
     var storyline = this.storylines.get(id);
     return storyline ? storyline.configuration.attributes : {};

--- a/app/assets/javascripts/pageflow/editor/models/uploaded_file.js
+++ b/app/assets/javascripts/pageflow/editor/models/uploaded_file.js
@@ -38,7 +38,12 @@ pageflow.UploadedFile = Backbone.Model.extend({
   },
 
   urlRoot: function() {
-    return this.collection.url();
+    if (this.isNew() && this.options.noUpload) {
+      return this.collection.url() + '/empty';
+    }
+    else {
+      return this.collection.url();
+    }
   },
 
   fileType: function() {

--- a/app/assets/javascripts/pageflow/entry_data.js
+++ b/app/assets/javascripts/pageflow/entry_data.js
@@ -3,6 +3,10 @@ pageflow.EntryData = pageflow.Object.extend({
     throw 'Not implemented';
   },
 
+  getFile: function(collectionName, id) {
+    throw 'Not implemented';
+  },
+
   getPageConfiguration: function(permaId) {
     throw 'Not implemented';
   },

--- a/app/assets/javascripts/pageflow/seed_entry_data.js
+++ b/app/assets/javascripts/pageflow/seed_entry_data.js
@@ -2,6 +2,15 @@ pageflow.SeedEntryData = pageflow.EntryData.extend({
   initialize: function(options) {
     this.theme = options.theme;
 
+    this.files = _(_.keys(options.files || {})).reduce(function(memo, collectionName) {
+      memo[collectionName] = _(options.files[collectionName]).reduce(function(result, file) {
+        result[file.id] = file;
+        return result;
+      }, {});
+
+      return memo;
+    }, {});
+
     this.storylineConfigurations = _(options.storylines).reduce(function(memo, storyline) {
       memo[storyline.id] = storyline.configuration;
       return memo;
@@ -41,6 +50,10 @@ pageflow.SeedEntryData = pageflow.EntryData.extend({
 
   getThemingOption: function(name) {
     return this.theme[name];
+  },
+
+  getFile: function(collectionName, id) {
+    return this.files[collectionName][id];
   },
 
   getChapterConfiguration: function(id) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Pageflow::Engine.routes.draw do
         resources :files,
                   path: 'files/:collection_name',
                   only: [:index, :create, :update, :destroy] do
+          post :empty, on: :collection, to: 'files#create'
           post :reuse, on: :collection
           post :retry, on: :member
         end

--- a/spec/javascripts/collections/files_collection_spec.js
+++ b/spec/javascripts/collections/files_collection_spec.js
@@ -47,6 +47,55 @@ describe('FileCollection', function() {
     });
   });
 
+  describe('#findOrCreateBy', function() {
+    support.useFakeXhr();
+
+    it('creates file if non with matching attributes exists', function() {
+      var fileType = f.fileType();
+      var files = [];
+      var entry = f.entry();
+      var collection = pageflow.FilesCollection.createForFileType(fileType, files, {entry: entry});
+
+      var file = collection.findOrCreateBy({source_image_id: 3});
+      this.requests[0].respond(201, {'Content-Type': 'application/json'}, JSON.stringify({id: 5}));
+
+      expect(file.isNew()).to.eq(false);
+    });
+
+    it('sets attribute on created file', function() {
+      var fileType = f.fileType();
+      var files = [];
+      var entry = f.entry();
+      var collection = pageflow.FilesCollection.createForFileType(fileType, files, {entry: entry});
+
+      var file = collection.findOrCreateBy({source_image_id: 3});
+
+      expect(file.get('source_image_id')).to.eq(3);
+    });
+
+    it('sets fileType on created file', function() {
+      var fileType = f.fileType();
+      var files = [];
+      var entry = f.entry();
+      var collection = pageflow.FilesCollection.createForFileType(fileType, files, {entry: entry});
+
+      var file = collection.findOrCreateBy({source_image_id: 3});
+
+      expect(file.fileType()).to.eq(fileType);
+    });
+
+    it('returns existing file with matching attributes', function() {
+      var fileType = f.fileType();
+      var files = [{file_name: 'existing.png', source_image_id: 3}];
+      var entry = f.entry();
+      var collection = pageflow.FilesCollection.createForFileType(fileType, files, {entry: entry});
+
+      var file = collection.findOrCreateBy({source_image_id: 3});
+
+      expect(file.get('file_name')).to.eq('existing.png');
+    });
+  });
+
   describe('#uploadable', function() {
     it('always contains subset of files with state uploadable', function() {
       var fileType = f.fileType();

--- a/spec/javascripts/models/entry_spec.js
+++ b/spec/javascripts/models/entry_spec.js
@@ -10,6 +10,34 @@ describe('Entry', function() {
     };
   });
 
+  describe('#getFileCollection', function() {
+    it('supports looking up via fileType object', function() {
+      var imageFiles = pageflow.FilesCollection.createForFileType(this.imageFileType, []);
+      var entry = this.buildEntry({}, {
+        files: {
+          image_files: imageFiles
+        }
+      });
+
+      var result = entry.getFileCollection(this.imageFileType);
+
+      expect(result).to.eq(imageFiles);
+    });
+
+    it('supports looking up via fileType collection name', function() {
+      var imageFiles = pageflow.FilesCollection.createForFileType(this.imageFileType, []);
+      var entry = this.buildEntry({}, {
+        files: {
+          image_files: imageFiles
+        }
+      });
+
+      var result = entry.getFileCollection(this.imageFileType.collectionName);
+
+      expect(result).to.eq(imageFiles);
+    });
+  });
+
   describe('#reuseFile', function() {
     support.useFakeXhr();
 

--- a/spec/javascripts/models/preview_entry_data_spec.js
+++ b/spec/javascripts/models/preview_entry_data_spec.js
@@ -26,6 +26,32 @@ describe('pageflow.PreviewEntryData', function() {
     });
   });
 
+  describe('#getFile', function() {
+    it('returns file attributes by collection name and file id', function() {
+      var entry = support.factories.entry({}, {
+        fileTypes: support.factories.fileTypesWithImageFileType(),
+        files: {
+          image_files: pageflow.FilesCollection.createForFileType(
+            support.factories.imageFileType(),
+            [
+              {
+                id: 1,
+                url: 'image.png'
+              }
+            ]
+          )
+        }
+      });
+      var entryData = new p.PreviewEntryData({
+        entry: entry
+      });
+
+      var result = entryData.getFile('image_files', 1);
+
+      expect(result.url).to.eq('image.png');
+    });
+  });
+
   describe('#getStorylineConfiguration', function() {
     it('returns configuration by storyline id', function() {
       var configuration = {title: 'some text'};

--- a/spec/javascripts/pageflow/seed_entry_data_spec.js
+++ b/spec/javascripts/pageflow/seed_entry_data_spec.js
@@ -15,6 +15,25 @@ describe('pageflow.SeedEntryData', function() {
     });
   });
 
+  describe('#getFile', function() {
+    it('returns file attributes by collection name and file id', function() {
+      var entryData = new p.SeedEntryData({
+        files: {
+          image_files: [
+            {
+              id: 1,
+              url: 'image.png'
+            }
+          ]
+        }
+      });
+
+      var result = entryData.getFile('image_files', 1);
+
+      expect(result.url).to.eq('image.png');
+    });
+  });
+
   describe('#getStorylineConfiguration', function() {
     it('returns configruation by chapter id', function() {
       var configuration = {};


### PR DESCRIPTION
* Add `findOrCreateBy` to files collection.

* Allow looking up files collection by file type object not just
  collection name.

* Add `getFile` method to `EntryData` to allow accessing file
  attributes in editor/published entry js consistently.

REDMINE-15957