### PR TITLE
Run checkbox toggle script for accounts only on new and edit

### DIFF
--- a/app/assets/javascripts/pageflow/admin/accounts.js
+++ b/app/assets/javascripts/pageflow/admin/accounts.js
@@ -1,5 +1,5 @@
 jQuery(function($) {
-  $('.admin_accounts form.pageflow_account').each(function() {
+  $('.admin_accounts').filter('.new, .edit').find('form.pageflow_account').each(function() {
     var themeSelect = $('#account_default_theming_attributes_theme_name', this);
     var themeOptions = JSON.parse($('script#theme_options', this).text());
     var homeButtonCheckBox = $('#account_default_theming_attributes_home_button_enabled_by_default', this);


### PR DESCRIPTION
ActiveAdmin sets the current action as class on the body.
Since the checkbox toggle script is only supposed to be run on the form (i.e. new and edit)
and not on the show view, the selector needs to be narrowed down to these actions.

REDMINE-16109