### PR TITLE
Migrate files whose upload failed

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/hosted_file.js
+++ b/app/assets/javascripts/pageflow/editor/models/hosted_file.js
@@ -4,7 +4,7 @@ pageflow.HostedFile = pageflow.UploadedFile.extend({
       {
         name: 'uploading',
         activeStates: ['uploading'],
-        failedStates: ['upload_failed']
+        failedStates: ['uploading_failed']
       }
     ].concat(_.result(this, 'processingStages'));
   },

--- a/app/assets/javascripts/pageflow/editor/models/image_file.js
+++ b/app/assets/javascripts/pageflow/editor/models/image_file.js
@@ -3,7 +3,7 @@ pageflow.ImageFile = pageflow.UploadedFile.extend({
     {
       name: 'uploading',
       activeStates: ['uploading'],
-      failedStates: ['upload_failed']
+      failedStates: ['uploading_failed']
     },
     {
       name: 'processing',

--- a/app/assets/javascripts/pageflow/editor/models/uploaded_file.js
+++ b/app/assets/javascripts/pageflow/editor/models/uploaded_file.js
@@ -75,7 +75,7 @@ pageflow.UploadedFile = Backbone.Model.extend({
   },
 
   isUploaded: function() {
-    return this.get('state') !== 'uploading' && this.get('state') !== 'upload_failed';
+    return this.get('state') !== 'uploading' && this.get('state') !== 'uploading_failed';
   },
 
   isPending: function() {
@@ -118,10 +118,9 @@ pageflow.UploadedFile = Backbone.Model.extend({
   },
 
   uploadFailed: function() {
-    this.set('state', 'upload_failed');
+    this.set('state', 'uploading_failed');
     this.unset('uploading_progress');
     this.trigger('uploadFailed');
-    this.destroy();
   },
 
   publish: function() {

--- a/app/models/concerns/pageflow/hosted_file.rb
+++ b/app/models/concerns/pageflow/hosted_file.rb
@@ -54,6 +54,10 @@ module Pageflow
       {}
     end
 
+    def can_upload?
+      uploading?
+    end
+
     def retryable?
       false
     end

--- a/app/models/concerns/pageflow/uploaded_file.rb
+++ b/app/models/concerns/pageflow/uploaded_file.rb
@@ -56,6 +56,12 @@ module Pageflow
       "#{super}-#{state}"
     end
 
+    def can_upload?
+      # Overwritten in HostedFile based on initial state_machine-state.
+      # Only true directly after creation.
+      false
+    end
+
     def direct_upload_config
       Pageflow.config.paperclip_direct_upload_options.call(attachment)
     end

--- a/app/views/pageflow/editor/files/_file.json.jbuilder
+++ b/app/views/pageflow/editor/files/_file.json.jbuilder
@@ -7,7 +7,7 @@ json.call(file,
           :rights,
           :usage_id)
 
-if file.uploading?
+if file.can_upload?
   json.direct_upload_config(file.direct_upload_config)
 end
 

--- a/db/migrate/20190306161431_copy_file_attributes_of_failed_uploads.rb
+++ b/db/migrate/20190306161431_copy_file_attributes_of_failed_uploads.rb
@@ -1,0 +1,25 @@
+class CopyFileAttributesOfFailedUploads < ActiveRecord::Migration[5.2]
+  def up
+    %w(audio text_track video).each do |hosted_file_type|
+      execute("UPDATE pageflow_#{hosted_file_type}_files hf
+                   SET hf.attachment_on_s3_file_name = hf.attachment_on_filesystem_file_name,
+                       hf.attachment_on_s3_content_type = hf.attachment_on_filesystem_content_type,
+                       hf.attachment_on_s3_file_size = hf.attachment_on_filesystem_file_size,
+                       hf.attachment_on_s3_updated_at = hf.attachment_on_filesystem_updated_at,
+                       hf.state = 'uploading_failed'
+                   WHERE hf.state = 'uploading_to_s3_failed';")
+    end
+  end
+
+  def down
+    %w(audio text_track video).each do |hosted_file_type|
+      execute("UPDATE pageflow_#{hosted_file_type}_files hf
+                   SET hf.attachment_on_s3_file_name = NULL,
+                       hf.attachment_on_s3_content_type = NULL,
+                       hf.attachment_on_s3_file_size = NULL,
+                       hf.attachment_on_s3_updated_at = NULL,
+                       hf.state = 'uploading_to_s3_failed'
+                   WHERE hf.state = 'uploading_failed';")
+    end
+  end
+end

--- a/spec/javascripts/models/mixins/stage_provider_spec.js
+++ b/spec/javascripts/models/mixins/stage_provider_spec.js
@@ -8,7 +8,7 @@ describe('stageProvider', function() {
       {
         name: 'uploading',
         activeStates: ['upload_running'],
-        failedStates: ['upload_failed']
+        failedStates: ['uploading_failed']
       },
       {
         name: 'checking',
@@ -59,7 +59,7 @@ describe('stageProvider', function() {
           {
             name: 'uploading',
             activeStates: ['upload_running'],
-            failedStates: ['upload_failed']
+            failedStates: ['uploading_failed']
           }
         ];
       }

--- a/spec/javascripts/models/uploaded_file_spec.js
+++ b/spec/javascripts/models/uploaded_file_spec.js
@@ -22,7 +22,7 @@ describe('UploadedFile', function() {
 
   describe('#isFailed', function() {
     it('returns true if state ends with _failed', function() {
-      var file = new File({state: 'upload_failed'});
+      var file = new File({state: 'uploading_failed'});
 
       expect(file.isFailed()).to.eq(true);
     });


### PR DESCRIPTION
- Copy filesystem attributes for legacy files in state uploading_failed to s3-related attributes
- mirror new uploading_failed backend state to frontend representation
- remove destroy-call when uploads fail to keep the records persisted in the failed state

REDMINE-16119