### PR TITLE
Improve lazy loading thumbnails

### DIFF
--- a/app/assets/javascripts/pageflow/jquery_utils.js
+++ b/app/assets/javascripts/pageflow/jquery_utils.js
@@ -14,6 +14,9 @@ $.fn.updateTitle = function () {
 $.fn.loadLazyImages = function() {
   this.find('img[data-src]').each(function() {
     var img = $(this);
-    img.attr('src', img.data('src'));
+
+    if (!img.attr('src')) {
+      img.attr('src', img.data('src'));
+    }
   });
 };

--- a/app/views/pageflow/entries/mobile_navigation/_page.html.erb
+++ b/app/views/pageflow/entries/mobile_navigation/_page.html.erb
@@ -1,5 +1,5 @@
 <li class="<%= page_navigation_css_class(page) %>">
   <%= link_to "##{page.perma_id}", data: {link: page.id, chapter_id: page.chapter_id} do %>
-    <%= image_tag('', data: {src: page.thumbnail_url(:thumbnail_overview_mobile)}) %>
+    <%= image_tag('', data: {src: asset_path(page.thumbnail_url(:thumbnail_overview_mobile))}) %>
   <% end %>
 </li>

--- a/app/views/pageflow/entries/navigation/_page.html.erb
+++ b/app/views/pageflow/entries/navigation/_page.html.erb
@@ -5,7 +5,7 @@
   <div class="navigation_site_detail">
     <%= page.title %>
     <div class="thumbnail is_<%= page.template %>">
-      <%= image_tag('', data: {src: page.thumbnail_url(:navigation_thumbnail_large)}) %>
+      <%= image_tag('', data: {src: asset_path(page.thumbnail_url(:navigation_thumbnail_large))}) %>
     </div>
   </div>
 </li>

--- a/app/views/pageflow/entries/overview/_page.html.erb
+++ b/app/views/pageflow/entries/overview/_page.html.erb
@@ -4,6 +4,6 @@
         <%= overview_page_description(page) %>
       </p>
     </div>
-    <%= image_tag('', data: {src: page.thumbnail_url(:thumbnail_overview_desktop)}) %>
+    <%= image_tag('', data: {src: asset_path(page.thumbnail_url(:thumbnail_overview_desktop))}) %>
     <div class="pictogram"></div>
 <% end %>


### PR DESCRIPTION
* Pass urls through `asset_path` to ensure digests are included in
  placeholder paths.

* Only set `src` attribute if empty to prevent reloading images on 404
  or when cache is disabled via dev tools.

REDMINE-16290