### PR TITLE
Make JSON seed safe to embed in HTML

### DIFF
--- a/app/helpers/pageflow/render_json_helper.rb
+++ b/app/helpers/pageflow/render_json_helper.rb
@@ -23,10 +23,11 @@ module Pageflow
 
     ESCAPED_CHARS = {
       "\u2028" => '\u2028',
-      "\u2029" => '\u2029'
+      "\u2029" => '\u2029',
+      '</' => '<\/'
     }
 
-    ESCAPED_CHARS_REGEX = /[\u2028\u2029]/u
+    ESCAPED_CHARS_REGEX = %r{</|[\u2028\u2029]}u
 
     def sanitize_json(json)
       json.gsub(ESCAPED_CHARS_REGEX, ESCAPED_CHARS)

--- a/spec/helpers/pageflow/entry_json_seed_helper_spec.rb
+++ b/spec/helpers/pageflow/entry_json_seed_helper_spec.rb
@@ -15,6 +15,18 @@ module Pageflow
         expect(result).to include('some\\u2028text')
       end
 
+      it 'escapes closing tags' do
+        revision = create(:revision, :published)
+        storyline = create(:storyline, revision: revision)
+        chapter = create(:chapter, storyline: storyline)
+        create(:page, chapter: chapter, configuration: {text: '</script>'})
+        entry = PublishedEntry.new(create(:entry, published_revision: revision))
+
+        result = helper.entry_json_seed(entry)
+
+        expect(result).to include('<\/script>')
+      end
+
       it 'renders ids of files' do
         entry = PublishedEntry.new(create(:entry, :published))
         video_file = create(:video_file, used_in: entry.revision)


### PR DESCRIPTION
Escape closing tags to prevent closing script tags from causing syntax
errors.

REDMINE-15615