### PR TITLE
Set locale to editors locale for new entries

### DIFF
--- a/admins/pageflow/accounts.rb
+++ b/admins/pageflow/accounts.rb
@@ -72,14 +72,15 @@ module Pageflow
 
     controller do
       helper Pageflow::Admin::FeaturesHelper
-      helper Pageflow::Admin::WidgetsHelper
       helper Pageflow::Admin::FormHelper
+      helper Pageflow::Admin::LocalesHelper
       helper Pageflow::Admin::MembershipsHelper
+      helper Pageflow::Admin::WidgetsHelper
       helper ThemesHelper
 
       def new
         @account = Account.new
-        @account.build_default_theming
+        @account.build_default_theming(default_locale: current_user.locale)
       end
 
       def create
@@ -145,7 +146,8 @@ module Pageflow
           :home_button_enabled_by_default,
           :default_author,
           :default_publisher,
-          :default_keywords
+          :default_keywords,
+          :default_locale
         ] +
           permitted_attributes_for(:theming)
       end

--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -213,6 +213,10 @@ module Pageflow
         entry.theming ||= entry.account.default_theming
       end
 
+      after_create do |entry|
+        entry.revisions.first&.update(locale: current_user.locale)
+      end
+
       before_update do |entry|
         if entry.account_id_changed? && !authorized?(:update_theming_on, resource)
           entry.theming = entry.account.default_theming

--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -213,10 +213,6 @@ module Pageflow
         entry.theming ||= entry.account.default_theming
       end
 
-      after_create do |entry|
-        entry.revisions.first&.update(locale: current_user.locale)
-      end
-
       before_update do |entry|
         if entry.account_id_changed? && !authorized?(:update_theming_on, resource)
           entry.theming = entry.account.default_theming

--- a/app/models/pageflow/theming.rb
+++ b/app/models/pageflow/theming.rb
@@ -37,7 +37,8 @@ module Pageflow
         publisher: default_publisher.presence || Pageflow.config.default_publisher_meta_tag,
         keywords: default_keywords.presence || Pageflow.config.default_keywords_meta_tag,
         theme_name: theme_name,
-        home_button_enabled: home_button_enabled_by_default
+        home_button_enabled: home_button_enabled_by_default,
+        locale: default_locale
       )
     end
 

--- a/app/views/admin/accounts/_form.html.erb
+++ b/app/views/admin/accounts/_form.html.erb
@@ -21,7 +21,9 @@
       <%= theming.input :default_locale,
                         as: :select,
                         include_blank: false,
-                        collection: available_locales_collection,
+                        collection: Pageflow.config.available_public_locales.map{ |locale|
+                          [I18n.t("pageflow.languages.#{locale}"), locale.to_s]
+                        },
                         hint: t('pageflow.admin.themings.default_locale_hint') %>
       <%= theming.input :default_author,
         hint: t('pageflow.admin.themings.default_author_hint'),

--- a/app/views/admin/accounts/_form.html.erb
+++ b/app/views/admin/accounts/_form.html.erb
@@ -22,7 +22,7 @@
                         as: :select,
                         include_blank: false,
                         collection: Pageflow.config.available_public_locales.map{ |locale|
-                          [I18n.t("pageflow.languages.#{locale}"), locale.to_s]
+                          [t('pageflow.public._language', locale: locale), locale.to_s]
                         },
                         hint: t('pageflow.admin.themings.default_locale_hint') %>
       <%= theming.input :default_author,

--- a/app/views/admin/accounts/_form.html.erb
+++ b/app/views/admin/accounts/_form.html.erb
@@ -18,6 +18,11 @@
     <% end %>
 
     <%= f.inputs do %>
+      <%= theming.input :default_locale,
+                        as: :select,
+                        include_blank: false,
+                        collection: available_locales_collection,
+                        hint: t('pageflow.admin.themings.default_locale_hint') %>
       <%= theming.input :default_author,
         hint: t('pageflow.admin.themings.default_author_hint'),
         placeholder: Pageflow.config.default_author_meta_tag %>

