### PR TITLE
Fix example migration in file type guide

### DIFF
--- a/doc/creating_file_types.md
+++ b/doc/creating_file_types.md
@@ -34,8 +34,17 @@ the required columns for the model.
           t.belongs_to(:entry, index: true)
           t.belongs_to(:uploader, index: true)
 
+          t.integer(:parent_file_id)
+          t.string(:parent_file_model_type)
+          t.index([:parent_file_id, :parent_file_model_type])
+
           t.string(:state)
           t.string(:rights)
+
+          t.string(:attachment_on_filesystem_file_name)
+          t.string(:attachment_on_filesystem_content_type)
+          t.integer(:attachment_on_filesystem_file_size, limit: 8)
+          t.datetime(:attachment_on_filesystem_updated_at)
 
           t.string(:attachment_on_s3_file_name)
           t.string(:attachment_on_s3_content_type)


### PR DESCRIPTION
We still need to include `attachment_on_filesystem` columns. Also
`parent_file` columns were missing.

Was missing in #1085.

REDMINE-16119