### PR TITLE
Add phone emulation mode to editor

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -11,7 +11,7 @@ linters:
     enabled: true
     severity: warning
   ColorVariable:
-    enabled: true
+    enabled: false
   Comment:
     enabled: true
   DebugStatement:

--- a/app/assets/javascripts/pageflow/editor/api/page_type.js
+++ b/app/assets/javascripts/pageflow/editor/api/page_type.js
@@ -50,5 +50,9 @@ pageflow.PageType = pageflow.Object.extend({
         'pageflow.common_page_link_attributes'
       ]
     }, options));
+  },
+
+  supportsPhoneEmulation: function() {
+    return !!this.options.supportsPhoneEmulation;
   }
 });

--- a/app/assets/javascripts/pageflow/editor/initializers/boot.js
+++ b/app/assets/javascripts/pageflow/editor/initializers/boot.js
@@ -12,9 +12,11 @@ pageflow.app.addInitializer(function(options) {
     model: pageflow.entry
   }));
 
-  pageflow.app.indicatorsRegion.show(new pageflow.DisabledAtmoIndicatorView().render());
-  pageflow.app.notificationsRegion.show(new pageflow.NotificationsView().render());
-  pageflow.app.helpButtonRegion.show(new pageflow.HelpButtonView().render());
+  pageflow.app.indicatorsRegion.show(new pageflow.DisabledAtmoIndicatorView());
+  pageflow.app.notificationsRegion.show(new pageflow.NotificationsView());
+  pageflow.app.sidebarFooterRegion.show(new pageflow.SidebarFooterView({
+    model: pageflow.entry
+  }));
 
   Backbone.history.start({root: options.root});
 });
@@ -26,5 +28,5 @@ pageflow.app.addRegions({
   sidebarRegion: 'sidebar .container',
   dialogRegion: '.dialog_container',
   notificationsRegion: 'sidebar .notifications_container',
-  helpButtonRegion: 'sidebar .help_button_container'
+  sidebarFooterRegion: 'sidebar .sidebar_footer_container'
 });

--- a/app/assets/javascripts/pageflow/editor/templates/emulation_mode_button.jst.ejs
+++ b/app/assets/javascripts/pageflow/editor/templates/emulation_mode_button.jst.ejs
@@ -1,0 +1,26 @@
+<div class="emulation_mode_button-menu">
+  <div class="emulation_mode_button-menu_header">
+    <%= I18n.t('pageflow.editor.templates.emulation_mode_button.header') %>
+  </div>
+  <ul>
+    <li class="emulation_mode_button-menu_item emulation_mode_button-desktop">
+      <a class="emulation_mode_button-menu_link">
+        <%= I18n.t('pageflow.editor.templates.emulation_mode_button.desktop') %>
+      </a>
+    </li>
+    <li class="emulation_mode_button-menu_item emulation_mode_button-phone">
+      <a class="emulation_mode_button-menu_link">
+        <%= I18n.t('pageflow.editor.templates.emulation_mode_button.phone') %>
+        <div class="emulation_mode_button-disabled_hint">
+          <%= I18n.t('pageflow.editor.templates.emulation_mode_button.disabled_hint') %>
+        </div>
+      </a>
+    </li>
+  </ul>
+</div>
+<div class="emulation_mode_button-display emulation_mode_button-desktop">
+  <%= I18n.t('pageflow.editor.templates.emulation_mode_button.desktop') %>
+</div>
+<div class="emulation_mode_button-display emulation_mode_button-phone">
+  <%= I18n.t('pageflow.editor.templates.emulation_mode_button.phone') %>
+</div>

--- a/app/assets/javascripts/pageflow/editor/templates/entry_preview.jst.ejs
+++ b/app/assets/javascripts/pageflow/editor/templates/entry_preview.jst.ejs
@@ -1,4 +1,9 @@
-<div class="header"></div>
-<div class="overview"></div>
+<div class="container">
+  <div class="header"></div>
+  <div class="overview"></div>
 
-<div class="entry"></div>
+  <div class="entry"></div>
+</div>
+<div class="navigation_disabled_hint">
+  <%= I18n.t('pageflow.editor.templates.entry_preview.navigation_disabled_hint') %>
+</div>

