### PR TITLE
Add shared example to pageflow-support to lint file types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,9 +29,19 @@ Style/FrozenStringLiteralComment:
 Style/LambdaCall:
   Enabled: false
 
+# In specs methods using RSpec DSL often become complex
+Metrics/AbcSize:
+  Exclude:
+    - spec/**/*
+
 # Ignore long RSpec describe blocks
 Metrics/BlockLength:
   ExcludedMethods: ['describe', 'context', 'feature']
+
+# In specs methods using RSpec DSL often become long
+Metrics/MethodLength:
+  Exclude:
+    - spec/**/*
 
 # Do not require class documentation for specs and migrations
 Style/Documentation:

--- a/doc/creating_file_types.md
+++ b/doc/creating_file_types.md
@@ -249,3 +249,19 @@ option to ensure all required image sizes will be generated.
 
 Pageflow automatically takes care of passing thumbails urls to the
 editor and displaying them in the appropriate places.
+
+## Using Shared Examples to Test Integration
+
+Pageflow provides a set of shared examples that can be used in a
+plugin's test suite to ensure the file type integrates correctly:
+
+    require 'spec_helper'
+    require 'pageflow/lint'
+
+    module Pageflow
+      module Panorama
+        Pageflow::Lint.file_type(:image_file,
+                                 create_file_type: -> { Panorama.package_file_type },
+                                 create_file: -> { create(:panorama_package) })
+      end
+    end

--- a/spec/pageflow/built_in_file_type_spec.rb
+++ b/spec/pageflow/built_in_file_type_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+require 'pageflow/lint'
+
 module Pageflow
   describe BuiltInFileType do
     it 'provides a file type under #image' do
@@ -14,4 +16,16 @@ module Pageflow
       expect(BuiltInFileType.audio).to be_a(Pageflow::FileType)
     end
   end
+
+  Pageflow::Lint.file_type('image_file',
+                           create_file_type: -> { BuiltInFileType.image },
+                           create_file: -> { create(:image_file) })
+
+  Pageflow::Lint.file_type('video_file',
+                           create_file_type: -> { BuiltInFileType.video },
+                           create_file: -> { create(:video_file) })
+
+  Pageflow::Lint.file_type('audio_file',
+                           create_file_type: -> { BuiltInFileType.audio },
+                           create_file: -> { create(:audio_file) })
 end

--- a/spec/support/helpers/pageflow_global_config_api_helper.rb
+++ b/spec/support/helpers/pageflow_global_config_api_helper.rb
@@ -1,29 +1,3 @@
-$CUSTOM_PAGEFLOW_CONFIGURE_BLOCK = nil
+require 'pageflow/global_config_api_test_helper'
 
-# This helper allows to register a custom configure block that shall
-# be executed in the context of a test. This is required when testing
-# functionality that calls `Pageflow.config_for`, which builds up a
-# new configuration object. Simply calling `Pageflow.configure` from
-# inside a test does not work since there is no easy way to tear it
-# down after the test.
-module PageflowGlobalConfigApiHelper
-  def pageflow_configure(&block)
-    $CUSTOM_PAGEFLOW_CONFIGURE_BLOCK = block
-    Pageflow.configure!
-  end
-end
-
-Pageflow.configure do |config|
-  if $CUSTOM_PAGEFLOW_CONFIGURE_BLOCK
-    $CUSTOM_PAGEFLOW_CONFIGURE_BLOCK.call(config)
-  end
-end
-
-RSpec.configure do |config|
-  config.include(PageflowGlobalConfigApiHelper)
-
-  config.before do
-    $CUSTOM_PAGEFLOW_CONFIGURE_BLOCK = nil
-    Pageflow.configure!
-  end
-end
+Pageflow::GlobalConfigApiTestHelper.setup

