### PR TITLE
Fix cracking noises in audios on Safari

### DIFF
--- a/app/assets/javascripts/pageflow/browser.js
+++ b/app/assets/javascripts/pageflow/browser.js
@@ -81,10 +81,17 @@ pageflow.browser = (function(){
 
       var asyncHas = function(name) {
         var runTest = function() {
-          if ((pageflow.debugMode() || pageflow.ALLOW_FEATURE_OVERRIDES) &&
-              window.localStorage &&
-              typeof window.localStorage['override ' + name] !== 'undefined') {
-            var value = (window.localStorage['override ' + name] === 'on');
+          var value, underscoredName = name.replace(/ /g, '_');
+
+          if (pageflow.debugMode() && location.href.indexOf('&has=' + underscoredName) >= 0) {
+            value = location.href.indexOf('&has=' + underscoredName + '_on') >= 0;
+            pageflow.log('FEATURE OVERRIDDEN ' + name + ': ' + value, {force: true});
+            return value;
+          }
+          else if ((pageflow.debugMode() || pageflow.ALLOW_FEATURE_OVERRIDES) &&
+                   window.localStorage &&
+                   typeof window.localStorage['override ' + name] !== 'undefined') {
+            value = (window.localStorage['override ' + name] === 'on');
             pageflow.log('FEATURE OVERRIDDEN ' + name + ': ' + value, {force: true});
             return value;
           }

--- a/app/assets/javascripts/pageflow/browser/agent.js
+++ b/app/assets/javascripts/pageflow/browser/agent.js
@@ -8,6 +8,10 @@ pageflow.browser.Agent = function(userAgent) {
       return matches(/\bSilk\b/);
     },
 
+    matchesDesktopSafari: function() {
+      return this.matchesSafari() && !this.matchesMobilePlatform();
+    },
+
     matchesDesktopSafari9: function() {
       return this.matchesSafari9() && !this.matchesMobilePlatform();
     },

--- a/app/assets/javascripts/pageflow/browser/volume_control_support.js
+++ b/app/assets/javascripts/pageflow/browser/volume_control_support.js
@@ -1,3 +1,7 @@
 pageflow.browser.feature('volume control support', function(has) {
   return has.not('ios platform');
 });
+
+pageflow.browser.feature('audio context volume fading support', function() {
+  return !pageflow.browser.agent.matchesDesktopSafari();
+});

--- a/app/assets/javascripts/pageflow/media_player/volume_fading.js
+++ b/app/assets/javascripts/pageflow/media_player/volume_fading.js
@@ -5,7 +5,8 @@ pageflow.mediaPlayer.volumeFading = function(player) {
   if (!pageflow.browser.has('volume control support')) {
     return pageflow.mediaPlayer.volumeFading.noop(player);
   }
-  else if (pageflow.audioContext.get() && player.getMediaElement) {
+  else if (pageflow.browser.has('audio context volume fading support') &&
+           pageflow.audioContext.get() && player.getMediaElement) {
     return pageflow.mediaPlayer.volumeFading.webAudio(
       player,
       pageflow.audioContext.get()

--- a/spec/javascripts/pageflow/browser/agent_spec.js
+++ b/spec/javascripts/pageflow/browser/agent_spec.js
@@ -55,4 +55,24 @@ describe('pageflow.browser.Agent', function() {
       expect(agent.matchesSafari11AndAbove()).to.eq(false);
     });
   });
+
+  describe('#matchesDesktopSafari', function() {
+    it('returns true for Safari 12', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) ' +
+        'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15'
+      );
+
+      expect(agent.matchesDesktopSafari()).to.eq(true);
+    });
+
+    it('returns false for Safari on iPhone', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_1 like Mac OS X) '+
+        'AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A403 Safari/602.1'
+      );
+
+      expect(agent.matchesDesktopSafari()).to.eq(false);
+    });
+  });
 });


### PR DESCRIPTION
When using Webaudio API there are cracking noises when playing
audio. Revert to legacy interval based volume fading for desktop
Safari.

Allow overriding browser feature flags via query string.

REDMINE-15776