### PR TITLE
Ignore storyline order error in js specs

### DIFF
--- a/spec/support/config/capybara.rb
+++ b/spec/support/config/capybara.rb
@@ -23,6 +23,9 @@ Capybara::Chromedriver::Logger.filters = [
   # page sections.
   /Target node has markup rendered by React/i,
 
+  # Ignore failure of debounced request to save order of storylines
+  %r{stroyline/order - Failed to load resource: the server responded with a status of 401},
+
   # Ignore failure of debounced request to refresh partials while db
   # has already been cleaned
   /partials - Failed to load resource: the server responded with a status of 401/


### PR DESCRIPTION
Saving the order of storylines is debounced (see
`app/assets/javascripts/pageflow/editor/initializers/setup_collections.js`)
and is therefore sometimes triggered even after the database cleaner
has removed the corresponding entities. This leads to a 401 error that
makes the tests fails.