### PR TITLE
Make js specs fail on js errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,6 @@ gem 'sassc-rails'
 
 # Required for XML serialization in Active Admin
 gem 'activemodel-serializers-xml'
+
+# Make tests fail on JS errors
+gem 'capybara-chromedriver-logger', git: 'https://github.com/codevise/capybara-chromedriver-logger', branch: 'do-not-raise-on-filtered-errors', require: false

--- a/spec/support/config/capybara.rb
+++ b/spec/support/config/capybara.rb
@@ -1,5 +1,6 @@
 require 'capybara/rspec'
 require 'selenium-webdriver'
+require 'capybara/chromedriver/logger'
 
 Capybara.register_driver :selenium_chrome_headless_no_sandbox do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
@@ -12,3 +13,15 @@ Capybara.register_driver :selenium_chrome_headless_no_sandbox do |app|
 end
 
 Capybara.javascript_driver = :selenium_chrome_headless_no_sandbox
+
+Capybara::Chromedriver::Logger.raise_js_errors = true
+Capybara::Chromedriver::Logger.filters = [
+  /bandwidth_probe.*Failed to load resource/i,
+  /Target node has markup rendered by React/i
+]
+
+RSpec.configure do |config|
+  config.after :each, js: true do
+    Capybara::Chromedriver::Logger::TestHooks.after_example!
+  end
+end


### PR DESCRIPTION
Install `capybara-chromedriver-logger`.