### PR TITLE
Lazy load navigation bar thumbnails

### DIFF
--- a/app/assets/javascripts/pageflow/widgets/navigation.js
+++ b/app/assets/javascripts/pageflow/widgets/navigation.js
@@ -187,6 +187,7 @@
           scroller: scroller,
           scrollToActive: true,
           animationDuration: 500,
+          lazyLoadImages: true,
           onAnimationStart: function() {
             element.addClass('is_animating');
           },

--- a/app/assets/javascripts/pageflow/widgets/page_navigation_list.js
+++ b/app/assets/javascripts/pageflow/widgets/page_navigation_list.js
@@ -95,9 +95,14 @@
         return $.when(animation.enabled && animationDurationElapsed()).then(function() {
           links.each(function() {
             var link = $(this);
+            var pageIsVisible = visible(currentPagePermaId, link);
 
-            animation.finish(link.parent(), visible(currentPagePermaId, link));
-            link.parent().andSelf().toggleClass('filtered', !visible(currentPagePermaId, link));
+            animation.finish(link.parent(), pageIsVisible);
+            link.parent().andSelf().toggleClass('filtered', !pageIsVisible);
+
+            if (pageIsVisible && options.lazyLoadImages) {
+              link.loadLazyImages();
+            }
           });
 
           scroller.refresh();

--- a/app/views/pageflow/entries/_navigation.html.erb
+++ b/app/views/pageflow/entries/_navigation.html.erb
@@ -5,8 +5,7 @@
   <div class="scroller">
     <ul class="navigation_thumbnails">
       <%= render :partial => 'pageflow/entries/navigation/page',
-                 :collection => entry.pages.displayed_in_navigation,
-                 :locals => {:image_style => :navigation_thumbnail_small, :image_width => 85} %>
+                 :collection => entry.pages.displayed_in_navigation %>
     </ul>
   </div>
   <%= render 'pageflow/entries/navigation/bar_bottom', :entry => entry %>

--- a/app/views/pageflow/entries/navigation/_page.html.erb
+++ b/app/views/pageflow/entries/navigation/_page.html.erb
@@ -1,6 +1,6 @@
 <li class="<%= page_navigation_css_class(page) %>">
   <%= link_to "##{page.perma_id}", :data => {:link => page.id, :chapter_id => page.chapter_id} do %>
-      <%= image_tag(page.thumbnail_url(image_style), :width => image_width) %>
+      <%= image_tag('', data: {src: asset_path(page.thumbnail_url(:navigation_thumbnail_small))}, width: 85, height: 47) %>
   <% end %>
   <div class="navigation_site_detail">
     <%= page.title %>


### PR DESCRIPTION
Prevent loading navigation bar thumbnails of pages in hidden
storylines.

Ensure images are lazy loaded once pages become visible. In
particular, this means images are loaded after the loading indicator
disappeared. Lately we've been moving towards displaying loading
states in less important cases in favor of speeding up observed
loading time.

REDMINE-16467