### PR TITLE
Add missing Active Admin translations for filters

### DIFF
--- a/config/locales/new/missing_active_admin_filters.de.yml
+++ b/config/locales/new/missing_active_admin_filters.de.yml
@@ -1,0 +1,8 @@
+de:
+  active_admin:
+    filters:
+      predicates:
+        gteq_datetime: "Größer gleich"
+        lteq_datetime: "Kleiner gleich"
+        from: "Von"
+        to: "Bis"


### PR DESCRIPTION
These are missing from the `de` locale in Active Admin 1.3.x and have
only been added in 1.4.0. Since Pageflow already duplicates a good
amount of the Active Admin locales, adding these does not really make
things worse.

REDMINE-16490