### PR TITLE
Ensure entries can be filtered by publication date

### DIFF
--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -13,6 +13,11 @@ module Pageflow
         published_at { 1.day.ago }
       end
 
+      trait :not_yet_depublished do
+        published
+        published_until { 1.day.from_now }
+      end
+
       trait :depublished do
         published
         published_until { 1.day.ago }

--- a/spec/features/account_previewer/filtering_entries_by_attributes_spec.rb
+++ b/spec/features/account_previewer/filtering_entries_by_attributes_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+feature 'as account previewer, filtering entries by attributes' do
+  scenario 'filtering by publication date' do
+    account = create(:account)
+    user = Dom::Admin::Page.sign_in_as(:previewer, on: account)
+    matching_entry = create(:entry,
+                            :published,
+                            account: account,
+                            with_previewer: user,
+                            published_revision_attributes: {
+                              published_at: 40.days.ago
+                            })
+    other_entry = create(:entry,
+                         :published,
+                         account: account,
+                         with_previewer: user,
+                         published_revision_attributes: {
+                           published_at: 2.days.ago
+                         })
+
+    visit(admin_entries_path)
+    filter_form = Dom::Admin::FilterForm.find!
+    filter_form.fill_in_date_range(:published_revision_published_at,
+                                   from: 2.month.ago,
+                                   to: 1.month.ago)
+    filter_form.submit
+
+    expect(Dom::Admin::EntryInIndexTable.find_by_title(matching_entry.title)).to be_present
+    expect(Dom::Admin::EntryInIndexTable.find_by_title(other_entry.title)).not_to be_present
+  end
+end

--- a/spec/models/pageflow/revision_spec.rb
+++ b/spec/models/pageflow/revision_spec.rb
@@ -318,6 +318,32 @@ module Pageflow
       end
     end
 
+    describe '.published' do
+      it 'includes revisions that are published indefinitely' do
+        revision = create(:revision, :published)
+
+        expect(Revision.published).to include(revision)
+      end
+
+      it 'includes revisions that are published and not yet depublished' do
+        revision = create(:revision, :not_yet_depublished)
+
+        expect(Revision.published).to include(revision)
+      end
+
+      it 'does not include revisions that are not published' do
+        revision = create(:revision)
+
+        expect(Revision.published).not_to include(revision)
+      end
+
+      it 'does not include revisions that are depublished' do
+        revision = create(:revision, :depublished)
+
+        expect(Revision.published).not_to include(revision)
+      end
+    end
+
     describe '.editable' do
       it 'includes draft revisions' do
         revision = create(:revision)

--- a/spec/support/dominos/admin/filter_form.rb
+++ b/spec/support/dominos/admin/filter_form.rb
@@ -1,0 +1,20 @@
+module Dom
+  module Admin
+    class FilterForm < Domino
+      selector 'form.filter_form'
+
+      def fill_in_date_range(attribute, options)
+        within(node) do
+          fill_in("q[#{attribute}_gteq_datetime]", with: options[:from])
+          fill_in("q[#{attribute}_lteq_datetime]", with: options[:to])
+        end
+      end
+
+      def submit
+        within(node) do
+          find('[name="commit"]').click
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trying to filter entries by publication date in the entry admin index
list caused an error of the form:

    Column 'published_at' in on clause is ambiguous

The combination of the `includes(:published_revision)` in
`scoped_collection` and the `:published_revision_published_at` filter
caused the revisions table to be joined twice, making the unqualified
column `published_at` in the query of the `Revision.published` scope
ambiguous.

Since there is no documented way to obtain the current table alias,
the `published` query has been rewritten to use hash syntax instead of
an SQL fragment.

The comparison of `published_until` can be replaced with a date
range. Since `published_at` is only ever set to the current time, its
value can never be in the future. Checking for its presence is
therefore equivalent to checking whether it lies in the past.

Duplicating the `published_at IS NOT NULL` check, to make precendence
of `AND` and `OR` operators explicit.

REDMINE-16490