### PR TITLE
Create new entries with default locale (12.x Backport)

### DIFF
--- a/admins/pageflow/accounts.rb
+++ b/admins/pageflow/accounts.rb
@@ -72,14 +72,15 @@ module Pageflow
 
     controller do
       helper Pageflow::Admin::FeaturesHelper
-      helper Pageflow::Admin::WidgetsHelper
       helper Pageflow::Admin::FormHelper
+      helper Pageflow::Admin::LocalesHelper
       helper Pageflow::Admin::MembershipsHelper
+      helper Pageflow::Admin::WidgetsHelper
       helper ThemesHelper
 
       def new
         @account = Account.new
-        @account.build_default_theming
+        @account.build_default_theming(default_locale: current_user.locale)
       end
 
       def create
@@ -145,7 +146,8 @@ module Pageflow
           :home_button_enabled_by_default,
           :default_author,
           :default_publisher,
-          :default_keywords
+          :default_keywords,
+          :default_locale
         ] +
           permitted_attributes_for(:theming)
       end

--- a/app/models/pageflow/theming.rb
+++ b/app/models/pageflow/theming.rb
@@ -37,7 +37,8 @@ module Pageflow
         publisher: default_publisher.presence || Pageflow.config.default_publisher_meta_tag,
         keywords: default_keywords.presence || Pageflow.config.default_keywords_meta_tag,
         theme_name: theme_name,
-        home_button_enabled: home_button_enabled_by_default
+        home_button_enabled: home_button_enabled_by_default,
+        locale: default_locale
       )
     end
 

--- a/app/views/admin/accounts/_form.html.erb
+++ b/app/views/admin/accounts/_form.html.erb
@@ -18,6 +18,13 @@
     <% end %>
 
     <%= f.inputs do %>
+      <%= theming.input :default_locale,
+                        as: :select,
+                        include_blank: false,
+                        collection: Pageflow.config.available_public_locales.map{ |locale|
+                          [t('pageflow.public._language', locale: locale), locale.to_s]
+                        },
+                        hint: t('pageflow.admin.themings.default_locale_hint') %>
       <%= theming.input :default_author,
         hint: t('pageflow.admin.themings.default_author_hint'),
         placeholder: Pageflow.config.default_author_meta_tag %>

--- a/app/views/admin/accounts/_theming_details.html.arb
+++ b/app/views/admin/accounts/_theming_details.html.arb
@@ -5,6 +5,9 @@ extensible_attributes_table_for(account.default_theming,
   row :theme, class: 'theme' do
     account.default_theming.theme.name
   end
+  row :default_locale, class: 'default_locale' do
+    t('pageflow.public._language', locale: account.default_theming.default_locale)
+  end
   row :default_author, class: 'default_author'
   row :default_publisher, class: 'default_publisher'
   row :default_keywords, class: 'default_keywords'

--- a/config/locales/new/create-new-entries-with-default-locale.de.yml
+++ b/config/locales/new/create-new-entries-with-default-locale.de.yml
@@ -1,0 +1,9 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/theming:
+        default_locale: Standard Sprache
+  pageflow:
+    admin:
+      themings:
+        default_locale_hint: Voreinstellung Sprache für Einträge

--- a/config/locales/new/create-new-entries-with-default-locale.en.yml
+++ b/config/locales/new/create-new-entries-with-default-locale.en.yml
@@ -1,0 +1,9 @@
+en:
+  activerecord:
+    attributes:
+      pageflow/theming:
+        default_locale: Default locale
+  pageflow:
+    admin:
+      themings:
+        default_locale_hint: Default language for entries

--- a/db/migrate/20190109085744_add_default_locale_to_themings.rb
+++ b/db/migrate/20190109085744_add_default_locale_to_themings.rb
@@ -1,0 +1,6 @@
+class AddDefaultLocaleToThemings < ActiveRecord::Migration
+  def change
+    add_column :pageflow_themings, :default_locale, :string,
+               after: 'default_publisher', default: 'de'
+  end
+end

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -479,6 +479,17 @@ describe Admin::EntriesController do
 
       expect(Pageflow::Entry.last.custom_field).to eq(nil)
     end
+
+    it 'sets the entry revisions locale to the default locale of the accounts theming' do
+      user = create(:user, locale: 'en')
+      account = create(:account, with_publisher: user)
+      account.default_theming.update(default_locale: user.locale)
+
+      sign_in(user)
+      post(:create, entry: {title: 'some_title'})
+
+      expect(Pageflow::Entry.last.revisions.first.locale).to eq('en')
+    end
   end
 
   describe '#edit' do


### PR DESCRIPTION
Backport of #1100 

Customers who have set their language to english have reported that
the default language for new stories is still German.
This behavior was perceived as a bug.
This PR introduces a new column default_locale on account/theming level
where a default language for new stories can be specified (defaults to German),
which is then used for new stories.

For new accounts the default_locale will initially get set to the locale the user
specified during signup.

REDMINE-16323