### PR TITLE
Decouple node package specs from pageflow.backgroundMedia

### DIFF
--- a/node_package/src/__spec__/backgroundMedia-spec.js
+++ b/node_package/src/__spec__/backgroundMedia-spec.js
@@ -1,15 +1,18 @@
-import backgroundMedia from 'backgroundMedia';
+import backgroundMediaModule from 'backgroundMedia';
+import {unmute} from 'backgroundMedia/actions';
 import {muted} from 'backgroundMedia/selectors';
 import createStore from 'createStore';
 import Backbone from 'backbone';
 
 import {expect} from 'support';
+import sinon from 'sinon';
 
 describe('backgroundMedia', () => {
   function setup() {
+    const backgroundMedia = {unmute: sinon.spy()};
     const events = {...Backbone.Events};
 
-    const store = createStore([backgroundMedia], {events});
+    const store = createStore([backgroundMediaModule], {backgroundMedia, events});
 
     return {
       dispatch: store.dispatch.bind(store),
@@ -18,6 +21,7 @@ describe('backgroundMedia', () => {
         return selector(store.getState());
       },
 
+      backgroundMedia,
       events
     };
   }
@@ -47,5 +51,13 @@ describe('backgroundMedia', () => {
     const result = select(muted);
 
     expect(result).to.eq(false);
+  });
+
+  it('calls pageflow.backgroundMedia.unmute on unmute action', () => {
+    const {dispatch, backgroundMedia} = setup();
+
+    dispatch(unmute());
+
+    expect(backgroundMedia.unmute).to.have.been.called;
   });
 });

--- a/node_package/src/backgroundMedia/index.js
+++ b/node_package/src/backgroundMedia/index.js
@@ -22,10 +22,10 @@ export default {
     return {backgroundMedia};
   },
 
-  createSaga: function() {
+  createSaga: function({backgroundMedia}) {
     return function*() {
       yield takeEvery(UNMUTE, function*() {
-        yield call(() => pageflow.backgroundMedia.unmute());
+        yield call(() => backgroundMedia.unmute());
       });
     };
   }

--- a/node_package/src/boot.js
+++ b/node_package/src/boot.js
@@ -51,6 +51,7 @@ export default function(pageflow) {
     events: pageflow.events,
     settings: pageflow.settings,
     widgetsApi: pageflow.widgets,
+    backgroundMedia: pageflow.backgroundMedia,
 
     window: isServerSide ? null : window
   };


### PR DESCRIPTION
Backport of #1052

Pass `backgroundMedia` as part of options in boot instead.