### PR TITLE
Add shared specs to pageflow-support to lint page types (13.x backbort)

### DIFF
--- a/app/helpers/pageflow/page_types_helper.rb
+++ b/app/helpers/pageflow/page_types_helper.rb
@@ -8,6 +8,12 @@ module Pageflow
                           as: :page_type)
     end
 
+    def page_type_json_seed(json, page_type)
+      if page_type.json_seed_template
+        json.partial!(template: page_type.json_seed_template, locals: {page_type: page_type})
+      end
+    end
+
     def page_type_templates(entry)
       safe_join(Pageflow.config.page_types.map do |page_type|
         content_tag(:script,

--- a/app/views/pageflow/page_types/_page_type.json.jbuilder
+++ b/app/views/pageflow/page_types/_page_type.json.jbuilder
@@ -17,6 +17,4 @@ json.thumbnail_candidates(page_type.thumbnail_candidates) do |candidate|
   end
 end
 
-if page_type.json_seed_template
-  json.partial!(:template => page_type.json_seed_template, :locals => {:page_type => page_type})
-end
+page_type_json_seed(json, page_type)

--- a/app/views/pageflow/react/page.html.erb
+++ b/app/views/pageflow/react/page.html.erb
@@ -1,6 +1,6 @@
 <% if page.template.present? %>
   <% concat React::ServerRendering.render(
      'pageflow.react.ServerSidePage',
-     %Q'{ "resolverSeed": #{@_pageflow_react_entry_seed ||= entry_json_seed(@entry)}, "pageId": #{page.perma_id}, "pageType": "#{page.template}" }',
+     %Q'{ "resolverSeed": #{@_pageflow_react_entry_seed ||= entry_json_seed(entry)}, "pageId": #{page.perma_id}, "pageType": "#{page.template}" }',
      true) %>
 <% end %>

--- a/doc/creating_page_types.md
+++ b/doc/creating_page_types.md
@@ -259,8 +259,12 @@ that users of our plugin can reference in their Pageflow initializer:
 module Rainbow
   class Plugin < Pageflow::Plugin
     def configure(config)
-      config.page_types.register(Pageflow::React.create_page_type('rainbow'))
+      config.page_types.register(Rainbow.page_type)
     end
+  end
+
+  def self.page_type
+    Pageflow::React.create_page_type('rainbow')
   end
 
   def self.plugin
@@ -284,3 +288,16 @@ There are some advanced customizations:
 
 * [Defining thumbnail candidates](#)
 * [Defining revision components](#)
+
+## Using Shared Examples to Test Integration
+
+Pageflow provides a set of shared examples that can be used in a
+plugin's test suite to ensure the page type integrates correctly:
+
+```ruby
+# rainbow/spec/integration/page_type_spec.rb
+require 'spec_helper'
+require 'pageflow/lint'
+
+Pageflow::Lint.page_type(Pageflow::Rainbow.page_type)
+```

--- a/lib/pageflow/built_in_page_type.rb
+++ b/lib/pageflow/built_in_page_type.rb
@@ -1,0 +1,73 @@
+module Pageflow
+  # @api private
+  module BuiltInPageType
+    def self.plain
+      Pageflow::React.create_page_type('background_image',
+                                       thumbnail_candidates: default_thumbnail_candidates,
+                                       file_types: [
+                                         BuiltInFileType.image,
+                                         BuiltInFileType.video
+                                       ])
+    end
+
+    def self.video
+      Pageflow::React.create_page_type('video',
+                                       thumbnail_candidates: video_thumbnail_candidates,
+                                       file_types: [
+                                         BuiltInFileType.image,
+                                         BuiltInFileType.video
+                                       ])
+    end
+
+    def self.audio
+      Pageflow::React.create_page_type('audio',
+                                       thumbnail_candidates: default_thumbnail_candidates,
+                                       file_types: [
+                                         BuiltInFileType.audio,
+                                         BuiltInFileType.image,
+                                         BuiltInFileType.video
+                                       ])
+    end
+
+    def self.video_thumbnail_candidates
+      [
+        {file_collection: 'image_files', attribute: 'thumbnail_image_id'},
+        {file_collection: 'image_files', attribute: 'poster_image_id'},
+        {file_collection: 'video_files', attribute: 'video_file_id'}
+      ]
+    end
+
+    def self.default_thumbnail_candidates
+      [
+        {
+          file_collection: 'image_files',
+          attribute: 'thumbnail_image_id'
+        },
+        {
+          file_collection: 'image_files',
+          attribute: 'background_image_id',
+          unless: {
+            attribute: 'background_type',
+            value: 'video'
+          }
+        },
+        {
+          file_collection: 'image_files',
+          attribute: 'poster_image_id',
+          if: {
+            attribute: 'background_type',
+            value: 'video'
+          }
+        },
+        {
+          file_collection: 'video_files',
+          attribute: 'video_file_id',
+          if: {
+            attribute: 'background_type',
+            value: 'video'
+          }
+        }
+      ]
+    end
+  end
+end

--- a/lib/pageflow/built_in_page_types_plugin.rb
+++ b/lib/pageflow/built_in_page_types_plugin.rb
@@ -1,80 +1,9 @@
 module Pageflow
   class BuiltInPageTypesPlugin < Plugin
     def configure(config)
-      config.page_types.register(plain_page_type)
-      config.page_types.register(video_page_type)
-      config.page_types.register(audio_page_type)
-    end
-
-    private
-
-    def plain_page_type
-      Pageflow::React.create_page_type('background_image',
-                                       thumbnail_candidates: default_thumbnail_candidates,
-                                       file_types: [
-                                         BuiltInFileType.image,
-                                         BuiltInFileType.video
-                                       ])
-    end
-
-    def video_page_type
-      Pageflow::React.create_page_type('video',
-                                       thumbnail_candidates: video_thumbnail_candidates,
-                                       file_types: [
-                                         BuiltInFileType.image,
-                                         BuiltInFileType.video
-                                       ])
-    end
-
-    def audio_page_type
-      Pageflow::React.create_page_type('audio',
-                                       thumbnail_candidates: default_thumbnail_candidates,
-                                       file_types: [
-                                         BuiltInFileType.audio,
-                                         BuiltInFileType.image,
-                                         BuiltInFileType.video
-                                       ])
-    end
-
-    def video_thumbnail_candidates
-      [
-        {file_collection: 'image_files', attribute: 'thumbnail_image_id'},
-        {file_collection: 'image_files', attribute: 'poster_image_id'},
-        {file_collection: 'video_files', attribute: 'video_file_id'}
-      ]
-    end
-
-    def default_thumbnail_candidates
-      [
-        {
-          file_collection: 'image_files',
-          attribute: 'thumbnail_image_id'
-        },
-        {
-          file_collection: 'image_files',
-          attribute: 'background_image_id',
-          unless: {
-            attribute: 'background_type',
-            value: 'video'
-          }
-        },
-        {
-          file_collection: 'image_files',
-          attribute: 'poster_image_id',
-          if: {
-            attribute: 'background_type',
-            value: 'video'
-          }
-        },
-        {
-          file_collection: 'video_files',
-          attribute: 'video_file_id',
-          if: {
-            attribute: 'background_type',
-            value: 'video'
-          }
-        }
-      ]
+      config.page_types.register(BuiltInPageType.plain)
+      config.page_types.register(BuiltInPageType.video)
+      config.page_types.register(BuiltInPageType.audio)
     end
   end
 end

--- a/spec/pageflow/built_in_page_type_spec.rb
+++ b/spec/pageflow/built_in_page_type_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+require 'pageflow/lint'
+
+module Pageflow
+  Pageflow::Lint.page_type(BuiltInPageType.plain)
+  Pageflow::Lint.page_type(BuiltInPageType.video)
+  Pageflow::Lint.page_type(BuiltInPageType.audio)
+end

--- a/spec/support/pageflow-support.gemspec
+++ b/spec/support/pageflow-support.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mysql2', '~> 0.5.2'
 
   s.add_runtime_dependency 'domino', '~> 0.7.0'
-  s.add_runtime_dependency 'factory_bot', '~> 4.8'
+  s.add_runtime_dependency 'factory_bot_rails', '~> 4.8'
 
   s.add_runtime_dependency 'listen', '~> 3.0'
   s.add_runtime_dependency 'bootsnap', '~> 1.0'

--- a/spec/support/pageflow/lint.rb
+++ b/spec/support/pageflow/lint.rb
@@ -1,6 +1,9 @@
 require 'pageflow/global_config_api_test_helper'
 require 'pageflow/test_page_type'
 
+require 'pageflow/lint/file_type'
+require 'pageflow/lint/page_type'
+
 module Pageflow
   # Shared examples providing integration level specs for Pageflow
   # components commonly defined by plugins.
@@ -24,53 +27,26 @@ module Pageflow
     #                              create_file_type: -> { SomePlugin.file_type },
     #                              create_file: -> { create(:some_file) })
     #   end
-    def self.file_type(name, create_file_type:, create_file:)
-      GlobalConfigApiTestHelper.setup
+    def self.file_type(*args)
+      Lint::FileType.lint(*args)
+    end
 
-      RSpec.describe "file type #{name}", type: :helper do
-        let(:file_type, &create_file_type)
-
-        let(:file, &create_file)
-
-        before do
-          pageflow_configure do |config|
-            page_type = TestPageType.new(name: :test,
-                                         file_types: [file_type])
-            config.page_types.clear
-            config.page_types.register(page_type)
-          end
-        end
-
-        it 'renders seed json without error' do
-          expect {
-            helper.extend(FilesHelper)
-            helper.render(partial: 'pageflow/files/file',
-                          formats: [:json],
-                          locals: {
-                            file: UsedFile.new(file, FileUsage.new),
-                            file_type: file_type
-                          })
-          }.not_to raise_error
-        end
-
-        it 'renders editor json without error' do
-          helper.extend(FilesHelper)
-          helper.render(partial: 'pageflow/editor/files/file',
-                        formats: [:json],
-                        locals: {
-                          file: UsedFile.new(file, FileUsage.new),
-                          file_type: file_type
-                        })
-        end
-
-        it 'provides css_background_image_urls that returns hash if present' do
-          if file_type.css_background_image_urls
-            result = file_type.css_background_image_urls.call(file)
-
-            expect(result).to be_a(Hash)
-          end
-        end
-      end
+    # Contract specs for page types
+    #
+    # @param page_type [PageType] Page type to run specs for
+    #
+    # @since edge
+    #
+    # @example
+    #
+    #   require 'spec_helper'
+    #   require 'pageflow/lint'
+    #
+    #   module SomePlugin
+    #     Pageflow::Lint.page_type(SomePLugin.page_type)
+    #   end
+    def self.page_type(*args)
+      Lint::PageType.lint(*args)
     end
   end
 end

--- a/spec/support/pageflow/lint/file_type.rb
+++ b/spec/support/pageflow/lint/file_type.rb
@@ -1,0 +1,58 @@
+require 'pageflow/global_config_api_test_helper'
+require 'pageflow/test_page_type'
+
+module Pageflow
+  module Lint
+    # @api private
+    module FileType
+      def self.lint(name, create_file_type:, create_file:)
+        GlobalConfigApiTestHelper.setup
+
+        RSpec.describe "file type #{name}", type: :helper do
+          let(:file_type, &create_file_type)
+
+          let(:file, &create_file)
+
+          before do
+            pageflow_configure do |config|
+              page_type = TestPageType.new(name: :test,
+                                           file_types: [file_type])
+              config.page_types.clear
+              config.page_types.register(page_type)
+            end
+          end
+
+          it 'renders seed json without error' do
+            expect {
+              helper.extend(FilesHelper)
+              helper.render(partial: 'pageflow/files/file',
+                            formats: [:json],
+                            locals: {
+                              file: UsedFile.new(file, FileUsage.new),
+                              file_type: file_type
+                            })
+            }.not_to raise_error
+          end
+
+          it 'renders editor json without error' do
+            helper.extend(FilesHelper)
+            helper.render(partial: 'pageflow/editor/files/file',
+                          formats: [:json],
+                          locals: {
+                            file: UsedFile.new(file, FileUsage.new),
+                            file_type: file_type
+                          })
+          end
+
+          it 'provides css_background_image_urls that returns hash if present' do
+            if file_type.css_background_image_urls
+              result = file_type.css_background_image_urls.call(file)
+
+              expect(result).to be_a(Hash)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/pageflow/lint/page_type.rb
+++ b/spec/support/pageflow/lint/page_type.rb
@@ -1,0 +1,51 @@
+require 'pageflow/render_page_test_helper'
+
+module Pageflow
+  module Lint
+    # @api private
+    module PageType
+      def self.lint(page_type)
+        GlobalConfigApiTestHelper.setup
+
+        RSpec.describe "page type #{page_type.name}", type: :helper do
+          include RenderPageTestHelper
+
+          before do
+            pageflow_configure do |config|
+              config.page_types.register(page_type)
+            end
+          end
+
+          it 'renderer page template without error' do
+            expect {
+              render_page(page_type)
+            }.not_to raise_error
+          end
+
+          it 'renders json seed template without error' do
+            helper.extend(PageTypesHelper)
+
+            expect {
+              JbuilderTemplate.encode(helper) do |json|
+                helper.page_type_json_seed(json, page_type)
+              end
+            }.not_to raise_error
+          end
+
+          it 'defines all required translations' do
+            expect(page_type.translation_key).to have_translation
+            expect(page_type.description_translation_key).to have_translation
+            expect(page_type.category_translation_key).to have_translation
+            expect(page_type.help_entry_translation_key).to have_translation
+          end
+
+          matcher :have_translation do
+            match do |key|
+              I18n.t(key, exception_handler: ->(*) { false })
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/pageflow/render_page_test_helper.rb
+++ b/spec/support/pageflow/render_page_test_helper.rb
@@ -1,0 +1,25 @@
+require 'pageflow/global_config_api_test_helper'
+require 'factory_bot_rails'
+
+module Pageflow
+  module RenderPageTestHelper
+    def render_page(page_type, configuration = {})
+      page = FactoryBot.create(:page, template: page_type.name, configuration: configuration)
+      revision = page.chapter.storyline.revision
+      entry = PublishedEntry.new(revision.entry, revision)
+
+      helper.extend(InfoBoxHelper)
+      helper.extend(BackgroundImageHelper)
+      helper.extend(EntryJsonSeedHelper)
+      helper.extend(PageBackgroundAssetHelper)
+      helper.extend(PagesHelper)
+      helper.extend(VideoFilesHelper)
+
+      page_type.view_helpers.each do |page_type_helper|
+        helper.extend(page_type_helper)
+      end
+
+      helper.render_page_template(page, entry: entry)
+    end
+  end
+end


### PR DESCRIPTION
Backport of #1133

This can be used by plugin engines to

* check that rendering page template does not raise errors

* check that rendering json seed does not raise errors

* check that all required translations are defined

Make `pageflow-support` depend on `factory_bot_rails` instead of
`factory_bot` to make sure factories are loaded automatically.

REDMINE-16511