### PR TITLE
Show widgets of all insert points in editor

### DIFF
--- a/app/models/pageflow/widget.rb
+++ b/app/models/pageflow/widget.rb
@@ -16,7 +16,7 @@ module Pageflow
 
     def matches?(options)
       enabled_for_scope?(options[:scope]) &&
-        for_insert_point?(options.fetch(:insert_point, :bottom_of_entry))
+        for_insert_point?(options.fetch(:insert_point, :any))
     end
 
     def self.copy_all_to(subject)
@@ -48,7 +48,7 @@ module Pageflow
     end
 
     def for_insert_point?(insert_point)
-      widget_type.insert_point == insert_point
+      insert_point == :any || widget_type.insert_point == insert_point
     end
 
     Resolver = Struct.new(:config, :options) do

--- a/spec/models/pageflow/widget_spec.rb
+++ b/spec/models/pageflow/widget_spec.rb
@@ -124,6 +124,21 @@ module Pageflow
         expect(widgets).to include_record_with(type_name: nil, role: 'header')
       end
 
+      it 'does not filter widgets by insert point by default' do
+        before_widget_type = TestWidgetType.new(name: 'before', insert_point: :before_entry)
+        bottom_widget_type = TestWidgetType.new(name: 'bottom', insert_point: :bottom_of_entry)
+        config = Configuration.new
+        config.widget_types.register(before_widget_type)
+        config.widget_types.register(bottom_widget_type)
+        revision = create(:revision)
+        before_widget = create(:widget, subject: revision, role: 'header', type_name: 'before')
+        bottom_widget = create(:widget, subject: revision, role: 'footer', type_name: 'bottom')
+
+        widgets = revision.widgets.resolve(config)
+
+        expect(widgets).to eq([before_widget, bottom_widget])
+      end
+
       it 'filters widgets by insert point' do
         before_widget_type = TestWidgetType.new(name: 'before', insert_point: :before_entry)
         bottom_widget_type = TestWidgetType.new(name: 'bottom', insert_point: :bottom_of_entry)


### PR DESCRIPTION
Do not filter widgets by insert point if not `insert_point` option is
passed to `resolve`.

This ensures all widgets show up in the `EditWidgetsView` regardless
of their insert point.

REDMINE-15907