### PR TITLE
Ignore invalid page perma id hash

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow.js
+++ b/app/assets/javascripts/pageflow/slideshow.js
@@ -183,9 +183,10 @@ pageflow.Slideshow = function($el, configurations) {
   function findNewCurrentPage(options) {
     if (!currentPage.length) {
       var permaId = options && options.landingPagePermaId;
+      var landingPage = permaId ? getPageByPermaId(permaId) : $();
 
-      return permaId ?
-        getPageByPermaId(permaId) :
+      return landingPage.length ?
+        landingPage :
         that.scrollNavigator.getLandingPage(pages);
     }
     else if (!currentPage.parent().length) {


### PR DESCRIPTION
Just go to normal landing page, instead of changing the hash to
`undefined` and failing to load.

REDMINE-15001