### PR TITLE
Increase max length for page tagline, title and subtitles

### DIFF
--- a/app/assets/javascripts/pageflow/editor/views/configuration_editors/groups/general.js
+++ b/app/assets/javascripts/pageflow/editor/views/configuration_editors/groups/general.js
@@ -1,8 +1,8 @@
 pageflow.ConfigurationEditorTabView.groups.define('general', function() {
-  this.input('title', pageflow.TextInputView, {required: true});
+  this.input('title', pageflow.TextInputView, {required: true, maxLength: 5000});
   this.input('hide_title', pageflow.CheckBoxInputView);
-  this.input('tagline', pageflow.TextInputView);
-  this.input('subtitle', pageflow.TextInputView);
+  this.input('tagline', pageflow.TextInputView, {maxLength: 5000});
+  this.input('subtitle', pageflow.TextInputView, {maxLength: 5000});
   this.input('text', pageflow.TextAreaInputView);
   this.input('text_position', pageflow.SelectInputView, {values: pageflow.Page.textPositions});
   this.input('gradient_opacity', pageflow.SliderInputView);


### PR DESCRIPTION
Some people rely on long titles as a workaround for missing formatting
options.

REDMINE-16574