### PR TITLE
Add config option to always redirect to cname of entry

### DIFF
--- a/app/controllers/concerns/pageflow/public_https_mode.rb
+++ b/app/controllers/concerns/pageflow/public_https_mode.rb
@@ -2,12 +2,16 @@ module Pageflow
   module PublicHttpsMode
     protected
 
-    def check_public_https_mode
+    def redirect_according_to_public_https_mode
       if request.ssl? && Pageflow.config.public_https_mode == :prevent
         redirect_to("http://#{request.host}#{request.fullpath}", status: :moved_permanently)
+        true
       elsif !request.ssl? && Pageflow.config.public_https_mode == :enforce
         redirect_to("https://#{request.host}#{request.fullpath}", status: :moved_permanently)
+        true
       end
     end
+
+    alias_method :check_public_https_mode, :redirect_according_to_public_https_mode
   end
 end

--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -5,10 +5,6 @@ module Pageflow
 
     before_action :authenticate_user!, except: [:index, :show, :page]
 
-    before_action :check_public_https_mode,
-                  only: [:index, :show],
-                  unless: lambda { |controller| controller.request.format.json? }
-
     after_action :allow_iframe_for_embed, only: :show
 
     helper_method :render_to_string
@@ -29,6 +25,12 @@ module Pageflow
         format.any(:html, :css) do
           @entry = PublishedEntry.find(params[:id], entry_request_scope)
           I18n.locale = @entry.locale
+
+          if redirect_location = entry_redirect(@entry)
+            return redirect_to(redirect_location, status: :moved_permanently)
+          end
+
+          return if redirect_according_to_public_https_mode
 
           if !request.format.css?
             check_entry_password_protection(@entry)
@@ -95,6 +97,10 @@ module Pageflow
 
     def entry_request_scope
       Pageflow.config.public_entry_request_scope.call(Entry, request)
+    end
+
+    def entry_redirect(entry)
+      Pageflow.config.public_entry_redirect.call(entry, request)
     end
 
     def allow_iframe_for_embed

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -162,6 +162,15 @@ module Pageflow
     #     end
     attr_accessor :public_entry_request_scope
 
+    # Either a lambda or an object with a `call` method taking an
+    # {Entry} record and an {ActionDispatch::Request} object and
+    # returning `nil` or a path to redirect to. Can be used in
+    # conjuction with {PrimaryDomainEntryRedirect} to make sure
+    # entries are accessed via their account's configured cname.
+    #
+    # @since 12.4
+    attr_accessor :public_entry_redirect
+
     # Either a lambda or an object with a `call` method taking a
     # {Theming} as paramater and returing a hash of options used to
     # construct the url of a published entry.
@@ -326,6 +335,7 @@ module Pageflow
 
       @theming_request_scope = CnameThemingRequestScope.new
       @public_entry_request_scope = lambda { |entries, request| entries }
+      @public_entry_redirect = ->(_entry, _request) { nil }
       @public_entry_url_options = Pageflow::ThemingsHelper::DEFAULT_PUBLIC_ENTRY_OPTIONS
       @entry_embed_url_options = {protocol: 'https'}
 

--- a/lib/pageflow/primary_domain_entry_redirect.rb
+++ b/lib/pageflow/primary_domain_entry_redirect.rb
@@ -1,0 +1,25 @@
+module Pageflow
+  # Use as {Configuration#public_entry_redirect} to make sure entries
+  # are accessed via their account's configured cname.
+  #
+  # @since 12.4
+  class PrimaryDomainEntryRedirect
+    def call(entry, request)
+      theming = entry.theming
+
+      if theming.cname.present? &&
+         !known_domains(theming).include?(request.host)
+        [request.protocol, theming.cname, request.fullpath].join
+      end
+    end
+
+    private
+
+    def known_domains(theming)
+      [
+        theming.cname,
+        (theming.additional_cnames || '').split(',').map(&:strip)
+      ].flatten
+    end
+  end
+end