--- a/app/assets/javascripts/pageflow/editor/views/emulation_mode_button_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/emulation_mode_button_view.js
@@ -1,0 +1,45 @@
+pageflow.EmulationModeButtonView = Backbone.Marionette.ItemView.extend({
+  template: 'templates/emulation_mode_button',
+  className: 'emulation_mode_button',
+
+  ui: {
+    phoneItem: '.emulation_mode_button-phone',
+    desktopItem: '.emulation_mode_button-desktop',
+
+    phoneDisplay: '.emulation_mode_button-display.emulation_mode_button-phone',
+    desktopDisplay: '.emulation_mode_button-display.emulation_mode_button-desktop'
+  },
+
+  events: {
+    'click .emulation_mode_button-desktop a': function() {
+      this.model.unset('emulation_mode');
+    },
+
+    'click .emulation_mode_button-phone a': function() {
+      if (!this.model.get('current_page_supports_emulation_mode')) {
+        return;
+      }
+
+      this.model.set('emulation_mode', 'phone');
+    }
+  },
+
+  modelEvents: {
+    'change:emulation_mode change:current_page_supports_emulation_mode': 'update'
+  },
+
+  onRender: function() {
+    this.update();
+  },
+
+  update: function() {
+    this.ui.phoneItem.toggleClass('disabled',
+                                  !this.model.get('current_page_supports_emulation_mode'));
+
+    this.ui.phoneItem.toggleClass('active', this.model.has('emulation_mode'));
+    this.ui.desktopItem.toggleClass('active', !this.model.has('emulation_mode'));
+
+    this.ui.phoneDisplay.toggleClass('active', this.model.has('emulation_mode'));
+    this.ui.desktopDisplay.toggleClass('active', !this.model.has('emulation_mode'));
+  }
+});

--- a/app/assets/javascripts/pageflow/editor/views/sidebar_footer_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/sidebar_footer_view.js
@@ -1,0 +1,12 @@
+pageflow.SidebarFooterView = Backbone.Marionette.View.extend({
+  className: 'sidebar_footer',
+
+  render: function() {
+    if (pageflow.features.isEnabled('editor_emulation_mode')) {
+      this.appendSubview(new pageflow.EmulationModeButtonView({model: this.model}));
+    }
+
+    this.appendSubview(new pageflow.HelpButtonView());
+    return this;
+  }
+});

--- a/app/assets/javascripts/pageflow/slideshow.js
+++ b/app/assets/javascripts/pageflow/slideshow.js
@@ -44,10 +44,6 @@ pageflow.Slideshow = function($el, configurations) {
     return result;
   }
 
-  function currentPagePermaId() {
-    return parseInt(currentPage.attr('id'), 10);
-  }
-
   this.nextPageExists = function() {
     return this.scrollNavigator.nextPageExists(currentPage, pages);
   };
