### PR TITLE
Hide scroll indicator during video also on iOS

### DIFF
--- a/node_package/src/media/sagas/index.js
+++ b/node_package/src/media/sagas/index.js
@@ -12,12 +12,12 @@ import {has} from 'utils';
 export default function*(options = {}) {
   const sagas = [
     togglePlaying(),
-    muteBackgroundMediaOnPlayFailed()
+    muteBackgroundMediaOnPlayFailed(),
+    disableScrollIndicatorDuringPlayback()
   ];
 
   if (!options.playsInNativePlayer || !options.playsInNativePlayer()) {
     sagas.push([
-      disableScrollIndicatorDuringPlayback(),
       goToNextPageOnEnd(),
       fadeOutWhenPageWillDeactivate(),
       hasNotBeenPlayingForAMoment()


### PR DESCRIPTION
Otherwise, when using slim player controls, it is not displayed again
on pause or when the video ends.

REDMINE-15847