### PR TITLE
Do not use asset host in entry stylesheet link tags

### DIFF
--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -71,9 +71,16 @@ module Pageflow
                              p: Pageflow::VERSION,
                              format: 'css')
 
-      stylesheet_link_tag(url,
-                          media: 'all',
-                          data: {name: 'entry'})
+      # We cannot use stylesheet_link_tag here since that always uses
+      # the asset host. Entry stylesheet requests are subject to
+      # `Configuration#public_entry_request_scope` and
+      # `Configuration#public_entry_redirect` which might depend on
+      # the hostname.
+      tag(:link,
+          rel: 'stylesheet',
+          href: url,
+          media: 'all',
+          data: {name: 'entry'})
     end
 
     def entry_mobile_navigation_pages(entry)

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -114,6 +114,34 @@ module Pageflow
     end
 
     describe '#entry_stylesheet_link_tag' do
+      it 'renders stylesheet link tag' do
+        revision = build_stubbed(:revision)
+        entry = PublishedEntry.new(build_stubbed(:entry), revision)
+
+        result = helper.entry_stylesheet_link_tag(entry)
+
+        expect(result).to have_selector('link[rel=stylesheet][media=all]', visible: false)
+      end
+
+      it 'sets data-name attribute' do
+        revision = build_stubbed(:revision)
+        entry = PublishedEntry.new(build_stubbed(:entry), revision)
+
+        result = helper.entry_stylesheet_link_tag(entry)
+
+        expect(result).to have_selector('link[data-name=entry]', visible: false)
+      end
+
+      it 'does not use asset_host' do
+        revision = build_stubbed(:revision)
+        entry = PublishedEntry.new(build_stubbed(:entry), revision)
+
+        controller.config.asset_host = 'some-asset-host'
+        result = helper.entry_stylesheet_link_tag(entry)
+
+        expect(result).not_to include('some-asset-host')
+      end
+
       it 'returns revision css for published entry with custom revision' do
         revision = build_stubbed(:revision)
         entry = PublishedEntry.new(build_stubbed(:entry), revision)


### PR DESCRIPTION
`Configuration#public_entry_request_scope` and
`Configuration#public_entry_redirect` can be used to restrict which
entries are accessible under which hostname. This also applies to
entry stylesheet requests. Therefore, when an asset host is
configured, we need to make sure that entry stylesheet requests are
not blocked.

`stylesheet_link_tag` always uses the asset host when a relative URL
is passed. We could pass an absolute URL using the hostname of the
current request, but that might cause problems with caching.

Enforce always using a relative URL by generating the link tag
manually.

REDMINE-16292