@@ -73,11 +69,13 @@ pageflow.Slideshow = function($el, configurations) {
   };
 
   this.parentPageExists = function() {
-    return !!pageflow.entryData.getParentPagePermaIdByPagePermaId(currentPagePermaId());
+    return !!pageflow.entryData.getParentPagePermaIdByPagePermaId(this.currentPagePermaId());
   };
 
   this.goToParentPage = function() {
-    this.goToByPermaId(pageflow.entryData.getParentPagePermaIdByPagePermaId(currentPagePermaId()));
+    this.goToByPermaId(pageflow.entryData.getParentPagePermaIdByPagePermaId(
+      this.currentPagePermaId()
+    ));
   };
 
   this.goToById = function(id, options) {
@@ -94,6 +92,18 @@ pageflow.Slideshow = function($el, configurations) {
     options = options || {};
 
     if (page.length && !page.is(currentPage)) {
+      var cancelled = false;
+
+      pageflow.events.trigger('page:changing', {
+        cancel: function() {
+          cancelled = true;
+        }
+      });
+
+      if (cancelled) {
+        return;
+      }
+
       transitionMutex(function() {
         var previousPage = currentPage;
         currentPage = page;
@@ -147,6 +157,10 @@ pageflow.Slideshow = function($el, configurations) {
 
   this.currentPage = function() {
     return currentPage;
+  };
+
+  this.currentPagePermaId = function() {
+    return parseInt(currentPage.attr('id'), 10);
   };
 
   this.currentPageConfiguration = function() {

--- a/app/assets/javascripts/pageflow/slideshow/scroll_indicator_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/scroll_indicator_widget.js
@@ -13,21 +13,18 @@
           fadeTimeout;
 
       function update(page) {
-        if (page.hasClass('scroll_indicator_mode_non') ||
-            (page.hasClass('scroll_indicator_mode_only_next') && direction === 'up') ||
-            (page.hasClass('scroll_indicator_mode_only_back') && direction === 'down')) {
-
-          that.element.hide();
-        }
-        else {
-          that.element.show();
-        }
-
+        that.element.toggleClass('hidden_by_scoll_indicator_mode', hiddenByMode(page));
         that.element.toggleClass('hidden_for_page', hideScrollIndicatorForPage(page));
 
         that.element.toggleClass('invert', invertIndicator(page));
         that.element.toggleClass('horizontal', page.hasClass('scroll_indicator_orientation_horizontal'));
         that.element.toggleClass('available', targetPageExists());
+      }
+
+      function hiddenByMode(page) {
+        return (page.hasClass('scroll_indicator_mode_non') ||
+                (page.hasClass('scroll_indicator_mode_only_next') && direction === 'up') ||
+                (page.hasClass('scroll_indicator_mode_only_back') && direction === 'down'));
       }
 
       function invertIndicator(page) {

--- a/app/assets/stylesheets/pageflow/editor/base.scss
+++ b/app/assets/stylesheets/pageflow/editor/base.scss
@@ -82,6 +82,8 @@
   @import "./page_links";
   @import "./storyline_picker";
   @import "./loading";
+  @import "./sidebar_footer";
+  @import "./emulation_mode_button";
 
   a.publish {
     @include eye-icon;

--- a/app/assets/stylesheets/pageflow/editor/base.scss
+++ b/app/assets/stylesheets/pageflow/editor/base.scss
@@ -7,6 +7,7 @@
 @import "./blank_entry";
 @import "./dialogs";
 @import "./colors";
+@import "./entry_preview";
 @import "./background_positioning";
 @import "./page_selection";
 @import "./files_explorer";

--- a/app/assets/stylesheets/pageflow/editor/emulation_mode_button.scss
+++ b/app/assets/stylesheets/pageflow/editor/emulation_mode_button.scss
@@ -1,0 +1,78 @@
+.emulation_mode_button {
+  @include background-icon-right($color: #444, $font-size: 16px, $top: 4px);
+  @include up-open-icon;
+  float: left;
+  height: 25px;
+  width: 100px;
+
+  &-menu {
+    background-color: #fff;
+    border: solid 1px #aaa;
+    padding: 1px;
+    position: absolute;
+    bottom: 1px;
+    left: 1px;
+    visibility: hidden;
+    width: 200px;
+    z-index: 1;
+  }
+
+  &-menu_header {
+    margin: 3px 6px;
+  }
+
+  &:hover .emulation_mode_button-menu {
+    visibility: visible;
+  }
+
+  &-display {
+    @include background-icon-center($color: #444, $font-size: 16px, $left: 15px);
+    display: none;
+    padding: 5px 10px 5px 30px;
+
+    &.active {
+      display: block;
+    }
+  }
+
+  &-menu_item {
+    @include background-icon-center($color: #444, $font-size: 16px, $left: 15px, $top: 15px);
+  }
+
+  &-menu_link {
+    padding: 7px 35px 7px 35px;
+    display: block;
+
+    &:hover {
+      background-color: #eee;
+    }
+  }
+
+  .active .emulation_mode_button-menu_link {
+    @include background-icon-right($color: #444, $font-size: 12px, $right: 15px, $top: 9px);
+    @include fa-check-icon;
+    pointer-events: none;
+  }
+
+  &-disabled_hint {
+    display: none;
+    font-size: 10px;
+  }
+
+  .disabled {
+    pointer-events: none;
+    opacity: 0.3;
+
+    .emulation_mode_button-disabled_hint {
+      display: block;
+    }
+  }
+
+  &-phone {
+    @include mobile-icon;
+  }
+
+  &-desktop {
+    @include monitor-icon;
+  }
+}

--- a/app/assets/stylesheets/pageflow/editor/entry_preview.scss
+++ b/app/assets/stylesheets/pageflow/editor/entry_preview.scss
@@ -7,12 +7,18 @@
     height: 100%;
   }
 
-  &.emulation_mode_phone > .container {
-    width: 400px;
-    height: 700px;
-    margin: auto;
-    top: 30px;
-    box-shadow: rgba(0, 0, 0, 0.5) 0px 1px 4px 0px
+  &.emulation_mode_phone {
+    > .container {
+      width: 400px;
+      height: 700px;
+      margin: auto;
+      top: 30px;
+      box-shadow: rgba(0, 0, 0, 0.5) 0px 1px 4px 0px;
+    }
+
+    .scroll_next_indicator {
+      display: none;
+    }
   }
 
   .navigation_disabled_hint {

--- a/app/assets/stylesheets/pageflow/editor/entry_preview.scss
+++ b/app/assets/stylesheets/pageflow/editor/entry_preview.scss
@@ -1,0 +1,35 @@
+.entry_preview {
+  background-color: #222;
+  height: 100%;
+
+  .container {
+    position: relative;
+    height: 100%;
+  }
+
+  &.emulation_mode_phone > .container {
+    width: 400px;
+    height: 700px;
+    margin: auto;
+    top: 30px;
+    box-shadow: rgba(0, 0, 0, 0.5) 0px 1px 4px 0px
+  }
+
+  .navigation_disabled_hint {
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    position: absolute;
+    width: 300px;
+    top: 30%;
+    left: 50%;
+    @include transform(translateX(-50%));
+    padding: 10px;
+    border-radius: 5px;
+    z-index: 10;
+    pointer-events: none;
+    opacity: 0;
+    @include transition(opacity 0.2s);
+    text-align: center;
+    font-size: 12px;
+  }
+}

--- a/app/assets/stylesheets/pageflow/editor/help.scss
+++ b/app/assets/stylesheets/pageflow/editor/help.scss
@@ -158,21 +158,11 @@
 }
 
 .editor .help_button {
-  @include background-icon-left($color: #a0c4e0, $font-size: 16px, $left: 5px);
+  @include background-icon-right($color: #a0c4e0, $font-size: 16px, $right: 5px, $top: 5px);
   @include help-circled-icon;
 
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  left: 0;
+  padding: 5px 30px 0 5px;
+  float: right;
   height: 20px;
-  padding: 5px 5px 0px 30px;
-
-  font-family: Helvetica, "Sans-Serif";
-  font-size: 13px;
-
-  border-top: solid 1px #aaa;
-
-  background-color: #fff;
   cursor: pointer;
 }

--- a/app/assets/stylesheets/pageflow/editor/sidebar_footer.scss
+++ b/app/assets/stylesheets/pageflow/editor/sidebar_footer.scss
@@ -1,0 +1,12 @@
+.sidebar_footer {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  left: 0;
+
+  font-family: Helvetica, "Sans-Serif";
+  font-size: 13px;
+
+  border-top: solid 1px #aaa;
+  background-color: #fff;
+}

--- a/app/assets/stylesheets/pageflow/entries.scss
+++ b/app/assets/stylesheets/pageflow/entries.scss
@@ -82,6 +82,10 @@
       visibility: hidden;
     }
 
+    &.hidden_by_scoll_indicator_mode {
+      display: none;
+    }
+
     .bigScreen & {
       opacity: 0;
       visibility: 0;

--- a/app/assets/stylesheets/pageflow/entries.scss
+++ b/app/assets/stylesheets/pageflow/entries.scss
@@ -62,6 +62,10 @@
       right: 15px;
     }
 
+    .emulation_mode_phone & {
+      display: none;
+    }
+
     &.visible {
       pointer-events: all;
       visibility: visible;

--- a/app/views/pageflow/entries/edit.html.erb
+++ b/app/views/pageflow/entries/edit.html.erb
@@ -19,7 +19,7 @@
     <div class="notifications_container"></div>
     <div class="container"></div>
   </div>
-  <div class="help_button_container"></div>
+  <div class="sidebar_footer_container"></div>
 </sidebar>
 
 <div class="dialog_container">

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -6,4 +6,5 @@ Pageflow.configure do |config|
     feature_config.help_entries.register('pageflow.help_entries.storylines', priority: 7)
   end
   config.features.register('selectable_themes')
+  config.features.register('editor_emulation_mode')
 end

--- a/config/locales/new/phone_emulation.de.yml
+++ b/config/locales/new/phone_emulation.de.yml
@@ -1,0 +1,6 @@
+de:
+  pageflow:
+    editor:
+      templates:
+        entry_preview:
+          navigation_disabled_hint: "Seitenwechsel sind innerhalb der Phone Vorschau nicht möglich."

--- a/config/locales/new/phone_emulation.de.yml
+++ b/config/locales/new/phone_emulation.de.yml
@@ -1,6 +1,13 @@
 de:
   pageflow:
+    editor_emulation_mode:
+      feature_name: "Editor Phone Emulationsmodus"
     editor:
       templates:
         entry_preview:
           navigation_disabled_hint: "Seitenwechsel sind innerhalb der Phone Vorschau nicht möglich."
+        emulation_mode_button:
+          header: "Vorschau Modus:"
+          disabled_hint: "Von diesem Seitentyp nicht unterstützt"
+          phone: "Phone"
+          desktop: "Desktop"

--- a/config/locales/new/phone_emulation.en.yml
+++ b/config/locales/new/phone_emulation.en.yml
@@ -1,0 +1,6 @@
+en:
+  pageflow:
+    editor:
+      templates:
+        entry_preview:
+          navigation_disabled_hint: "Page changes not possible in phone preview."

--- a/config/locales/new/phone_emulation.en.yml
+++ b/config/locales/new/phone_emulation.en.yml
@@ -1,6 +1,13 @@
 en:
   pageflow:
+    editor_emulation_mode:
+      feature_name: "Editor phone emulation mode"
     editor:
       templates:
         entry_preview:
           navigation_disabled_hint: "Page changes not possible in phone preview."
+        emulation_mode_button:
+          header: "Preview mode:"
+          disabled_hint: "Not supported by this page type"
+          phone: "Phone"
+          desktop: "Desktop"


### PR DESCRIPTION
* Let page types declare phone emulation support

* Resize entry preview to phone layout

* Prevent slidehshow navigation to other page since it might not
  support phone emulation

* Display message when slideshow navigation is prevented

* Add emulation mode menu to bottom of editor sidebar

REDMINE-15957