### PR TITLE
Prevent missing first pagepreloaded event in pageflow.ready

### DIFF
--- a/app/assets/javascripts/pageflow/ready.js
+++ b/app/assets/javascripts/pageflow/ready.js
@@ -1,10 +1,14 @@
 pageflow.ready = new $.Deferred(function(readyDeferred) {
+  var pagePreloaded = new $.Deferred(function(pagePreloadedDeferred) {
+    $(document).one('pagepreloaded', pagePreloadedDeferred.resolve);
+  }).promise();
+
   window.onload = function() {
     pageflow.browser.detectFeatures().then(function() {
       var slideshow = $('[data-role=slideshow]');
       var body = $('body');
 
-      body.one('pagepreloaded', function() {
+      pagePreloaded.then(function() {
         readyDeferred.resolve();
         pageflow.events.trigger('ready');
       });


### PR DESCRIPTION
The editor initializes the slideshow independently of the
`pageflow.ready` promise. This can cause the first `pagepreloaded`
event to be dispatched even before feature detection has finished.

In these cases `pageflow.ready` stayed pending and features depending
on `pageflow.ready` (e.g. lazy loading of thumbnails in the built in
navigation bar) did not work correctly.

Start listening for a `pagepreload` event on the document element
right away and track whether the event occurred with a promise.

REDMINE-16546