### PR TITLE
Introduce widget insert points

### DIFF
--- a/app/models/pageflow/widget.rb
+++ b/app/models/pageflow/widget.rb
@@ -14,14 +14,9 @@ module Pageflow
       record.save!
     end
 
-    def enabled?(options)
-      if options[:scope] == :editor
-        widget_type.enabled_in_editor?
-      elsif options[:scope] == :preview
-        widget_type.enabled_in_preview?
-      else
-        true
-      end
+    def matches?(options)
+      enabled_for_scope?(options[:scope]) &&
+        for_insert_point?(options.fetch(:insert_point, :bottom_of_entry))
     end
 
     def self.copy_all_to(subject)
@@ -40,10 +35,26 @@ module Pageflow
       Resolver.new(config, options).result
     end
 
+    private
+
+    def enabled_for_scope?(scope)
+      if scope == :editor
+        widget_type.enabled_in_editor?
+      elsif scope == :preview
+        widget_type.enabled_in_preview?
+      else
+        true
+      end
+    end
+
+    def for_insert_point?(insert_point)
+      widget_type.insert_point == insert_point
+    end
+
     Resolver = Struct.new(:config, :options) do
       def result
         assign_widget_types(all).select do |widget|
-          widget.enabled?(options)
+          widget.matches?(options)
         end
       end
 

--- a/app/views/pageflow/entries/_entry.html.erb
+++ b/app/views/pageflow/entries/_entry.html.erb
@@ -17,5 +17,5 @@
 
   <%= render 'pageflow/entries/header', :entry => entry %>
   <%= render 'pageflow/entries/overview', :entry => entry %>
-  <%= render_widgets(entry, :scope => widget_scope) %>
+  <%= render_widgets(entry, scope: widget_scope, insert_point: :bottom_of_entry) %>
 <% end %>

--- a/app/views/pageflow/entries/show.html.erb
+++ b/app/views/pageflow/entries/show.html.erb
@@ -20,6 +20,7 @@
   <%= render 'pageflow/entries/ie8_hint' %>
   <%= render 'pageflow/entries/loading_spinner' %>
   <%= render 'pageflow/entries/multimedia_alert' %>
+  <%= render_widgets(@entry, scope: @widget_scope, insert_point: :before_entry) %>
   <%= render @entry, :widget_scope => @widget_scope %>
 
   <script>

--- a/lib/pageflow/react/widget_type.rb
+++ b/lib/pageflow/react/widget_type.rb
@@ -1,15 +1,20 @@
 module Pageflow
   module React
     class WidgetType < Pageflow::WidgetType
-      attr_reader :name, :role
+      attr_reader :name, :role, :options
 
-      def initialize(name, role)
+      def initialize(name, role, options = {})
         @name = name
         @role = role
+        @options = options
       end
 
       def roles
         [role]
+      end
+
+      def insert_point
+        @options[:insert_point] || super
       end
 
       def render(template, _)

--- a/lib/pageflow/widget_type.rb
+++ b/lib/pageflow/widget_type.rb
@@ -25,6 +25,14 @@ module Pageflow
       true
     end
 
+    # Point in DOM where widget should be inserted. Possible values
+    # are `:bottom_of_entry` (default) or `:before_entry`.
+    #
+    # @since edge
+    def insert_point
+      :bottom_of_entry
+    end
+
     # Override instead of render to use the widget
     # configuration. Return html as string.
     def render_with_configuration(template, entry, _configuration)

--- a/spec/controllers/pageflow/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/entries_controller_spec.rb
@@ -202,7 +202,7 @@ module Pageflow
           expect(response.body).to have_selector('html[lang=de]')
         end
 
-        it 'renders widgets for entry' do
+        it 'renders widgets at bottom of entry' do
           widget_type = TestWidgetType.new(name: 'test_widget',
                                            rendered: '<div class="test_widget"></div>')
 
@@ -215,7 +215,24 @@ module Pageflow
 
           get(:show, params: {id: entry})
 
-          expect(response.body).to have_selector('div.test_widget')
+          expect(response.body).to have_selector('#outer_wrapper > div.test_widget')
+        end
+
+        it 'renders widgets at before_entry insert point' do
+          widget_type = TestWidgetType.new(name: 'test_widget',
+                                           rendered: '<div class="test_widget"></div>',
+                                           insert_point: :before_entry)
+
+          pageflow_configure do |config|
+            config.widget_types.register(widget_type)
+          end
+
+          entry = create(:entry, :published)
+          create(:widget, subject: entry.published_revision, type_name: 'test_widget')
+
+          get(:show, params: {id: entry})
+
+          expect(response.body).to have_selector('body > div.test_widget')
         end
 
         it 'renders widgets which are disabled in editor and preview' do

--- a/spec/models/pageflow/widget_spec.rb
+++ b/spec/models/pageflow/widget_spec.rb
@@ -123,6 +123,36 @@ module Pageflow
 
         expect(widgets).to include_record_with(type_name: nil, role: 'header')
       end
+
+      it 'filters widgets by insert point' do
+        before_widget_type = TestWidgetType.new(name: 'before', insert_point: :before_entry)
+        bottom_widget_type = TestWidgetType.new(name: 'bottom', insert_point: :bottom_of_entry)
+        config = Configuration.new
+        config.widget_types.register(before_widget_type)
+        config.widget_types.register(bottom_widget_type)
+        revision = create(:revision)
+        matching_widget = create(:widget, subject: revision, role: 'header', type_name: 'before')
+        create(:widget, subject: revision, role: 'footer', type_name: 'bottom')
+
+        widgets = revision.widgets.resolve(config, insert_point: :before_entry)
+
+        expect(widgets).to eq([matching_widget])
+      end
+
+      it 'widgets use bottom_of_entry insert point by default' do
+        before_widget_type = TestWidgetType.new(name: 'before', insert_point: :before_entry)
+        bottom_widget_type = TestWidgetType.new(name: 'bottom')
+        config = Configuration.new
+        config.widget_types.register(before_widget_type)
+        config.widget_types.register(bottom_widget_type)
+        revision = create(:revision)
+        create(:widget, subject: revision, role: 'header', type_name: 'before')
+        matching_widget = create(:widget, subject: revision, role: 'footer', type_name: 'bottom')
+
+        widgets = revision.widgets.resolve(config, insert_point: :bottom_of_entry)
+
+        expect(widgets).to eq([matching_widget])
+      end
     end
 
     describe '.batch_update!' do

--- a/spec/support/helpers/test_widget_type.rb
+++ b/spec/support/helpers/test_widget_type.rb
@@ -5,6 +5,7 @@ module Pageflow
     def initialize(options = {})
       @name = options.fetch(:name, 'test_widget')
       @roles = options.fetch(:roles, [])
+      @insert_point = options[:insert_point]
       @enabled_in_editor = options.fetch(:enabled_in_editor, true)
       @enabled_in_preview = options.fetch(:enabled_in_preview, true)
       @rendered = options.fetch(:rendered, '')
@@ -17,6 +18,10 @@ module Pageflow
 
     def enabled_in_preview?
       @enabled_in_preview
+    end
+
+    def insert_point
+      @insert_point || super
     end
 
     def render(template, entry)


### PR DESCRIPTION
Allow inserting widgets before entry. This is a prerequisite to
introduce widget types for different loading spinners.

REDMINE-15907