--- a/spec/controllers/pageflow/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/entries_controller_spec.rb
@@ -297,6 +297,51 @@ module Pageflow
           end
         end
 
+        describe 'with configured public_entry_redirect' do
+          it 'redirects to returned location' do
+            entry = create(:entry, :published)
+
+            Pageflow.config.public_entry_redirect = ->(_, _) { '/some_location' }
+
+            get(:show, params: {id: entry})
+
+            expect(response).to redirect_to('/some_location')
+          end
+
+          it 'redirects even before https redirect takes place' do
+            entry = create(:entry, :published)
+
+            Pageflow.config.public_https_mode = :enforce
+            Pageflow.config.public_entry_redirect = ->(_, _) { '/some_location' }
+
+            get(:show, params: {id: entry})
+
+            expect(response).to redirect_to('/some_location')
+          end
+
+          it 'passes entry and request' do
+            some_entry = create(:entry, :published, title: 'My Entry')
+
+            Pageflow.config.public_entry_redirect = lambda do |entry, request|
+              "#{request.protocol}#{request.host}/#{entry.slug}"
+            end
+
+            get(:show, params: {id: some_entry, q: 1})
+
+            expect(response).to redirect_to('http://test.host/my-entry')
+          end
+
+          it 'does not redirect if nil is returned' do
+            entry = create(:entry, :published, title: 'My Entry')
+
+            Pageflow.config.public_entry_redirect = ->(_, _) { nil }
+
+            get(:show, params: {id: entry})
+
+            expect(response.status).to eq(200)
+          end
+        end
+
         context 'with page parameter' do
           it 'renders social sharing meta tags for page' do
             entry = create(:entry, :published)

--- a/spec/pageflow/primary_domain_entry_redirect_spec.rb
+++ b/spec/pageflow/primary_domain_entry_redirect_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+module Pageflow
+  describe PrimaryDomainEntryRedirect do
+    it 'returns primary theming domain when request uses unknown domain' do
+      theming = create(:theming, cname: 'pageflow.example.com')
+      entry = create(:entry, theming: theming)
+      request = request('https://legacy.example.com/some-entry')
+
+      redirect = PrimaryDomainEntryRedirect.new.call(entry, request)
+
+      expect(redirect).to eq('https://pageflow.example.com/some-entry')
+    end
+
+    it 'returns nil when request uses primary theming domain' do
+      theming = create(:theming, cname: 'pageflow.example.com')
+      entry = create(:entry, theming: theming)
+      request = request('https://pageflow.example.com')
+
+      redirect = PrimaryDomainEntryRedirect.new.call(entry, request)
+
+      expect(redirect).to eq(nil)
+    end
+
+    it 'returns nil when request uses additional theming domain' do
+      theming = create(:theming,
+                       cname: 'pageflow.example.com',
+                       additional_cnames: 'extra.example.com, other.example.com')
+      entry = create(:entry, theming: theming)
+      request = request('https://extra.example.com/some-entry')
+
+      redirect = PrimaryDomainEntryRedirect.new.call(entry, request)
+
+      expect(redirect).to eq(nil)
+    end
+
+    it 'returns nil if theming does not have domains' do
+      theming = create(:theming, cname: '')
+      entry = create(:entry, theming: theming)
+      request = request('https://some.example.com/some-entry')
+
+      redirect = PrimaryDomainEntryRedirect.new.call(entry, request)
+
+      expect(redirect).to eq(nil)
+    end
+
+    def request(uri)
+      ActionDispatch::Request.new(Rack::MockRequest.env_for(uri))
+    end
+  end
+end


### PR DESCRIPTION
Add `public_entry_redirect` configuration attribute, to determine
a redirect location based on an entry.

Provide `PrimaryDomainEntryRedirect` implementation that redirect to
entry url using account cname.

REDMINE-16070, REDMINE-15193, REDMINE-15984