### PR TITLE
Scope phone horizontal swipe with feature flag

### DIFF
--- a/config/locales/new/phone_horizontal_slideshow_mode_feature.de.yml
+++ b/config/locales/new/phone_horizontal_slideshow_mode_feature.de.yml
@@ -1,0 +1,4 @@
+de:
+  pageflow:
+    phone_horizontal_slideshow_mode:
+      feature_name: "Horizontales Wischen auf Phones"

--- a/config/locales/new/phone_horizontal_slideshow_mode_feature.en.yml
+++ b/config/locales/new/phone_horizontal_slideshow_mode_feature.en.yml
@@ -1,0 +1,4 @@
+en:
+  pageflow:
+    phone_horizontal_slideshow_mode:
+      feature_name: "Horizontal swipe on phone"

--- a/lib/pageflow/built_in_widget_types_plugin.rb
+++ b/lib/pageflow/built_in_widget_types_plugin.rb
@@ -3,7 +3,11 @@ module Pageflow
     def configure(config)
       config.widget_types.register(Pageflow::BuiltInWidgetType.default_slideshow_mode,
                                    default: true)
-      config.widget_types.register(Pageflow::BuiltInWidgetType.phone_horizontal_slideshow_mode)
+
+      config.features.register('phone_horizontal_slideshow_mode') do |feature_config|
+        feature_config.widget_types.register(Pageflow::BuiltInWidgetType
+                                               .phone_horizontal_slideshow_mode)
+      end
 
       config.widget_types.register(Pageflow::BuiltInWidgetType.classic_loading_spinner,
                                    default: true)


### PR DESCRIPTION
Provide a way to disable the editor option if it is not wanted.

REDMINE-15907

**Manual Update Step**

The horizontal swipe navigation on phone is now guarded by a feature
flag. If you there are entries using this functionality, make sure to
add the following line to your Pageflow initializer:

    config.features.enable_by_default('phone_horizontal_slideshow_mode')