### PR TITLE
Prevent class name collision in admin tabs view

### DIFF
--- a/app/assets/stylesheets/pageflow/admin/tabs_view.scss
+++ b/app/assets/stylesheets/pageflow/admin/tabs_view.scss
@@ -3,7 +3,7 @@
   background-color: #f4f4f4;
   @include inset-shadow(0, 1px, 4px, #ddd);
 
-  > .tabs {
+  &-tabs {
     @include gradient(#efefef, #dfe1e2);
     box-shadow: 0 1px 1px rgba(0,0,0,0.10), 0 1px 0 0 rgba(255,255,255, 0.8) inset;
     border: solid 1px #c7c7c7;
@@ -37,7 +37,7 @@
     }
   }
 
-  > .tab_container {
+  &-container {
     @include clearfix;
     @extend .panel_contents;
 

--- a/app/views/components/pageflow/admin/tabs_view.rb
+++ b/app/views/components/pageflow/admin/tabs_view.rb
@@ -26,7 +26,7 @@ module Pageflow
       end
 
       def build_tab_list
-        ul(class: 'tabs') do
+        ul(class: 'admin_tabs_view-tabs') do
           tabs.each do |tab|
             build_tab_item(tab)
           end
@@ -66,8 +66,8 @@ module Pageflow
 
       def tab_container_class(tab_name)
         [
-          'tab_container',
-          "#{tab_name}_tab_container",
+          'admin_tabs_view-container',
+          "admin_tabs_view-#{tab_name}_container",
           current_tab?(tab_name) ? 'active' : nil
         ].compact.join(' ')
       end

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -33,7 +33,7 @@ module Admin
           sign_in(user, scope: :user)
           get(:show, params: {id: account.id})
 
-          expect(response.body).to have_selector('.admin_tabs_view .tabs .features')
+          expect(response.body).to have_selector('.admin_tabs_view-tabs .features')
         end
 
         context 'with config.permissions.only_admins_may_update_features' do
@@ -48,7 +48,7 @@ module Admin
             sign_in(user, scope: :user)
             get(:show, params: {id: account.id})
 
-            expect(response.body).not_to have_selector('.admin_tabs_view .tabs .features')
+            expect(response.body).not_to have_selector('.admin_tabs_view-tabs .features')
           end
 
           it 'admin sees features tab' do
@@ -62,7 +62,7 @@ module Admin
             sign_in(user, scope: :user)
             get(:show, params: {id: entry.id})
 
-            expect(response.body).to have_selector('.admin_tabs_view .tabs .features')
+            expect(response.body).to have_selector('.admin_tabs_view-tabs .features')
           end
         end
 
@@ -73,7 +73,7 @@ module Admin
           sign_in(user, scope: :user)
           get(:show, params: {id: account.id})
 
-          expect(response.body).not_to have_selector('.admin_tabs_view .tabs .features')
+          expect(response.body).not_to have_selector('.admin_tabs_view-tabs .features')
         end
       end
 

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -97,8 +97,8 @@ describe Admin::EntriesController do
         sign_in(user, scope: :user)
         get(:show, params: {id: entry.id})
 
-        expect(response.body).to have_selector('.admin_tabs_view .tabs .members')
-        expect(response.body).to have_selector('.admin_tabs_view .tabs .revisions')
+        expect(response.body).to have_selector('.admin_tabs_view-tabs .members')
+        expect(response.body).to have_selector('.admin_tabs_view-tabs .revisions')
       end
 
       it 'account manager sees features tab' do
@@ -109,7 +109,7 @@ describe Admin::EntriesController do
         sign_in(user, scope: :user)
         get(:show, params: {id: entry.id})
 
-        expect(response.body).to have_selector('.admin_tabs_view .tabs .features')
+        expect(response.body).to have_selector('.admin_tabs_view-tabs .features')
       end
 
       context 'with config.permissions.only_admins_may_update_features' do
@@ -125,7 +125,7 @@ describe Admin::EntriesController do
           sign_in(user, scope: :user)
           get(:show, params: {id: entry.id})
 
-          expect(response.body).not_to have_selector('.admin_tabs_view .tabs .features')
+          expect(response.body).not_to have_selector('.admin_tabs_view-tabs .features')
         end
 
         it 'admin sees features tab' do
@@ -139,7 +139,7 @@ describe Admin::EntriesController do
           sign_in(user, scope: :user)
           get(:show, params: {id: entry.id})
 
-          expect(response.body).to have_selector('.admin_tabs_view .tabs .features')
+          expect(response.body).to have_selector('.admin_tabs_view-tabs .features')
         end
       end
 
@@ -151,7 +151,7 @@ describe Admin::EntriesController do
         sign_in(user, scope: :user)
         get(:show, params: {id: entry.id})
 
-        expect(response.body).not_to have_selector('.admin_tabs_view .tabs .features')
+        expect(response.body).not_to have_selector('.admin_tabs_view-tabs .features')
       end
 
       it 'entry manager does not see features tab' do
@@ -161,7 +161,7 @@ describe Admin::EntriesController do
         sign_in(user, scope: :user)
         get(:show, params: {id: entry.id})
 
-        expect(response.body).not_to have_selector('.admin_tabs_view .tabs .features')
+        expect(response.body).not_to have_selector('.admin_tabs_view-tabs .features')
       end
     end
 

--- a/spec/support/dominos/admin/account_page.rb
+++ b/spec/support/dominos/admin/account_page.rb
@@ -13,7 +13,7 @@ module Dom
 
       def features_tab
         within(node) do
-          find('.tabs > .features a')
+          find('.admin_tabs_view-tabs > .features a')
         end
       end
 

--- a/spec/views/components/pageflow/admin/tabs_view_spec.rb
+++ b/spec/views/components/pageflow/admin/tabs_view_spec.rb
@@ -24,7 +24,7 @@ module Pageflow
 
         render(tabs)
 
-        expect(rendered).to have_selector('.admin_tabs_view ul.tabs li.some_tab a')
+        expect(rendered).to have_selector('.admin_tabs_view ul.admin_tabs_view-tabs li.some_tab a')
       end
 
       it 'filters query parameters in tab link' do
@@ -44,7 +44,7 @@ module Pageflow
 
         render(tabs)
 
-        expect(rendered).to have_selector('.admin_tabs_view .tab_container.active .tab_view_component')
+        expect(rendered).to have_selector('.admin_tabs_view-container.active .tab_view_component')
       end
 
       it 'renders tab from tab param as active' do
@@ -56,7 +56,8 @@ module Pageflow
         controller.request.params.merge!(tab: 'other_tab')
         render(tabs)
 
-        expect(rendered).to have_selector('.admin_tabs_view .tab_container.active .other_tab_view_component')
+        expect(rendered)
+          .to have_selector('.admin_tabs_view-container.active .other_tab_view_component')
       end
 
       it 'renders current tab component as active' do
@@ -67,7 +68,8 @@ module Pageflow
 
         render(tabs, current_tab: :other_tab)
 
-        expect(rendered).to have_selector('.admin_tabs_view .tab_container.active .other_tab_view_component')
+        expect(rendered)
+          .to have_selector('.admin_tabs_view-container.active .other_tab_view_component')
       end
 
       it 'also renders inactive tabs' do
@@ -78,7 +80,7 @@ module Pageflow
 
         render(tabs, current_tab: :other_tab)
 
-        expect(rendered).to have_selector('.admin_tabs_view .tab_container .tab_view_component')
+        expect(rendered).to have_selector('.admin_tabs_view-container .tab_view_component')
       end
 
       it 'allows passing arguments to tab view component build method' do
@@ -91,7 +93,8 @@ module Pageflow
 
         render(tabs, build_args: ['custom'])
 
-        expect(rendered).to have_selector('.admin_tabs_view .tab_container .tab_view_component[data-custom="custom"]')
+        expect(rendered)
+          .to have_selector('.admin_tabs_view-container .tab_view_component[data-custom="custom"]')
       end
 
       context 'with :authorize options' do
@@ -102,7 +105,7 @@ module Pageflow
 
           render(tabs, authorize: :see_some_tab)
 
-          expect(rendered).not_to have_selector('.admin_tabs_view ul.tabs li.some_tab a')
+          expect(rendered).not_to have_selector('ul.admin_tabs_view-tabs li.some_tab a')
         end
 
         it 'renders links for tabs we are authorized for' do
@@ -112,7 +115,7 @@ module Pageflow
 
           render(tabs, authorize: :see_some_tab)
 
-          expect(rendered).to have_selector('.admin_tabs_view ul.tabs li.some_tab a')
+          expect(rendered).to have_selector('ul.admin_tabs_view-tabs li.some_tab a')
         end
 
         it 'passes :view action and component class to authorized? method' do


### PR DESCRIPTION
Active Admin tries to apply jQuery UI tabs widgets to elements
matching `.tabs`. Use fully qualified class instead to prevent this.

REDMINE-15764