--- a/spec/support/pageflow/global_config_api_test_helper.rb
+++ b/spec/support/pageflow/global_config_api_test_helper.rb
@@ -1,0 +1,53 @@
+module Pageflow
+  # This helper allows to register a custom configure block that shall
+  # be executed in the context of a test. This is required when testing
+  # functionality that calls `Pageflow.config_for`, which builds up a
+  # new configuration object. Simply calling `Pageflow.configure` from
+  # inside a test does not work since there is no easy way to tear it
+  # down after the test.
+  #
+  # @since edge
+  module GlobalConfigApiTestHelper
+    mattr_accessor :custom_configure_block
+
+    # Call as part of test setup to add fixture configuration. Can be
+    # thought of as a test specific `Pageflow.configure`. Can only be
+    # used once per spec (including `before` blocks etc.)
+    #
+    # @example
+    #
+    #   it 'works when the page type is registered'
+    #     pageflow_configure do |config|
+    #       config.page_types.register(Some.page_type)
+    #     end
+    #
+    #     # ...
+    #   end
+    def pageflow_configure(&block)
+      GlobalConfigApiTestHelper.custom_configure_block = block
+      Pageflow.configure!
+    end
+
+    # Call from plugin test suite to make the `pageflow_configure`
+    # helper available and RSpec hooks to apply configuration changes.
+    def self.setup
+      return if @setup
+      @setup = true
+
+      RSpec.configure do |config|
+        config.include(GlobalConfigApiTestHelper)
+
+        config.before(:suite) do
+          Pageflow.configure do |pageflow_config|
+            GlobalConfigApiTestHelper.custom_configure_block&.call(pageflow_config)
+          end
+        end
+
+        config.before do
+          GlobalConfigApiTestHelper.custom_configure_block = nil
+          Pageflow.configure!
+        end
+      end
+    end
+  end
+end

--- a/spec/support/pageflow/lint.rb
+++ b/spec/support/pageflow/lint.rb
@@ -1,0 +1,68 @@
+require 'pageflow/global_config_api_test_helper'
+require 'pageflow/test_page_type'
+
+module Pageflow
+  # Shared examples providing integration level specs for Pageflow
+  # components commonly defined by plugins.
+  #
+  # @since edge
+  module Lint
+    # Ensure file type json partials render correctly.
+    #
+    # @param name [String] File type name to use in spec descriptions
+    # @param create_file_type [#call] Proc creating the file type to test
+    # @param create_file [#call] Proc creating a fixture file of the
+    #   file type
+    #
+    # @example
+    #
+    #   require 'spec_helper'
+    #   require 'pageflow/lint'
+    #
+    #   module SomePlugin
+    #     Pageflow::Lint.file_type('some file type',
+    #                              create_file_type: -> { SomePlugin.file_type },
+    #                              create_file: -> { create(:some_file) })
+    #   end
+    def self.file_type(name, create_file_type:, create_file:)
+      GlobalConfigApiTestHelper.setup
+
+      RSpec.describe "file type #{name}", type: :helper do
+        let(:file_type, &create_file_type)
+
+        let(:file, &create_file)
+
+        before do
+          pageflow_configure do |config|
+            page_type = TestPageType.new(name: :test,
+                                         file_types: [file_type])
+            config.page_types.clear
+            config.page_types.register(page_type)
+          end
+        end
+
+        it 'renders seed json without error' do
+          expect {
+            helper.extend(FilesHelper)
+            helper.render(partial: 'pageflow/files/file',
+                          formats: [:json],
+                          locals: {
+                            file: UsedFile.new(file, FileUsage.new),
+                            file_type: file_type
+                          })
+          }.not_to raise_error
+        end
+
+        it 'renders editor json without error' do
+          helper.extend(FilesHelper)
+          helper.render(partial: 'pageflow/editor/files/file',
+                        formats: [:json],
+                        locals: {
+                          file: UsedFile.new(file, FileUsage.new),
+                          file_type: file_type
+                        })
+        end
+      end
+    end
+  end
+end

--- a/spec/support/pageflow/test_page_type.rb
+++ b/spec/support/pageflow/test_page_type.rb
@@ -1,0 +1,12 @@
+require 'pageflow/page_type'
+
+module Pageflow
+  class TestPageType < PageType
+    attr_reader :name, :file_types
+
+    def initialize(name:, file_types: [])
+      @name = name
+      @file_types = file_types
+    end
+  end
+end


### PR DESCRIPTION
Provide specs that can be used by plugins to ensure that file type
json partials render correctly.

Extract global config api helper and test file/page types into
`pageflow-support`.