### PR TITLE
Improve handling of externally controlled player

### DIFF
--- a/node_package/src/media/__spec__/createReducer-spec.js
+++ b/node_package/src/media/__spec__/createReducer-spec.js
@@ -95,4 +95,141 @@ describe('createReducer creates function that', () => {
 
     expect(nextState.playFailed).to.eq(false);
   });
+
+  it('sets shouldPlay to true on PLAY', () => {
+    const {play} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, play());
+
+    expect(state.shouldPlay).to.eq(true);
+  });
+
+  it('sets shouldPlay to true on PLAYING even if play started playing by itself', () => {
+    const {playing} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, playing());
+
+    expect(state.shouldPlay).to.eq(true);
+  });
+
+  it('resets shouldPlay to false on PAUSE', () => {
+    const {play, pause} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, play());
+    state = reducer(state, pause());
+
+    expect(state.shouldPlay).to.eq(false);
+  });
+
+  it('sets shouldPlay to false on PAUSED even if player pauses by itself', () => {
+    const {play, playing, paused} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, play());
+    state = reducer(state, playing());
+    state = reducer(state, paused());
+
+    expect(state.shouldPlay).to.eq(false);
+  });
+
+  it('resets shouldPlay to false on ENDED', () => {
+    const {play, playing, ended} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, play());
+    state = reducer(state, playing());
+    state = reducer(state, ended());
+
+    expect(state.shouldPlay).to.eq(false);
+  });
+
+  it('leaves shouldPlay true on PAUSED action during buffer underuns', () => {
+    const {play, paused, bufferUnderrun} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, play());
+    state = reducer(state, bufferUnderrun());
+    state = reducer(state, paused());
+
+    expect(state.shouldPlay).to.eq(true);
+  });
+
+  it('sets shouldPlay to false on PAUSED action again after buffer underun', () => {
+    const {play, paused, bufferUnderrun, bufferUnderrunContinue} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, play());
+    state = reducer(state, bufferUnderrun());
+    state = reducer(state, bufferUnderrunContinue());
+    state = reducer(state, paused());
+
+    expect(state.shouldPlay).to.eq(false);
+  });
+
+
+  it('sets isPlaying to true on PLAYING action', () => {
+    const {playing} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, playing());
+
+    expect(state.isPlaying).to.eq(true);
+  });
+
+  it('resets isPlaying to false on PAUSED action', () => {
+    const {playing, paused} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, playing());
+    state = reducer(state, paused());
+
+    expect(state.isPlaying).to.eq(false);
+  });
+
+  it('resets isPlaying to false on ENDED action', () => {
+    const {playing, ended} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, playing());
+    state = reducer(state, ended());
+
+    expect(state.isPlaying).to.eq(false);
+  });
+
+  it('does not change isPlaying on actions that only intend to play', () => {
+    const {paused, play, playAndFadeIn} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, paused());
+    state = reducer(state, play());
+    state = reducer(state, playAndFadeIn({fadeDuration: 1000}));
+
+    expect(state.isPlaying).to.eq(false);
+  });
+
+  it('does not change isPlaying on actions that only intend to pause', () => {
+    const {playing, pause, fadeOutAndPause} = actionCreators();
+    const reducer = createReducer();
+    var state = {};
+
+    state = reducer(state, playing());
+    state = reducer(state, pause());
+    state = reducer(state, fadeOutAndPause({fadeDuration: 1000}));
+
+    expect(state.isPlaying).to.eq(true);
+  });
 });

--- a/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
+++ b/node_package/src/media/components/__spec__/createFilePlayer-spec.jsx
@@ -195,27 +195,38 @@ describe('createFilePlayer', () => {
       expect(mockPlayer.playAndFadeIn).to.have.been.calledWith(500);
     });
 
-    it('calls pause on player when shouldPlay changes to false in playerState', () => {
-      const {FilePlayer, mockPlayer} = setup();
+    it('calls pause on player when isPlaying and shouldPlay changes to false in playerState',
+       () => {
+         const {FilePlayer, mockPlayer} = setup();
 
-      const wrapper = mount(<FilePlayer {...requiredProps}
-                                        playerState={{shouldPlay: true}} />);
+         const wrapper = mount(<FilePlayer {...requiredProps}
+                                           playerState={{isPlaying: true, shouldPlay: true}} />);
 
-      wrapper.setProps({playerState: {shouldPlay: false}});
+         wrapper.setProps({playerState: {isPlaying: true, shouldPlay: false}});
 
-      expect(mockPlayer.pause).to.have.been.called;
-    });
+         expect(mockPlayer.pause).to.have.been.called;
+       }
+    );
 
-    it('calls fadeOutAndPause on player when shouldPlay changes to false and fadeDuration is present', () => {
-      const {FilePlayer, mockPlayer} = setup();
+    it('calls fadeOutAndPause on player when isPlaying, shouldPlay changes to false and' +
+       'fadeDuration is present',
+       () => {
+        const {FilePlayer, mockPlayer} = setup();
 
-      const wrapper = mount(<FilePlayer {...requiredProps}
-                                        playerState={{shouldPlay: true}} />);
+        const wrapper = mount(<FilePlayer {...requiredProps}
+                                          playerState={{isPlaying: true, shouldPlay: true}} />);
 
-      wrapper.setProps({playerState: {shouldPlay: false, fadeDuration: 500}});
+        wrapper.setProps({
+          playerState: {
+            isPlaying: true,
+            shouldPlay: false,
+            fadeDuration: 500
+          }
+        });
 
-      expect(mockPlayer.fadeOutAndPause).to.have.been.calledWith(500);
-    });
+        expect(mockPlayer.fadeOutAndPause).to.have.been.calledWith(500);
+      }
+    );
 
     it('mutes the player when muted changes to true', () => {
       const {FilePlayer, mockPlayer} = setup();

--- a/node_package/src/media/components/createFilePlayer/handlePlayerState.js
+++ b/node_package/src/media/components/createFilePlayer/handlePlayerState.js
@@ -35,7 +35,7 @@ export function updatePlayer(player, playerState, nextPlayerState, playerActions
       player.play();
     }
   }
-  else if (playerState.shouldPlay && !nextPlayerState.shouldPlay) {
+  else if (playerState.shouldPlay && !nextPlayerState.shouldPlay && nextPlayerState.isPlaying) {
     if (nextPlayerState.fadeDuration) {
       player.fadeOutAndPause(nextPlayerState.fadeDuration);
     }

--- a/node_package/src/media/createReducer.js
+++ b/node_package/src/media/createReducer.js
@@ -55,6 +55,7 @@ export default function({scope = 'default'} = {}) {
     case PLAYING:
       return {
         ...state,
+        shouldPlay: true,
         isPlaying: true
       };
     case PLAY_FAILED:
@@ -102,7 +103,6 @@ export default function({scope = 'default'} = {}) {
       return {
         ...state,
         shouldPlay: false,
-        isPlaying: false,
         fadeDuration: action.payload.fadeDuration,
         isLoading: false
       };


### PR DESCRIPTION
When the media player is paused by an external event (i.e. a different
player library that has direct access to the media element), we want
to make sure that the `PAUSED` action does not lead to another call of
`pause` on the media element.

We can distinguish this from the case where `PAUSE` caused
`shouldPlay` to become `false` by checking whether `isPlaying` is
already false and skip calling `pause` on the media player.

By mistake, `isPlaying` was also set to `false` on
`FADE_OUT_AND_PAUSE` before. This needs to be removed since otherwise
now the `pause` would be skipped

REDMINE-16148, REDMINE-14305