### PR TITLE
Fix adjacent page lookup for page preloading

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/adjacent_pages.js
+++ b/app/assets/javascripts/pageflow/slideshow/adjacent_pages.js
@@ -9,8 +9,8 @@ pageflow.AdjacentPages = pageflow.Object.extend({
     var pages = this.pages();
     var nextPage = this.nextPage(page);
 
-    if (nextPage.length) {
-      result.push(nextPage.page('instance'));
+    if (nextPage) {
+      result.push(nextPage);
     }
 
     _(page.linkedPages()).each(function(permaId) {


### PR DESCRIPTION
`AdjacentPage#nextPage` already returns a page widget
instance. `AdjacentPage#of` treated it like a jQuery object.

REDMINE-16050