### PR TITLE
Ensure share-icon-color key can be used in $widget-icon-font-options

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/overview/icons/icon_font.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/overview/icons/icon_font.scss
@@ -4,7 +4,10 @@
 
   $button-icon-color,
   $active-button-icon-color,
-  $deactivated-button-icon-color
+  $deactivated-button-icon-color,
+
+  $share-icon-color: null,
+  $active-share-icon-color: null
 ) {
 
   .button {


### PR DESCRIPTION
Add unused parameters to overview icon font mixin to prevent error
caused by unknown parameters.

REDMINE-15986