### PR TITLE
Ensure hls videos are used in Safari

### DIFF
--- a/app/assets/javascripts/pageflow/browser/video.js
+++ b/app/assets/javascripts/pageflow/browser/video.js
@@ -25,6 +25,11 @@ pageflow.browser.feature('mp4 support only', function(has) {
     pageflow.browser.agent.matchesDesktopSafari10();
 });
 
+pageflow.browser.feature('mse and native hls support', function(has) {
+  return pageflow.browser.agent.matchesSafari() &&
+    !pageflow.browser.agent.matchesMobilePlatform();
+});
+
 pageflow.browser.feature('native video player', function(has) {
   return has('iphone platform');
 });

--- a/app/assets/javascripts/pageflow/video_player/filter_sources.js
+++ b/app/assets/javascripts/pageflow/video_player/filter_sources.js
@@ -1,8 +1,22 @@
 pageflow.VideoPlayer.filterSources = function(playerElement) {
-  if ($(playerElement).is('video') && pageflow.browser.has('mp4 support only')) {
+  if (!$(playerElement).is('video')) {
+    return playerElement;
+  }
+
+  var changed = false;
+
+  if (pageflow.browser.has('mp4 support only')) {
     // keep only mp4 source
     $(playerElement).find('source').not('source[type="video/mp4"]').remove();
+    changed = true;
+  }
+  else if (pageflow.browser.has('mse and native hls support')) {
+    // remove dash source to ensure hls is used
+    $(playerElement).find('source[type="application/dash+xml"]').remove();
+    changed = true;
+  }
 
+  if (changed) {
     // the video tags initially in the dom are broken since they "saw"
     // the other sources. replace with clones
     var clone = $(playerElement).clone(true);


### PR DESCRIPTION
Safari also supports MSE and therefore picks dash in our current
setup. Still dash performs slightly worse in Safari, i.e. displaying a
black frame at the end when looping a video.

We could change the order of sources to make hls come first. Since
this might have negative effects in other browsers and we already need
to filter sources to handle bugs in Safari < 11, we instead remove the
dash source dynamically.

REDMINE-16318