### PR TITLE
Extract DelayedStart from pageflow.manualStart

### DIFF
--- a/app/assets/javascripts/pageflow/base.js
+++ b/app/assets/javascripts/pageflow/base.js
@@ -29,6 +29,7 @@
 //= require ./visited
 //= require ./print_layout
 //= require ./history
+//= require ./delayed_start
 //= require ./manual_start
 //= require ./widgets
 //= require ./widget_types

--- a/app/assets/javascripts/pageflow/delayed_start.js
+++ b/app/assets/javascripts/pageflow/delayed_start.js
@@ -1,0 +1,50 @@
+pageflow.DelayedStart = (function($) {
+  return function() {
+    var waitDeferred = new $.Deferred();
+    var promises = [];
+    var performed = false;
+
+    return {
+      promise: function() {
+        return waitDeferred.promise();
+      },
+
+      wait: function(callback) {
+        var cancelled = false;
+
+        waitDeferred.then(function() {
+          if (!cancelled) {
+            callback();
+          }
+        });
+
+        return {
+          cancel: function() {
+            cancelled = true;
+          }
+        };
+      },
+
+      waitFor: function(callbackOrPromise) {
+        if (!performed) {
+          if (typeof callbackOrPromise === 'function') {
+            callbackOrPromise = new $.Deferred(function(deferred) {
+              callbackOrPromise(deferred.resolve);
+            }).promise();
+          }
+
+          promises.push(callbackOrPromise);
+        }
+      },
+
+      perform: function() {
+        if (!performed) {
+          performed = true;
+          $.when.apply(null, promises).then(waitDeferred.resolve);
+        }
+      }
+    };
+  };
+}(jQuery));
+
+pageflow.delayedStart = new pageflow.DelayedStart();

--- a/app/assets/javascripts/pageflow/editor/views/entry_preview_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/entry_preview_view.js
@@ -68,6 +68,8 @@ pageflow.EntryPreviewView = Backbone.Marionette.ItemView.extend({
       simulateHistory: true
     });
 
+    pageflow.delayedStart.perform();
+
     this.listenTo(this.pages, 'add', function() {
       slideshow.update();
     });

--- a/app/assets/javascripts/pageflow/manual_start.js
+++ b/app/assets/javascripts/pageflow/manual_start.js
@@ -4,30 +4,12 @@ pageflow.manualStart = (function($) {
 
   $(function() {
     if (pageflow.manualStart.enabled) {
+      pageflow.delayedStart.waitFor(waitDeferred);
       requiredDeferred.resolve(waitDeferred.resolve);
-    }
-    else {
-      waitDeferred.resolve();
     }
   });
 
   return {
-    wait: function(callback) {
-      var cancelled = false;
-
-      waitDeferred.then(function() {
-        if (!cancelled) {
-          callback();
-        }
-      });
-
-      return {
-        cancel: function() {
-          cancelled = true;
-        }
-      };
-    },
-
     required: function() {
       return requiredDeferred.promise();
     }

--- a/app/assets/javascripts/pageflow/ready.js
+++ b/app/assets/javascripts/pageflow/ready.js
@@ -32,6 +32,7 @@ pageflow.ready = new $.Deferred(function(readyDeferred) {
             $('.multimedia_alert').multimediaAlert();
 
             pageflow.widgetTypes.enhance(body);
+            pageflow.delayedStart.perform();
             pageflow.phoneLandscapeFullscreen();
           }
         });

--- a/app/assets/javascripts/pageflow/slideshow/page_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/page_widget.js
@@ -175,7 +175,7 @@
 
     _triggerDelayedPageTypeHook: function(name) {
       var that = this;
-      var handle = pageflow.manualStart.wait(function() {
+      var handle = pageflow.delayedStart.wait(function() {
         that._triggerPageTypeHook(name);
       });
 

--- a/app/assets/javascripts/pageflow/slideshow/scroll_indicator_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/scroll_indicator_widget.js
@@ -104,7 +104,7 @@
         that.element.removeClass('visible');
       });
 
-      $.when(pageflow.ready, pageflow.manualStart).done(function() {
+      $.when(pageflow.ready, pageflow.delayedStart.promise()).done(function() {
         setTimeout(function() {
           that.element.addClass('attract');
           setTimeout(function() {

--- a/spec/javascripts/pageflow/delayed_start_spec.js
+++ b/spec/javascripts/pageflow/delayed_start_spec.js
@@ -1,0 +1,88 @@
+describe('pageflow.DelayedStart', function() {
+  var DelayedStart = pageflow.DelayedStart;
+
+  it('invokes callbacks registered via #wait on #perform', function() {
+    var delayedStart = new DelayedStart();
+    var callback = sinon.spy();
+
+    delayedStart.wait(callback);
+    delayedStart.perform();
+
+    expect(callback).to.have.been.called;
+  });
+
+  it('delays callbacks by promises passed to #waitFor', function() {
+    var delayedStart = new DelayedStart();
+    var callback = sinon.spy();
+    var deferred = new $.Deferred();
+
+    delayedStart.wait(callback);
+    delayedStart.waitFor(deferred.promise());
+    delayedStart.perform();
+
+    expect(callback).not.to.have.been.called;
+  });
+
+  it('invokes callback when all #waitFor promises are resolved', function() {
+    var delayedStart = new DelayedStart();
+    var callback = sinon.spy();
+    var deferred = new $.Deferred();
+
+    delayedStart.wait(callback);
+    delayedStart.waitFor(deferred.promise());
+    delayedStart.perform();
+    deferred.resolve();
+
+    expect(callback).to.have.been.called;
+  });
+
+  it('resolves #promise on #perform', function() {
+    var delayedStart = new DelayedStart();
+    var callback = sinon.spy();
+
+    delayedStart.promise().then(callback);
+    delayedStart.perform();
+
+    expect(callback).to.have.been.called;
+  });
+
+  it('resolves #promise only after promises passed to #waitFor have been resolved', function() {
+    var delayedStart = new DelayedStart();
+    var callback = sinon.spy();
+    var deferred = new $.Deferred();
+
+    delayedStart.promise().then(callback);
+    delayedStart.waitFor(deferred.promise());
+    delayedStart.perform();
+
+    expect(callback).not.to.have.been.called;
+  });
+
+  it('resolves #promise when all #waitFor promises are resolved', function() {
+    var delayedStart = new DelayedStart();
+    var callback = sinon.spy();
+    var deferred = new $.Deferred();
+
+    delayedStart.promise().then(callback);
+    delayedStart.waitFor(deferred.promise());
+    delayedStart.perform();
+    deferred.resolve();
+
+    expect(callback).to.have.been.called;
+  });
+
+  it('supports passing a function to #waitFor', function() {
+    var delayedStart = new DelayedStart();
+    var callback = sinon.spy();
+    var delayedStartResolve;
+
+    delayedStart.promise().then(callback);
+    delayedStart.waitFor(function(resolve) {
+      delayedStartResolve = resolve;
+    });
+    delayedStart.perform();
+    delayedStartResolve();
+
+    expect(callback).to.have.been.called;
+  });
+});


### PR DESCRIPTION
Manual start is only one way to delay the first page. Provide API to
wait for additional promises before triggering delayed page type
hooks.

REDMINE-16148, REDMINE-15907