### PR TITLE
Also release pageflow-support when running release task (12.x Backport)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,10 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
+task 'release' do
+  Rake.application['pageflow:release:pageflow_support'].invoke
+end
+
 require 'semmy'
 Semmy::Tasks.install do |config|
   config.github_repository = 'codevise/pageflow'

--- a/lib/tasks/pageflow_tasks.rake
+++ b/lib/tasks/pageflow_tasks.rake
@@ -12,6 +12,16 @@ namespace :pageflow do
     end
   end
 
+  namespace :release do
+    task :pageflow_support do
+      Dir.chdir('spec/support') do
+        puts '=== Releasing pageflow-support ==='
+        system('bundle exec rake release')
+        puts '==='
+      end
+    end
+  end
+
   namespace :prune_auto_snapshots_jobs do
     desc 'Enqueue jobs to destroy old auto snapshot revisions'
     task :enqueue => :environment do


### PR DESCRIPTION
Ensure `pageflow-support` is released from the same commit as the main
gem.

To run the task even before the bump version commit is created, the
task needs to be defined before installing semmy tasks.

Note that defining a task multiple times does not override it, but
only adds additional steps. Bundler defines its `release` task via
prerequisites (e.g. `task :release => [:build, :push, :etc]`). This
causes the actual release tasks to always run before the
`pageflow:release:pageflow_support` task - even though the bundler
tasks are installed later in the Rakefile.

REDMINE-16381