### PR TITLE
Play background video silently until page did activate

### DIFF
--- a/app/assets/javascripts/pageflow/media_player/volume_binding.js
+++ b/app/assets/javascripts/pageflow/media_player/volume_binding.js
@@ -7,6 +7,7 @@ pageflow.mediaPlayer.volumeBinding = function(player, settings, options) {
   var volumeFactor = 'volumeFactor' in options ? options.volumeFactor : 1;
 
   player.play = function() {
+    player.intendToPlay();
     player.volume(player.targetVolume());
     listenToVolumeSetting();
 

--- a/app/assets/javascripts/pageflow/widgets/multimedia_alert.js
+++ b/app/assets/javascripts/pageflow/widgets/multimedia_alert.js
@@ -23,6 +23,7 @@
 
         widget.element.find('.close').one('click', function() {
           hide();
+          pageflow.backgroundMedia.unmute();
 
           pageflow.events.trigger('button:close_multimedia_alert');
           start();

--- a/node_package/src/media/actions.js
+++ b/node_package/src/media/actions.js
@@ -6,7 +6,7 @@ export const PLAY_AND_FADE_IN = 'MEDIA_PLAY_AND_FADE_IN';
 export const PAUSE = 'MEDIA_PAUSE';
 export const FADE_OUT_AND_PAUSE = 'MEDIA_FADE_OUT_AND_PAUSE';
 export const PLAY_FAILED = 'MEDIA_PLAY_FAILED';
-export const PLAY_MUTED = 'MEDIA_PLAY_MUTED';
+export const PLAYING_MUTED = 'MEDIA_PLAYING_MUTED';
 
 export const SCRUB_TO = 'MEDIA_SCRUB_TO';
 export const SEEK_TO = 'MEDIA_SEEK_TO';
@@ -75,8 +75,8 @@ export function actionCreators({scope = 'default'} = {}) {
       return pageAction(PLAY_FAILED);
     },
 
-    playMuted() {
-      return pageAction(PLAY_MUTED);
+    playingMuted() {
+      return pageAction(PLAYING_MUTED);
     },
 
 

--- a/node_package/src/media/actions.js
+++ b/node_package/src/media/actions.js
@@ -5,6 +5,9 @@ export const PLAY = 'MEDIA_PLAY';
 export const PLAY_AND_FADE_IN = 'MEDIA_PLAY_AND_FADE_IN';
 export const PAUSE = 'MEDIA_PAUSE';
 export const FADE_OUT_AND_PAUSE = 'MEDIA_FADE_OUT_AND_PAUSE';
+
+export const CHANGE_VOLUME_FACTOR = 'CHANGE_VOLUME_FACTOR';
+
 export const PLAY_FAILED = 'MEDIA_PLAY_FAILED';
 export const PLAYING_MUTED = 'MEDIA_PLAYING_MUTED';
 
@@ -70,6 +73,15 @@ export function actionCreators({scope = 'default'} = {}) {
         fadeDuration
       });
     },
+
+
+    changeVolumeFactor(volumeFactor, {fadeDuration}) {
+      return pageAction(CHANGE_VOLUME_FACTOR, {
+        volumeFactor,
+        fadeDuration
+      });
+    },
+
 
     playFailed() {
       return pageAction(PLAY_FAILED);

--- a/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
+++ b/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
@@ -146,7 +146,7 @@ describe('createFilePlayer', () => {
     [
       {event: 'play', action: 'playing'},
       {event: 'playfailed', action: 'playFailed'},
-      {event: 'playmuted', action: 'playMuted'},
+      {event: 'playmuted', action: 'playingMuted'},
       {event: 'pause', action: 'paused'},
       {event: 'loadedmetadata', action: 'metaDataLoaded', payload: {currentTime: 5, duration: 10}},
       {event: 'progress', action: 'progress', payload: {bufferedEnd: 7}},

--- a/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
+++ b/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
@@ -217,6 +217,17 @@ describe('createFilePlayer', () => {
       expect(mockPlayer.fadeOutAndPause).to.have.been.calledWith(500);
     });
 
+    it('calls changeVolumeFactor on player when volumeFactor changes', () => {
+      const {FilePlayer, mockPlayer} = setup();
+
+      const wrapper = mount(<FilePlayer {...requiredProps}
+                                        playerState={{}} />);
+
+      wrapper.setProps({playerState: {volumeFactor: 0.2, volumeFactorFadeDuration: 500}});
+
+      expect(mockPlayer.changeVolumeFactor).to.have.been.calledWith(0.2, 500);
+    });
+
     it('mutes the player when muted changes to true', () => {
       const {FilePlayer, mockPlayer} = setup();
 
@@ -421,6 +432,7 @@ describe('createFilePlayer', () => {
       pause: sinon.spy(),
       fadeOutAndPause: sinon.spy(),
       muted: sinon.spy(),
+      changeVolumeFactor: sinon.spy(),
       dispose: sinon.spy(),
 
       updateCueLineSettings: sinon.spy(),

--- a/node_package/src/media/components/createFilePlayer/handlePlayerState.js
+++ b/node_package/src/media/components/createFilePlayer/handlePlayerState.js
@@ -24,7 +24,7 @@ export function initPlayer(player, getPlayerState, playerActions, prevFileId, fi
 
 export function updatePlayer(player, playerState, nextPlayerState, playerActions) {
   if (!playerState.shouldPrebuffer && nextPlayerState.shouldPrebuffer) {
-    player.prebuffer().then(playerActions.prebuffered);
+    player.prebuffer().then(() => setTimeout(playerActions.prebuffered, 0));
   }
 
   if (!playerState.shouldPlay && nextPlayerState.shouldPlay) {

--- a/node_package/src/media/components/createFilePlayer/index.jsx
+++ b/node_package/src/media/components/createFilePlayer/index.jsx
@@ -66,7 +66,7 @@ export default function({
           watchPlayer(this.player, this.props.playerActions);
 
           this.prevFileId = this.props.file.id;
-        });
+        }, true);
       };
 
       this.disposeMediaTag = () => {
@@ -80,12 +80,21 @@ export default function({
         return;
       }
 
-      updatePlayerMuted(this.player, prevProps.muted, this.props.muted);
+      this.player.ready(() =>  {
+        updatePlayerMuted(this.player,
+                          prevProps.muted,
+                          this.props.muted);
 
-      updatePlayerFromPlayerState(this.player,
-                                  prevProps.playerState,
-                                  this.props.playerState,
-                                  this.props.playerActions);
+        updatePlayerVolumeFactor(this.player,
+                                 prevProps.playerState.volumeFactor,
+                                 this.props.playerState.volumeFactor,
+                                 this.props.playerState.volumeFactorFadeDuration);
+
+        updatePlayerFromPlayerState(this.player,
+                                    prevProps.playerState,
+                                    this.props.playerState,
+                                    this.props.playerActions);
+      }, true);
 
       if (!this.displaysTextTracksInNativePlayer) {
         updateTextTracks(this.player,
@@ -179,5 +188,11 @@ function textTrackPosition(state, {playerState}) {
 function updatePlayerMuted(player, prevMuted, muted) {
   if (prevMuted !== muted) {
     player.muted(muted);
+  }
+}
+
+function updatePlayerVolumeFactor(player, prevVolumeFactor, volumeFactor, fadeDuration) {
+  if (prevVolumeFactor !== volumeFactor) {
+    player.changeVolumeFactor(volumeFactor, fadeDuration);
   }
 }

--- a/node_package/src/media/components/createFilePlayer/watchPlayer.js
+++ b/node_package/src/media/components/createFilePlayer/watchPlayer.js
@@ -10,7 +10,7 @@ export default function(player, actions) {
 
   player.on('play', actions.playing);
   player.on('playfailed', actions.playFailed);
-  player.on('playmuted', actions.playMuted);
+  player.on('playmuted', actions.playingMuted);
   player.on('pause', actions.paused);
   player.on('waiting', actions.waiting);
   player.on('seeking', actions.seeking);

--- a/node_package/src/media/createReducer.js
+++ b/node_package/src/media/createReducer.js
@@ -1,6 +1,7 @@
 import {
   PLAY, PLAYING, PLAY_FAILED, PAUSE, PAUSED, SCRUB_TO, SEEK_TO,
   FADE_OUT_AND_PAUSE, PLAY_AND_FADE_IN,
+  CHANGE_VOLUME_FACTOR,
   PREBUFFER, PREBUFFERED,
   BUFFER_UNDERRUN, BUFFER_UNDERRUN_CONTINUE, WAITING, SEEKING, SEEKED,
   META_DATA_LOADED, PROGRESS, TIME_UPDATE, ENDED,
@@ -105,6 +106,13 @@ export default function({scope = 'default'} = {}) {
         isPlaying: false,
         fadeDuration: action.payload.fadeDuration,
         isLoading: false
+      };
+
+    case CHANGE_VOLUME_FACTOR:
+      return {
+        ...state,
+        volumeFactor: action.payload.volumeFactor,
+        volumeFactorFadeDuration: action.payload.fadeDuration
       };
 
     case PREBUFFER:

--- a/node_package/src/media/sagas/__spec__/fadeInWhenPageWillActivate-spec.js
+++ b/node_package/src/media/sagas/__spec__/fadeInWhenPageWillActivate-spec.js
@@ -1,0 +1,102 @@
+import fadeInWhenPageWillActivate from '../fadeInWhenPageWillActivate';
+import {PREBUFFER, PLAY, CHANGE_VOLUME_FACTOR, actionCreators} from '../../actions';
+import {pageWillActivate, pageDidActivate, pageWillDeactivate} from 'pages/actions';
+import backgroundMediaModule from 'backgroundMedia';
+
+import {delay} from 'redux-saga';
+
+import {expect} from 'support/chai';
+import {runSagaInPageScope} from 'support/sagas';
+import sinon from 'sinon';
+
+const {prebuffered} = actionCreators();
+
+describe('fadeInWhenPageWillActivate', () => {
+  it('prebuffers when page will activate', () => {
+    const run = runSagaInPageScope(fadeInWhenPageWillActivate, {
+      reduxModules: [backgroundMediaModule]
+    })
+      .dispatch(pageWillActivate());
+
+    expect(run.put).to.have.been.calledWith(action(PREBUFFER));
+  });
+
+  it('does not play video before it is prebuffered', () => {
+    const run = runSagaInPageScope(fadeInWhenPageWillActivate, {
+      reduxModules: [backgroundMediaModule]
+    })
+      .dispatch(pageWillActivate());
+
+    expect(run.put).not.to.have.been.calledWith(action(PLAY));
+  });
+
+  it('plays video silently once it is prebuffered', () => {
+    const run = runSagaInPageScope(fadeInWhenPageWillActivate, {
+      reduxModules: [backgroundMediaModule]
+    })
+      .stubCall(delay)
+      .dispatch(pageWillActivate())
+      .dispatch(prebuffered());
+
+    expect(run.put).to.have.been.calledWith(action(CHANGE_VOLUME_FACTOR, {volumeFactor: 0}));
+    expect(run.put).to.have.been.calledWith(action(PLAY));
+  });
+
+  it('does not play video if page is deactivated before video is prebuffered', () => {
+    const run = runSagaInPageScope(fadeInWhenPageWillActivate, {
+      reduxModules: [backgroundMediaModule]
+    })
+      .dispatch(pageWillActivate())
+      .dispatch(pageWillDeactivate())
+      .dispatch(prebuffered());
+
+    expect(run.put).not.to.have.been.calledWith(action(PLAY));
+  });
+
+  it('does not turn up volume before video is prebuffered', () => {
+    const run = runSagaInPageScope(fadeInWhenPageWillActivate, {
+      reduxModules: [backgroundMediaModule]
+    })
+      .dispatch(pageWillActivate());
+
+    expect(run.put).not.to.have.been.calledWith(action(CHANGE_VOLUME_FACTOR, {volumeFactor: 1}));
+  });
+
+  it('does not turn up volume before page did activate', () => {
+    const run = runSagaInPageScope(fadeInWhenPageWillActivate, {
+      reduxModules: [backgroundMediaModule]
+    })
+      .dispatch(prebuffered());
+
+    expect(run.put).not.to.have.been.calledWith(action(CHANGE_VOLUME_FACTOR, {volumeFactor: 1}));
+  });
+
+  it('turns up volume when video is prebuffered and page did acticate', () => {
+    const run = runSagaInPageScope(fadeInWhenPageWillActivate, {
+      reduxModules: [backgroundMediaModule]
+    })
+      .stubCall(delay)
+      .dispatch(pageWillActivate())
+      .dispatch(prebuffered())
+      .dispatch(pageDidActivate());
+
+    expect(run.put).to.have.been.calledWith(action(CHANGE_VOLUME_FACTOR, {volumeFactor: 1}));
+  });
+
+  it('does not turn up volume when page is deactivated again', () => {
+    const run = runSagaInPageScope(fadeInWhenPageWillActivate, {
+      reduxModules: [backgroundMediaModule]
+    })
+      .stubCall(delay)
+      .dispatch(pageWillActivate())
+      .dispatch(pageDidActivate())
+      .dispatch(pageWillDeactivate())
+      .dispatch(prebuffered());
+
+    expect(run.put).not.to.have.been.calledWith(action(CHANGE_VOLUME_FACTOR, {volumeFactor: 1}));
+  });
+
+  function action(type, payload = {}) {
+    return sinon.match({type, payload});
+  }
+});

--- a/node_package/src/media/sagas/fadeInWhenPageWillActivate.js
+++ b/node_package/src/media/sagas/fadeInWhenPageWillActivate.js
@@ -2,24 +2,36 @@ import {takeEvery} from 'redux-saga';
 import {put, take, call, race} from 'redux-saga/effects';
 
 import {PREBUFFERED, actionCreators} from '../actions';
-import {PAGE_WILL_ACTIVATE, PAGE_WILL_DEACTIVATE} from 'pages/actions';
+import {PAGE_WILL_ACTIVATE, PAGE_DID_ACTIVATE, PAGE_WILL_DEACTIVATE} from 'pages/actions';
 
 export default function*({scope} = {}) {
   const actions = actionCreators({scope});
 
   yield takeEvery(PAGE_WILL_ACTIVATE, function*(action) {
-    yield race({
-      task: call(prebufferAndPlay, actions),
-      cancel: take(PAGE_WILL_DEACTIVATE)
-    });
+    yield [
+      race({
+        task: [
+          put(actions.prebuffer()),
+          call(playSilentlyWhenPrebuffered, actions),
+          call(fadeInOnPageDidActivateAndPrebuffered, actions)
+        ],
+        cancel: take(PAGE_WILL_DEACTIVATE)
+      }),
+    ];
   });
 }
 
-function* prebufferAndPlay({prebuffer, playAndFadeIn}) {
+function* playSilentlyWhenPrebuffered({prebuffer, changeVolumeFactor, play}) {
+  yield put(changeVolumeFactor(0, {fadeDuration: 0}));
+
+  yield take(PREBUFFERED);
+  yield put(play());
+}
+
+function* fadeInOnPageDidActivateAndPrebuffered({changeVolumeFactor}) {
   yield [
     take(PREBUFFERED),
-    put(prebuffer())
+    take(PAGE_DID_ACTIVATE)
   ];
-
-  yield put(playAndFadeIn({fadeDuration: 1000}));
+  yield put(changeVolumeFactor(1, {fadeDuration: 1000}));
 }

--- a/node_package/src/media/sagas/muteBackgroundMediaOnPlayFailed.js
+++ b/node_package/src/media/sagas/muteBackgroundMediaOnPlayFailed.js
@@ -1,10 +1,10 @@
-import {PLAY_FAILED, PLAY_MUTED} from '../actions';
+import {PLAY_FAILED, PLAYING_MUTED} from '../actions';
 
 import {takeEvery} from 'redux-saga';
 import {call} from 'redux-saga/effects';
 
 export default function*() {
-  yield takeEvery([PLAY_FAILED, PLAY_MUTED], muteBackgoundAudio);
+  yield takeEvery([PLAY_FAILED, PLAYING_MUTED], muteBackgoundAudio);
 }
 
 function* muteBackgoundAudio() {

--- a/node_package/src/pages/actions.js
+++ b/node_package/src/pages/actions.js
@@ -16,7 +16,7 @@ export const CLEANUP = 'PAGE_CLEANUP';
 export const UPDATE_PAGE_ATTRIBUTE = 'UPDATE_PAGE_ATTRIBUTE';
 export const UPDATE_PAGE_LINK = 'UPDATE_PAGE_LINK';
 
-export function pageWillActivate({id, position}) {
+export function pageWillActivate({id, position} = {}) {
   return pageAction(PAGE_WILL_ACTIVATE, id, {position});
 }
 


### PR DESCRIPTION
Ensure volume is turned down until delayed start has finished
(e.g. the multimedia alert has been closed).

We cannot use mute since, if unmuted autoplay is disabled, there is no way
to know whether unmuting the video will pause it. Hence we change the
volume factor to set volume to 0. That way the unmute button will be shown
if autoplay fails.

Add a `backgroundMedia.unmute` call to the multmedia alert, to ensure
clicking the "Let's go" button unmutes background media.

To prevent timing issues:

- Ensure `PREBUFFERED` is never dispatched immediately after
  `PREBUFFER` to be able to wait in sagas.

- Wait for videojs to be ready, but use sync variant of `ready` by
  passing `true` as second argument. Otherwise `shouldPlay` can
  already be reset a `pause` event, before we handle the prop change
  and call `play`.

REDMINE-16148