--- a/app/views/admin/accounts/_theming_details.html.arb
+++ b/app/views/admin/accounts/_theming_details.html.arb
@@ -6,7 +6,7 @@ extensible_attributes_table_for(account.default_theming,
     account.default_theming.theme.name
   end
   row :default_locale, class: 'default_locale' do
-    I18n.t("pageflow.languages.#{account.default_theming.default_locale}")
+    t('pageflow.public._language', locale: account.default_theming.default_locale)
   end
   row :default_author, class: 'default_author'
   row :default_publisher, class: 'default_publisher'

--- a/app/views/admin/accounts/_theming_details.html.arb
+++ b/app/views/admin/accounts/_theming_details.html.arb
@@ -5,6 +5,7 @@ extensible_attributes_table_for(account.default_theming,
   row :theme, class: 'theme' do
     account.default_theming.theme.name
   end
+  row :default_locale, class: 'default_locale'
   row :default_author, class: 'default_author'
   row :default_publisher, class: 'default_publisher'
   row :default_keywords, class: 'default_keywords'

--- a/app/views/admin/accounts/_theming_details.html.arb
+++ b/app/views/admin/accounts/_theming_details.html.arb
@@ -5,7 +5,9 @@ extensible_attributes_table_for(account.default_theming,
   row :theme, class: 'theme' do
     account.default_theming.theme.name
   end
-  row :default_locale, class: 'default_locale'
+  row :default_locale, class: 'default_locale' do
+    I18n.t("pageflow.languages.#{account.default_theming.default_locale}")
+  end
   row :default_author, class: 'default_author'
   row :default_publisher, class: 'default_publisher'
   row :default_keywords, class: 'default_keywords'

--- a/config/locales/new/create_new_entry_in_editors_locale.de.yml
+++ b/config/locales/new/create_new_entry_in_editors_locale.de.yml
@@ -1,0 +1,9 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/theming:
+        default_locale: Standard Sprache
+  pageflow:
+    admin:
+      themings:
+        default_locale_hint: Voreinstellung Sprache für Einträge

--- a/config/locales/new/create_new_entry_in_editors_locale.de.yml
+++ b/config/locales/new/create_new_entry_in_editors_locale.de.yml
@@ -7,14 +7,3 @@ de:
     admin:
       themings:
         default_locale_hint: Voreinstellung Sprache für Einträge
-    languages:
-      bg: Bulgarisch
-      cs-CZ: Tschechisch
-      fa-IR: Persisch
-      gn: Guarani
-      id: Indonesisch
-      ms: Malaysisch
-      nl-BE: Holländisch (Belgien)
-      pl-PL: Polnisch
-      pt-BR: Portugiesisch (Brasilien)
-      ru-RU: Russisch

--- a/config/locales/new/create_new_entry_in_editors_locale.de.yml
+++ b/config/locales/new/create_new_entry_in_editors_locale.de.yml
@@ -7,3 +7,14 @@ de:
     admin:
       themings:
         default_locale_hint: Voreinstellung Sprache für Einträge
+    languages:
+      bg: Bulgarisch
+      cs-CZ: Tschechisch
+      fa-IR: Persisch
+      gn: Guarani
+      id: Indonesisch
+      ms: Malaysisch
+      nl-BE: Holländisch (Belgien)
+      pl-PL: Polnisch
+      pt-BR: Portugiesisch (Brasilien)
+      ru-RU: Russisch

--- a/config/locales/new/create_new_entry_in_editors_locale.en.yml
+++ b/config/locales/new/create_new_entry_in_editors_locale.en.yml
@@ -1,0 +1,9 @@
+en:
+  activerecord:
+    attributes:
+      pageflow/theming:
+        default_locale: Default locale
+  pageflow:
+    admin:
+      themings:
+        default_locale_hint: Default language for entries

--- a/config/locales/new/create_new_entry_in_editors_locale.en.yml
+++ b/config/locales/new/create_new_entry_in_editors_locale.en.yml
@@ -7,3 +7,14 @@ en:
     admin:
       themings:
         default_locale_hint: Default language for entries
+    languages:
+      bg: Bulgarian
+      cs-CZ: Czech
+      fa-IR: Persian
+      gn: Guarani
+      id: Indonesian
+      ms: Malay
+      nl-BE: Dutch (Belgium)
+      pl-PL: Polish
+      pt-BR: Portuguese (Brazil)
+      ru-RU: Russian

--- a/config/locales/new/create_new_entry_in_editors_locale.en.yml
+++ b/config/locales/new/create_new_entry_in_editors_locale.en.yml
@@ -7,14 +7,3 @@ en:
     admin:
       themings:
         default_locale_hint: Default language for entries
-    languages:
-      bg: Bulgarian
-      cs-CZ: Czech
-      fa-IR: Persian
-      gn: Guarani
-      id: Indonesian
-      ms: Malay
-      nl-BE: Dutch (Belgium)
-      pl-PL: Polish
-      pt-BR: Portuguese (Brazil)
-      ru-RU: Russian

--- a/db/migrate/20190109085744_add_default_locale_to_themings.rb
+++ b/db/migrate/20190109085744_add_default_locale_to_themings.rb
@@ -1,0 +1,6 @@
+class AddDefaultLocaleToThemings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pageflow_themings, :default_locale, :string,
+               after: 'default_publisher', default: 'de'
+  end
+end

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -480,14 +480,15 @@ describe Admin::EntriesController do
       expect(Pageflow::Entry.last.custom_field).to eq(nil)
     end
 
-    it 'sets the entry revisions locale to the current users locale' do
-      user = create(:user, locale: 'es')
-      create(:account, with_publisher: user)
+    it 'sets the entry revisions locale to the default locale of the accounts theming' do
+      user = create(:user, locale: 'en')
+      account = create(:account, with_publisher: user)
+      account.default_theming.update(default_locale: user.locale)
 
       sign_in(user, scope: :user)
       post(:create, params: {entry: {title: 'some_title'}})
 
-      expect(Pageflow::Entry.last.revisions.first.locale).to eq('es')
+      expect(Pageflow::Entry.last.revisions.first.locale).to eq('en')
     end
   end
 

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -479,6 +479,16 @@ describe Admin::EntriesController do
 
       expect(Pageflow::Entry.last.custom_field).to eq(nil)
     end
+
+    it 'sets the entry revisions locale to the current users locale' do
+      user = create(:user, locale: 'es')
+      create(:account, with_publisher: user)
+
+      sign_in(user, scope: :user)
+      post(:create, params: {entry: {title: 'some_title'}})
+
+      expect(Pageflow::Entry.last.revisions.first.locale).to eq('es')
+    end
   end
 
   describe '#edit' do


### PR DESCRIPTION
Customers who have set their language to english have reported that the default language for new stories is still German. This behavior was perceived as a bug.

This PR introduces a new column `default_locale` on account/theming level where a default language for new stories can be specified (defaults to German), which is then used for new stories.

For new accounts the `default_locale` will initially get set to the locale the user specified during signup.

REDMINE-16323