### PR TITLE
Re-apply loop patch for Audio5js

### DIFF
--- a/vendor/assets/javascripts/audio5.min.js
+++ b/vendor/assets/javascripts/audio5.min.js
@@ -514,7 +514,9 @@
    * HTML5 Audio Player
    * @constructor
    */
-  HTML5AudioPlayer = function () {};
+  HTML5AudioPlayer = function (options) {
+    this.options = options;
+  };
 
   HTML5AudioPlayer.prototype = {
     /**
@@ -533,6 +535,10 @@
       this.audio.preload = 'auto';
       this.audio.autobuffer = true;
       this.audio.playbackRate = this._rate;
+
+      if (this.options.loop) {
+        this.audio.setAttribute('loop', 'true');
+      }
 
       this.audio.setAttribute('crossorigin', 'anonymous');
 
@@ -887,7 +893,7 @@
         for (i = 0, l = this.settings.codecs.length; i < l; i++) {
           codec = this.settings.codecs[i];
           if (Audio5js.can_play(codec)) {
-            player = new HTML5AudioPlayer();
+            player = new HTML5AudioPlayer(this.settings);
             this.settings.use_flash = false;
             this.settings.player = {
               engine: 'html',
@@ -899,7 +905,7 @@
         if (player === undefined) {
           // here we double check for mp3 support instead of defaulting to Flash in case user overrode the settings.codecs array with an empty array.
           this.settings.use_flash = !Audio5js.can_play('mp3');
-          player = this.settings.use_flash ? new FlashAudioPlayer() : new HTML5AudioPlayer();
+          player = this.settings.use_flash ? new FlashAudioPlayer() : new HTML5AudioPlayer(this.settings);
           this.settings.player = {
             engine: (this.settings.use_flash ? 'flash' : 'html'),
             codec: 'mp3'


### PR DESCRIPTION
Support for loop option was accidentally removed in #1018.

REDMINE-16543