### PR TITLE
Remove HostedFile#keep_on_filesystem_after_upload_to_s3

### DIFF
--- a/app/jobs/pageflow/upload_file_to_s3_job.rb
+++ b/app/jobs/pageflow/upload_file_to_s3_job.rb
@@ -10,7 +10,7 @@ module Pageflow
           file.attachment_on_s3 = file.attachment_on_filesystem
           file.save!
 
-          file.attachment_on_filesystem.destroy unless file.keep_on_filesystem_after_upload_to_s3?
+          file.attachment_on_filesystem.destroy
           :ok
         else
           logger.info "#{file.class.name} #{file.id} not yet transfered to instance."

--- a/app/models/concerns/pageflow/hosted_file.rb
+++ b/app/models/concerns/pageflow/hosted_file.rb
@@ -47,10 +47,6 @@ module Pageflow
       self.attachment_on_filesystem = value
     end
 
-    def keep_on_filesystem_after_upload_to_s3?
-      false
-    end
-
     def retryable?
       can_retry?
     end

--- a/spec/factories/hosted_files.rb
+++ b/spec/factories/hosted_files.rb
@@ -26,14 +26,6 @@ module Pageflow
 
       trait :uploaded_to_s3 do
       end
-
-      trait :with_overridden_keep_on_filesystem do
-        after(:build) do |hosted_file|
-          def hosted_file.keep_on_filesystem_after_upload_to_s3?
-            true
-          end
-        end
-      end
     end
   end
 end

--- a/spec/jobs/pageflow/upload_file_to_s3_job_spec.rb
+++ b/spec/jobs/pageflow/upload_file_to_s3_job_spec.rb
@@ -17,13 +17,5 @@ module Pageflow
 
       expect(hosted_file.attachment_on_filesystem).not_to be_present
     end
-
-    it 'keeps attachment_on_filesystem if hosted_file returns ' do
-      hosted_file = create(:hosted_file, :on_filesystem, :with_overridden_keep_on_filesystem)
-
-      UploadFileToS3Job.new.perform_with_result(hosted_file)
-
-      expect(hosted_file.attachment_on_filesystem).to be_present
-    end
   end
 end


### PR DESCRIPTION
Future versions of Pageflow will use direct upload to transfer files
to S3. Files will need to be re-downloaded for processing.

The only known (to the author) Pageflow plugin that uses this option
is `pageflow-panorama` < 1.0. `pageflow-panorama` 1.0 switches to
re-downloading in
https://github.com/codevise/pageflow-panorama/commit/23c5e6e7a931002f55c62dbfd25b20d82c155f15

REDMINE-16119