### PR TITLE
Fix mask image in Safari 12

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/mixins/masks.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/mixins/masks.scss
@@ -1,7 +1,8 @@
-  // scss-lint:disable VendorPrefix
+// scss-lint:disable VendorPrefix
 
 @mixin mask-bottom {
-  -webkit-mask-image: image-url("pageflow/themes/default/mask_bottom.png");
+  // Safari 12 requires CORS headers for mask images
+  -webkit-mask-image: image-path-ignoring-asset-host("pageflow/themes/default/mask_bottom.png");
   -webkit-mask-position: bottom left;
   -webkit-mask-repeat: repeat-x;
 }

--- a/config/initializers/sass.rb
+++ b/config/initializers/sass.rb
@@ -1,0 +1,5 @@
+module SassC::Script::Functions
+  def image_path_ignoring_asset_host(path)
+    asset_path(path, type: :image, host: ->(*) { nil })
+  end
+end

--- a/spec/pageflow/sass_functions_spec.rb
+++ b/spec/pageflow/sass_functions_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'ostruct'
+
+module Pageflow
+  describe 'sass functions' do
+    describe 'image-path-ignoring-asset-host' do
+      it 'ignores asset host' do
+        with_asset_host 'http://some-asset-host' do
+          image_url_result = render_scss(<<-CSS)
+            div { background-image: image-url("pageflow/down.png"); }
+          CSS
+
+          image_url_ignoring_asset_host_result = render_scss(<<-CSS)
+            div { background-image: image-url-ignoring-asset-host("pageflow/down.png"); }
+          CSS
+
+          expect(image_url_result).to include('some-asset-host')
+          expect(image_url_ignoring_asset_host_result).not_to include('some-asset-host')
+        end
+      end
+
+      def render_scss(template)
+        environment = Sprockets::Railtie.build_environment(Rails.application)
+        engine = SassC::Rails::SassTemplate.new
+
+        engine.call(environment: environment,
+                    filename: '/',
+                    data: template.strip,
+                    metadata: {})[:data]
+      end
+
+      def with_asset_host(asset_host)
+        backup = Rails.application.config.action_controller.asset_host
+        Rails.application.config.action_controller.asset_host = asset_host
+
+        yield
+      ensure
+        Rails.application.config.action_controller.asset_host = backup
+      end
+    end
+  end
+end


### PR DESCRIPTION
Safari 12 requires CORS headers for cross origin mask images. Do not
use asset host in mask image url to support CDN setups which do not
set CORS headers for static assets.

REDMINE-16141

x# Please enter the commit message for your changes. Lines starting