### PR TITLE
Validate attachment presence for image and hosted files

### DIFF
--- a/app/controllers/pageflow/editor/files_controller.rb
+++ b/app/controllers/pageflow/editor/files_controller.rb
@@ -19,10 +19,13 @@ module Pageflow
         authorize!(:edit, entry.to_model)
         verify_edit_lock!(entry)
 
-        @file = entry.create_file(file_type.model, create_params)
+        @file = entry.create_file!(file_type.model, create_params)
         @file.publish!
 
         respond_with(:editor, @file)
+      rescue ActiveRecord::RecordInvalid => e
+        debug_log_with_backtrace(e)
+        head :unprocessable_entity
       end
 
       def reuse

--- a/app/models/concerns/pageflow/hosted_file.rb
+++ b/app/models/concerns/pageflow/hosted_file.rb
@@ -7,6 +7,8 @@ module Pageflow
       has_attached_file(:attachment_on_filesystem, Pageflow.config.paperclip_filesystem_default_options)
       has_attached_file(:attachment_on_s3, Pageflow.config.paperclip_s3_default_options)
 
+      validates :attachment, presence: true
+
       do_not_validate_attachment_file_type(:attachment_on_filesystem)
       do_not_validate_attachment_file_type(:attachment_on_s3)
 

--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -35,8 +35,8 @@ module Pageflow
       entry.title
     end
 
-    def create_file(model, attributes)
-      file = model.create(attributes.except(:configuration)) do |f|
+    def create_file!(model, attributes)
+      file = model.create!(attributes.except(:configuration)) do |f|
         f.entry = entry
       end
 

--- a/app/models/pageflow/image_file.rb
+++ b/app/models/pageflow/image_file.rb
@@ -45,6 +45,8 @@ module Pageflow
                                source_file_options: SOURCE_FILE_OPTIONS,
                                convert_options: CONVERT_OPTIONS))
 
+    validates :attachment, presence: true
+
     do_not_validate_attachment_file_type(:unprocessed_attachment)
     do_not_validate_attachment_file_type(:processed_attachment)
 

--- a/spec/models/concerns/pageflow/hosted_file_spec.rb
+++ b/spec/models/concerns/pageflow/hosted_file_spec.rb
@@ -2,6 +2,26 @@ require 'spec_helper'
 
 module Pageflow
   describe HostedFile, perform_jobs: true do
+    it 'is invalid if attachment is missing' do
+      hosted_file = build(:hosted_file, attachment: nil)
+
+      hosted_file.valid?
+
+      expect(hosted_file).to have(1).errors_on(:attachment)
+    end
+
+    it 'is valid if attachment_on_filesystem is present' do
+      hosted_file = build(:hosted_file, :on_filesystem)
+
+      expect(hosted_file).to be_valid
+    end
+
+    it 'is valid if attachment_on_s3 is present' do
+      hosted_file = build(:hosted_file, :uploaded_to_s3)
+
+      expect(hosted_file).to be_valid
+    end
+
     describe '#publish' do
       it 'transitions to uploaded_to_s3 state' do
         hosted_file = create(:hosted_file, :on_filesystem)
@@ -12,7 +32,7 @@ module Pageflow
       end
 
       it 'transitions to uploading_to_s3_failed state on result :error' do
-        hosted_file = create(:hosted_file)
+        hosted_file = create(:hosted_file, :on_filesystem)
 
         allow_any_instance_of(UploadFileToS3Job).to receive(:perform_with_result).and_return(:error)
 
@@ -22,7 +42,7 @@ module Pageflow
       end
 
       it 're-schedules the job on result :pending', perform_jobs: :except_enqued_at do
-        hosted_file = create(:hosted_file)
+        hosted_file = create(:hosted_file, :on_filesystem)
 
         allow_any_instance_of(UploadFileToS3Job)
           .to receive(:perform_with_result).and_return(:pending)

--- a/spec/models/pageflow/draft_entry_spec.rb
+++ b/spec/models/pageflow/draft_entry_spec.rb
@@ -15,12 +15,12 @@ module Pageflow
       end
     end
 
-    describe '#create_file' do
+    describe '#create_file!' do
       it 'creates image_file on draft' do
         entry = create(:entry)
         draft_entry = DraftEntry.new(entry)
 
-        image_file = draft_entry.create_file(ImageFile, {})
+        draft_entry.create_file!(ImageFile, attachment: fixture_file)
 
         expect(entry.draft.reload).to have(1).image_file
       end
@@ -29,9 +29,22 @@ module Pageflow
         entry = create(:entry)
         draft_entry = DraftEntry.new(entry)
 
-        image_file = draft_entry.create_file(ImageFile, {})
+        image_file = draft_entry.create_file!(ImageFile, attachment: fixture_file)
 
         expect(image_file.usage_id).to be_present
+      end
+
+      it 'raises exception if record is invalid' do
+        entry = create(:entry)
+        draft_entry = DraftEntry.new(entry)
+
+        expect {
+          draft_entry.create_file!(ImageFile, {})
+        }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      def fixture_file
+        File.open(Engine.root.join('spec', 'fixtures', 'image.jpg'))
       end
     end
 

--- a/spec/models/pageflow/image_file_spec.rb
+++ b/spec/models/pageflow/image_file_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Pageflow
   describe ImageFile do
     it 'saves image width and height of original attachment' do
-      image_file = create(:image_file, :unprocessed_attachment => File.open(Engine.root.join('spec', 'fixtures', '7x15.png')))
+      image_file = create(:image_file, unprocessed_attachment: fixture_file)
       image_file.reload
 
       expect(image_file.width).to eq(7)
@@ -11,11 +11,24 @@ module Pageflow
     end
 
     it 'sets width and height to nil if image cannot be identied' do
-      image_file = create(:image_file, :attachment => File.open(Engine.root.join('spec', 'fixtures', 'broken.jpg')))
+      image_file = create(:image_file, attachment: broken_fixture_file)
       image_file.reload
 
       expect(image_file.width).to be_nil
       expect(image_file.height).to be_nil
+    end
+
+    it 'is invalid if attachment is missing' do
+      image_file = build(:image_file, unprocessed_attachment: nil)
+
+      image_file.valid?
+      expect(image_file).to have(1).errors_on(:attachment)
+    end
+
+    it 'is valid if unprocessed_attachment is present' do
+      image_file = build(:image_file, unprocessed_attachment: fixture_file)
+
+      expect(image_file).to be_valid
     end
 
     describe '::STYLES#call' do
@@ -56,13 +69,21 @@ module Pageflow
         expect(styles[:panorama_large][1]).to eq(:JPG)
       end
     end
-  end
 
-  describe 'basename' do
-    it 'returns the original file name without extention' do
-      image_file = build(:image_file, processed_attachment_file_name: 'image.jpg')
+    describe 'basename' do
+      it 'returns the original file name without extention' do
+        image_file = build(:image_file, processed_attachment_file_name: 'image.jpg')
 
-      expect(image_file.basename).to eq('image')
+        expect(image_file.basename).to eq('image')
+      end
+    end
+
+    def fixture_file
+      File.open(Engine.root.join('spec', 'fixtures', '7x15.png'))
+    end
+
+    def broken_fixture_file
+      File.open(Engine.root.join('spec', 'fixtures', 'broken.jpg'))
     end
   end
 end


### PR DESCRIPTION
Prevent creating files without attachment. Make `FilesController`
respond with `:unprocessable_entity`.

Before creating a file without attachment lead to an exception of the
form

> no implicit conversion of nil into String

when trying to get the file's basename for entry seed data.

REDMINE-15616