### PR TITLE
Use polyfill to fix Array#reverse in Safari 12

### DIFF
--- a/node_package/package.json
+++ b/node_package/package.json
@@ -57,6 +57,7 @@
     "webpack-dev-server": "^1.16.1"
   },
   "dependencies": {
+    "array-reverse-polyfill": "^1.0.9",
     "babel-polyfill": "^6.2.0",
     "classnames": "^2.1.3",
     "react": "^0.14.3",

--- a/node_package/src/index.js
+++ b/node_package/src/index.js
@@ -1,5 +1,8 @@
 /*global module*/
 
+// Fix Array#reverse in Safari 12
+import 'array-reverse-polyfill';
+
 import * as actions from 'actions';
 import * as components from 'components';
 import * as selectors from 'selectors';


### PR DESCRIPTION
In Safari 12, creating an array via a literal and calling
`Array#reverse` on it causes arrays created from an identical literal
to be reversed as well from that point on. An internal shared
representation of the array literal gets mutated.

https://stackoverflow.com/questions/52390368/array-state-will-be-cached-in-ios-12-safari-is-it-a-bug-or-feature/52392901#52392901

This polyfill detects the bug and overrides `Array#reverse` with a
fixed implementation.

The bug caused video text tracks to switch positions from bottom to
top on each update.

REDMINE-16049