### PR TITLE
Do not fail capybara spec on failing widget refresh

### DIFF
--- a/spec/support/config/capybara.rb
+++ b/spec/support/config/capybara.rb
@@ -16,8 +16,16 @@ Capybara.javascript_driver = :selenium_chrome_headless_no_sandbox
 
 Capybara::Chromedriver::Logger.raise_js_errors = true
 Capybara::Chromedriver::Logger.filters = [
+  # Bandwidth probe files are not available in tests
   /bandwidth_probe.*Failed to load resource/i,
-  /Target node has markup rendered by React/i
+
+  # React does not like the server rendered "back to top" link inside
+  # page sections.
+  /Target node has markup rendered by React/i,
+
+  # Ignore failure of debounced request to refresh partials while db
+  # has already been cleaned
+  /partials - Failed to load resource: the server responded with a status of 401/
 ]
 
 RSpec.configure do |config|


### PR DESCRIPTION
Whenever changes a made inside the editor, a debounced request is made
to update the server rendered widgets.

Some of the js based editor specs trigger this request even after the
test itself has finished. The request fails since the database has
already been cleaned.

Do not make the spec fail if this happens.