### PR TITLE
Run npm ci on Travis and release:prepare task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - nvm install stable
 
 before_script:
-  - bin/npm install
+  - bin/npm ci
   - bin/npm run build
   - bin/rake pageflow:dummy
   - bin/rake app:assets:precompile

--- a/lib/tasks/pageflow_tasks.rake
+++ b/lib/tasks/pageflow_tasks.rake
@@ -8,7 +8,7 @@ namespace :pageflow do
   namespace :node_package do
     desc 'Build node package'
     task :build do
-      system('bin/npm run build')
+      system('bin/npm ci && bin/npm run build')
     end
   end
 


### PR DESCRIPTION
Ensure `node_package/node_modules` match the lock file when running
tests and building releases. `npm ci` is faster and stricter than `npm
install`. From the docs:

> * The project must have an existing package-lock.json or npm-shrinkwrap.json.
>
> * If dependencies in the package lock do not match those in
>   package.json, npm ci will exit with an error, instead of updating
>   the package lock.
>
> * npm ci can only install entire projects at a time: individual
>   dependencies cannot be added with this command.
>
> * If a node_modules is already present, it will be automatically
>   removed before npm ci begins its install.
>
> * It will never write to package.json or any of the package-locks:
>   installs are essentially frozen.

REDMINE-16381