### PR TITLE
Parse page perma id from URL fragment

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow.js
+++ b/app/assets/javascripts/pageflow/slideshow.js
@@ -194,7 +194,7 @@ pageflow.Slideshow = function($el, configurations) {
   }
 
   function getPageByPermaId(permaId) {
-    return $el.find('#' + permaId);
+    return $el.find('#' + parseInt(permaId, 10));
   }
 
   this.on = function() {


### PR DESCRIPTION
Prevent creating an invalid CSS selector when looking up a page based
on the perma id passed in the fragment of a deep link.

REDMINE-16276