### PR TITLE
Display text tracks at the top if waveform is present

### DIFF
--- a/node_package/src/builtInPageTypes/audio.jsx
+++ b/node_package/src/builtInPageTypes/audio.jsx
@@ -35,7 +35,8 @@ function AudioPage(props) {
       <PageBackgroundAsset />
       <PageAudioFilePlayer file={props.audioFile}
                            playerState={props.playerState}
-                           playerActions={props.playerActions} />
+                           playerActions={props.playerActions}
+                           textTrackPosition={textTrackPosition(playerControlsVariant)} />
     </MediaPage>
   );
 }
@@ -46,6 +47,12 @@ function playerControlsComponent(variant) {
   }
   else {
     return PlayerControls;
+  }
+}
+
+function textTrackPosition(variant) {
+  if (variant == 'waveform') {
+    return 'top';
   }
 }
 

--- a/node_package/src/media/components/PageFilePlayer.jsx
+++ b/node_package/src/media/components/PageFilePlayer.jsx
@@ -21,7 +21,8 @@ export function PageFilePlayer(props) {
                   muted={props.muted}
                   playsInline={props.playsInline}
                   defaultTextTrackFileId={props.defaultTextTrackFileId}
-                  textTracksEnabled={props.textTracksEnabled} />
+                  textTracksEnabled={props.textTracksEnabled}
+                  textTrackPosition={props.textTrackPosition} />
     );
   }
   else if (props.preloadComponent && fileReady && props.pageIsPreloaded) {

--- a/node_package/src/media/components/createFilePlayer/index.jsx
+++ b/node_package/src/media/components/createFilePlayer/index.jsx
@@ -174,7 +174,11 @@ export default function({
 
 const slimPlayerControlsPresent = widgetPresent('slimPlayerControls');
 
-function textTrackPosition(state, {playerState}) {
+function textTrackPosition(state, {playerState, textTrackPosition}) {
+  if (textTrackPosition) {
+    return textTrackPosition;
+  }
+
   if (slimPlayerControlsPresent(state)) {
     // see pageflow.VideoPlayer#updateCueLineSettings for explanation of values.
     if (playerState.controlsHidden) {


### PR DESCRIPTION
Prevent displaying text tracks behind the waveform player controls.

REDMINE-16524