### PR TITLE
Trigger resize hooks on cookie notice dismiss

### DIFF
--- a/app/assets/javascripts/pageflow/widgets.js
+++ b/app/assets/javascripts/pageflow/widgets.js
@@ -35,6 +35,7 @@ pageflow.widgets = (function() {
       .addClass(replacement);
 
     pageflow.events.trigger('widgets:update');
+    pageflow.slides.triggerResizeHooks();
   }
 
   function className(name, state) {


### PR DESCRIPTION
Previously, dismissing the cookie notice removed the div but did not resize the banner image,
which left an empty div at the bottom of the page.
Explicitly calling the resize hook in `pageflow.widgets.use` takes care of resizing the banner image
back to the full available height.

REDMINE-16186