### PR TITLE
Change page DOM layout

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/page_split_layout.js
+++ b/app/assets/javascripts/pageflow/slideshow/page_split_layout.js
@@ -31,21 +31,21 @@ pageflow.pageSplitLayout = (function() {
   };
 
   function getContentClientRect(pageElement, pageClientRect) {
-    var pageTitle = pageElement.find('.page_header .title');
-    var contentText = pageElement.find('.contentText p');
+    var pageTitle = pageElement.find('.page_header-title');
+    var pageText = pageElement.find('.page_text p');
 
     var pageTitleClientRect = pageTitle[0].getBoundingClientRect();
-    var contentTextClientRect = contentText[0].getBoundingClientRect();
+    var pageTextClientRect = pageText[0].getBoundingClientRect();
 
     var contentRight;
     var contentLeft;
 
     if (isTitleHidden(pageTitleClientRect)) {
-      contentRight = contentTextClientRect.right;
-      contentLeft = contentTextClientRect.left;
+      contentRight = pageTextClientRect.right;
+      contentLeft = pageTextClientRect.left;
     }
     else {
-      contentRight = Math.max(pageTitleClientRect.right, contentTextClientRect.right);
+      contentRight = Math.max(pageTitleClientRect.right, pageTextClientRect.right);
       contentLeft = pageTitleClientRect.left;
     }
 
@@ -63,7 +63,7 @@ pageflow.pageSplitLayout = (function() {
   }
 
   function getContentTranslationCausedByHiddenText(pageElement, pageClientRect) {
-    var contentWrapper = pageElement.find('.contentWrapper');
+    var contentWrapper = pageElement.find('.content_wrapper');
     var contentWrapperClientRect = contentWrapper[0].getBoundingClientRect();
 
     var contentWrapperMarginInsidePage = contentWrapper[0].offsetLeft;

--- a/app/assets/javascripts/pageflow/slideshow/page_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/page_widget.js
@@ -214,7 +214,7 @@
 
     _setupContentLinkTargetHandling: function() {
       this._on({
-        'click .contentText p a': function(event) {
+        'click .page_text p a': function(event) {
           var href = $(event.currentTarget).attr('href');
 
           if (href[0] === '#') {

--- a/app/assets/stylesheets/pageflow/delayed_text_fade_in.scss
+++ b/app/assets/stylesheets/pageflow/delayed_text_fade_in.scss
@@ -1,17 +1,18 @@
 .has_css_animations section.active {
-
   &.delayed_text_fade_in_short {
     .page_header {
       opacity: 0;
 
       @include animation(fade_in ease forwards 2s 1s);
     }
+
     .shadow_wrapper {
       opacity: 0;
 
       @include animation(fade_in ease forwards 2s 0s);
     }
-    .contentText {
+
+    .page_text {
       opacity: 0;
       @include animation(fade_in ease forwards 2s 2s);
     }
@@ -22,11 +23,13 @@
       opacity: 0;
       @include animation(fade_in ease forwards 2s 3s);
     }
+
     .shadow_wrapper {
       opacity: 0;
       @include animation(fade_in ease forwards 2s 2s);
     }
-    .contentText {
+
+    .page_text {
       opacity: 0;
       @include animation(fade_in ease forwards 2s 4s);
     }
@@ -37,11 +40,13 @@
       opacity: 0;
       @include animation(fade_in ease forwards 2s 5s);
     }
+
     .shadow_wrapper {
       opacity: 0;
       @include animation(fade_in ease forwards 2s 4s);
     }
-    .contentText {
+
+    .page_text {
       opacity: 0;
       @include animation(fade_in ease forwards 2s 6s);
     }

--- a/app/assets/stylesheets/pageflow/hide_text.scss
+++ b/app/assets/stylesheets/pageflow/hide_text.scss
@@ -1,4 +1,4 @@
-.slideshow .content .contentWrapper {
+.slideshow .content .content_wrapper {
   -webkit-transition: 0.8s ease !important;
   -moz-transition: 0.8s ease !important;
   -ms-transition: 0.8s ease !important;
@@ -15,7 +15,7 @@
     visibility: hidden;
   }
 
-  .slideshow .content .contentWrapper {
+  .slideshow .content .content_wrapper {
     @include transform(translate3d(-200%,0,0));
   }
 

--- a/app/assets/stylesheets/pageflow/lt_ie9.scss
+++ b/app/assets/stylesheets/pageflow/lt_ie9.scss
@@ -62,7 +62,7 @@
   }
 }
 
-.videoPage {
+.video_page {
   .fade-in {
     visibility: visible !important;
   }
@@ -72,7 +72,8 @@
   }
 }
 
-.js .page .videoPage .add_info_box, .js .audioPage .add_info_box {
+.js .page .video_page .add_info_box,
+.js .audio_page .add_info_box {
   margin: 0 0 63px -214px;
   max-width: 434px;
 }
@@ -142,8 +143,7 @@
   }
 }
 
-
-
-.hideText .slideshow .content .contentWrapper, .hidden_text_indicator {
+.hideText .slideshow .content .content_wrapper,
+.hidden_text_indicator {
   display: none;
 }

--- a/app/assets/stylesheets/pageflow/page.scss
+++ b/app/assets/stylesheets/pageflow/page.scss
@@ -47,7 +47,7 @@
     }
   }
 
-  &.hide_title h2 {
+  &.hide_title .page_header {
     display: none;
   }
 

--- a/app/assets/stylesheets/pageflow/page.scss
+++ b/app/assets/stylesheets/pageflow/page.scss
@@ -33,7 +33,7 @@
     position: relative;
   }
 
-  .backgroundArea {
+  .page_background {
     width:100%;
     height: 100%;
   }

--- a/app/assets/stylesheets/pageflow/page_transitions/crossfade.scss
+++ b/app/assets/stylesheets/pageflow/page_transitions/crossfade.scss
@@ -8,7 +8,7 @@ section.crossfade {
     @include transition(0.5s ease);
   }
 
-  .blackLayer {
+  .black_layer {
     display: none;
   }
 

--- a/app/assets/stylesheets/pageflow/page_transitions/fade.scss
+++ b/app/assets/stylesheets/pageflow/page_transitions/fade.scss
@@ -11,27 +11,27 @@ section.fade {
     background-color: transparent;
   }
 
-  .blackLayer {
+  .black_layer {
     display: none;
   }
 
-  .backgroundArea {
+  .page_background {
     background-color: black;
     -webkit-backface-visibility: hidden;
   }
 
-  &.invert .backgroundArea {
+  &.invert .page_background {
     background-color: white;
   }
 
-  &.animate-in-forwards .backgroundArea,
-  &.animate-in-backwards .backgroundArea {
+  &.animate-in-forwards .page_background,
+  &.animate-in-backwards .page_background {
     opacity: 0;
   }
 
-  &.animate-out-forwards .backgroundArea,
-  &.animate-out-backwards .backgroundArea,
-  &.active .backgroundArea {
+  &.animate-out-forwards .page_background,
+  &.animate-out-backwards .page_background,
+  &.active .page_background {
     opacity: 1;
   }
 
@@ -45,9 +45,9 @@ section.fade {
   }
 
   @mixin define($translate, $duration) {
-    &.active .backgroundArea,
-    &.animate-out-forwards .backgroundArea,
-    &.animate-out-backwards .backgroundArea {
+    &.active .page_background,
+    &.animate-out-forwards .page_background,
+    &.animate-out-backwards .page_background {
       @include transition(opacity $duration ease);
     }
 

--- a/app/assets/stylesheets/pageflow/page_transitions/fade_to_black.scss
+++ b/app/assets/stylesheets/pageflow/page_transitions/fade_to_black.scss
@@ -8,7 +8,7 @@ section.fade_to_black {
     background-color: transparent;
   }
 
-  .blackLayer {
+  .black_layer {
     @include transition(1s ease);
     opacity: 0;
     background-color: black;
@@ -17,11 +17,11 @@ section.fade_to_black {
     position: absolute;
   }
 
-  &.invert .blackLayer {
+  &.invert .black_layer {
     background-color: white;
   }
 
-  &.active .blackLayer {
+  &.active .black_layer {
     opacity: 1;
   }
 
@@ -33,32 +33,35 @@ section.fade_to_black {
     z-index: 2;
   }
 
-  .backgroundArea {
+  .page_background {
     opacity: 0;
     background-color: black;
     -webkit-backface-visibility: hidden;
   }
 
-  &.invert .backgroundArea {
+  &.invert .page_background {
     background-color: white;
   }
 
-  &.animate-in-forwards .backgroundArea {
+  &.animate-in-forwards .page_background {
     opacity: 0;
   }
-  &.animate-out-forwards .backgroundArea{
-    opacity: 0;
-    @include transition(1s ease);
-  }
-  &.animate-in-backwards .backgroundArea{
-    opacity: 0;
-  }
-  &.animate-out-backwards .backgroundArea{
+
+  &.animate-out-forwards .page_background {
     opacity: 0;
     @include transition(1s ease);
   }
 
-  &.active .backgroundArea {
+  &.animate-in-backwards .page_background {
+    opacity: 0;
+  }
+
+  &.animate-out-backwards .page_background {
+    opacity: 0;
+    @include transition(1s ease);
+  }
+
+  &.active .page_background {
     opacity: 1;
     @include transition(1s ease 1s);
   }

--- a/app/assets/stylesheets/pageflow/page_types/audio.scss
+++ b/app/assets/stylesheets/pageflow/page_types/audio.scss
@@ -7,13 +7,13 @@
   right: 0;
 }
 
-.js .audioPage {
+.js .audio_page {
   .non_js_audio {
     display: none;
   }
 }
 
-.non_js .text_position_right .audioPage {
+.non_js .text_position_right .audio_page {
   .page_header {
     margin-left: 0;
     max-width: initial;

--- a/app/assets/stylesheets/pageflow/page_types/video.scss
+++ b/app/assets/stylesheets/pageflow/page_types/video.scss
@@ -1,7 +1,7 @@
 @import "./video/content_hiding";
 @import "./video/mobile_poster";
 
-.has_native_video_player .page .videoPage .videoWrapper {
+.has_native_video_player .page .video_page .uncropped_media_wrapper {
   margin-right: 0;
   position: initial;
   height: 100%;
@@ -32,7 +32,7 @@
   }
 }
 
-.videoPage .video-js {
+.video_page .video-js {
   background-color: transparent;
 
   .vjs-tech {
@@ -40,12 +40,12 @@
   }
 }
 
-.page .videoPage {
+.page .video_page {
   .shadow {
     display: none;
   }
 
-  .contentText {
+  .page_text {
     padding-top: 2em;
   }
 
@@ -70,7 +70,7 @@
     background-color: black;
   }
 
-  .backgroundArea {
+  .page_background {
     height: initial;
   }
 
@@ -80,8 +80,8 @@
   }
 }
 
-.js .page .videoPage {
-  .contentText {
+.js .page .video_page {
+  .page_text {
     padding-top: initial;
   }
 
@@ -89,7 +89,7 @@
     display: block;
   }
 
-  .backgroundArea {
+  .page_background {
     height: 100%;
   }
 
@@ -98,7 +98,7 @@
   }
 }
 
-.non_js .text_position_right .videoPage {
+.non_js .text_position_right .video_page {
   .page_header {
     margin-left: 0;
     max-width: initial;

--- a/app/assets/stylesheets/pageflow/page_types/video/content_hiding.scss
+++ b/app/assets/stylesheets/pageflow/page_types/video/content_hiding.scss
@@ -1,5 +1,5 @@
-.js .audioPage.has_text_tracks,
-.js .videoPage {
+.js .audio_page.has_text_tracks,
+.js .video_page {
   .scroller {
     @include transition(opacity 0.2s linear);
   }

--- a/app/assets/stylesheets/pageflow/page_types/video/mobile_poster.scss
+++ b/app/assets/stylesheets/pageflow/page_types/video/mobile_poster.scss
@@ -1,15 +1,15 @@
-.videoPage .background_image {
+.video_page .background_image {
   display: none;
 }
 
 .has_phone_platform {
   // Show mobile poster only on phone platform
-  .videoPage .background_image {
+  .video_page .background_image {
     display: block;
   }
 
   // But not while playing inline (e.g. on Android)
-  &.has_no_native_video_player .videoPage.should_play .background_image {
+  &.has_no_native_video_player .video_page.should_play .background_image {
     display: none;
   }
 }

--- a/app/assets/stylesheets/pageflow/print_view.scss
+++ b/app/assets/stylesheets/pageflow/print_view.scss
@@ -71,11 +71,14 @@ body {
       page-break-inside: avoid !important;
     }
 
-    .contentText, .videoPage .contentText, .audioPage .contentText {
+    .page_text,
+    .video_page .page_text,
+    .audio_page .page_text {
       margin-bottom: 20px;
     }
 
-    .videoPage .vjs-control-bar, .audioPage .-vjs-control-bar {
+    .video_page .vjs-control-bar,
+    .audio_page .vjs-control-bar {
       display: none !important;
     }
 
@@ -116,7 +119,7 @@ body {
     }
 
 
-    .backgroundArea {
+    .page_background {
       width: initial;
       height: initial;
       position: absolute;
@@ -147,7 +150,7 @@ body {
     }
   }
 
-  .blackLayer {
+  .black_layer {
     display: none !important;
   }
 

--- a/app/assets/stylesheets/pageflow/slideshow.scss
+++ b/app/assets/stylesheets/pageflow/slideshow.scss
@@ -8,8 +8,8 @@
   z-index: 0;
 
 
-  .blackLayer,
-  .backgroundArea {
+  .black_layer,
+  .page_background {
     -webkit-backface-visibility: hidden;
     position: relative;
   }
@@ -36,16 +36,17 @@
   section.active {
     display: block;
     -webkit-backface-visibility: hidden;
-    .backgroundArea {
+
+    .page_background {
       opacity: 1;
     }
   }
 
-  section .videoPage .video-js {
+  section .video_page .video-js {
     background-color: black;
   }
 
-  section.invert .videoPage .video-js {
+  section.invert .video_page .video-js {
     background-color: white;
   }
 

--- a/app/assets/stylesheets/pageflow/themes/default/base.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/base.scss
@@ -28,7 +28,7 @@
 @import "./overview";
 @import "./player_controls";
 @import "./video_player";
-@import "./video_wrapper";
+@import "./uncropped_media_wrapper";
 @import "./text_track_cues";
 @import "./slideshow";
 @import "./probes";

--- a/app/assets/stylesheets/pageflow/themes/default/page.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page.scss
@@ -81,7 +81,7 @@ $page-content-text-line-height: 1.5em !default;
     }
   }
 
-  .contentText > * {
+  .page_text > * {
     @include typography(
       $page-content-text-typography,
       (

--- a/app/assets/stylesheets/pageflow/themes/default/page.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page.scss
@@ -5,39 +5,6 @@
 /// Base typography for page.
 $page-typography: () !default;
 
-/// Typography for header.
-$page-header-typography: () !default;
-
-/// Typography for header tagline.
-$page-header-tagline-typography: () !default;
-
-/// Typography for header tagline in phone layout.
-$page-header-tagline-phone-typography: () !default;
-
-/// Typography for header title.
-$page-header-title-typography: () !default;
-
-/// Typography for header title in phone layout.
-$page-header-title-phone-typography: () !default;
-
-/// Typography for title on first page.
-$page-header-first-page-title-typography: () !default;
-
-/// Typography for title on first page in phone layout.
-$page-header-first-page-title-phone-typography: () !default;
-
-/// Typography for title on first page of chapter.
-$page-header-chapter-beginning-title-typography: () !default;
-
-/// Typography for title on first page of chapter in phone layout.
-$page-header-chapter-beginning-title-phone-typography: () !default;
-
-/// Typography for header subtitle.
-$page-header-subtitle-typography: () !default;
-
-/// Typography for header subtitle in phone layout.
-$page-header-subtitle-phone-typography: () !default;
-
 /// Typography for content text.
 $page-content-text-typography: () !default;
 
@@ -71,31 +38,12 @@ $page-inverted-background-color: #fff !default;
 
 $page-font-family: $standard-font !default;
 $page-font-size: 16px !default;
-$page-header-font-family: $page-font-family !default;
-$page-header-font-size: 1.375em !default;
-$page-header-font-weight: normal !default;
-$page-header-tagline-font-size: 1em !default;
-$page-header-tagline-font-weight: $page-header-font-weight !default;
-$page-header-tagline-line-height: normal !default;
-$page-header-tagline-margin-top: 0 !default;
-$page-header-title-font-size: 2.3em !default;
-$page-header-title-phone-font-size: 1.8em !default;
-$page-header-first-page-title-font-size: 2.5em !default;
-$page-header-first-page-title-phone-font-size: 2em !default;
-$page-header-title-font-weight: $page-header-font-weight !default;
-$page-header-title-line-height: 1em !default;
-$page-header-first-page-title-line-height: 1em !default;
-$page-header-title-margin-top: 0.4em !default;
-$page-header-title-margin-bottom: 0.4em !default;
-$page-header-subtitle-font-size: 1em !default;
-$page-header-subtitle-font-weight: $page-header-font-weight !default;
-$page-header-subtitle-line-height: normal !default;
-$page-header-subtitle-margin-bottom: 1.875em !default;
 $page-content-text-font-family: $page-font-family !default;
 $page-content-text-font-size: 1.2em !default;
 $page-content-text-line-height: 1.5em !default;
 
 @import "./page/anchors";
+@import "./page/header";
 @import "./page/hyphenate";
 @import "./page/paddings";
 @import "./page/content_text_margin";
@@ -120,7 +68,7 @@ $page-content-text-line-height: 1.5em !default;
     color: $page-inverted-text-color;
     background-color: $page-inverted-background-color;
 
-    h2 .title {
+    .page_header-title {
       color: $page-inverted-title-color;
     }
   }
@@ -130,83 +78,6 @@ $page-content-text-line-height: 1.5em !default;
 
     @include phone {
       font-size: $page-content-phone-font-size;
-    }
-  }
-
-  h2 {
-    @include typography(
-      $page-header-typography,
-      (
-        font-family: $page-header-font-family,
-        font-size: $page-header-font-size
-      )
-    );
-
-    .tagline {
-      display: block;
-
-      @include typography(
-        $page-header-tagline-typography,
-        (
-          font-size: $page-header-tagline-font-size,
-          font-weight: $page-header-tagline-font-weight,
-          line-height: $page-header-tagline-line-height,
-          margin-top: $page-header-tagline-margin-top,
-          letter-spacing: 0
-        )
-      );
-
-      @include phone {
-        @include typography(
-          $page-header-tagline-phone-typography
-        );
-      }
-    }
-
-    .title {
-      display: block;
-
-      @include typography(
-        $page-header-title-typography,
-        (
-          font-size: $page-header-title-font-size,
-          font-weight: $page-header-title-font-weight,
-          line-height: $page-header-title-line-height,
-          margin-top: $page-header-title-margin-top,
-          margin-bottom: $page-header-title-margin-bottom,
-          letter-spacing: 0
-        )
-      );
-
-      @include phone {
-        @include typography(
-          $page-header-title-phone-typography,
-          (
-            font-size: $page-header-title-phone-font-size
-          )
-        );
-      }
-    }
-
-    .subtitle {
-      display: block;
-
-      @include typography(
-        $page-header-subtitle-typography,
-        (
-          font-size: $page-header-subtitle-font-size,
-          font-weight: $page-header-subtitle-font-weight,
-          line-height: $page-header-subtitle-line-height,
-          margin-top: 0,
-          margin-bottom: $page-header-subtitle-margin-bottom
-        )
-      );
-
-      @include phone {
-        @include typography(
-          $page-header-subtitle-phone-typography
-        );
-      }
     }
   }
 
@@ -223,41 +94,5 @@ $page-content-text-line-height: 1.5em !default;
 
   p {
     margin-top: 0;
-  }
-}
-
-.page:first-child {
-  h2 .title {
-    @include typography(
-      $page-header-first-page-title-typography,
-      (
-        font-size: $page-header-first-page-title-font-size,
-        line-height: $page-header-first-page-title-line-height,
-        letter-spacing: 0
-      )
-    );
-
-    @include phone {
-      @include typography(
-        $page-header-first-page-title-phone-typography,
-        (
-          font-size: $page-header-first-page-title-phone-font-size
-        )
-      );
-    }
-  }
-}
-
-.emphasize_chapter_beginning .page.chapter_beginning:nth-of-type(n+2) {
-  h2 .title {
-    @include typography(
-      $page-header-chapter-beginning-title-typography
-    );
-
-    @include phone {
-      @include typography(
-        $page-header-chapter-beginning-title-phone-typography
-      );
-    }
   }
 }

--- a/app/assets/stylesheets/pageflow/themes/default/page/anchors.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/anchors.scss
@@ -11,13 +11,13 @@ $page-anchor-inverted-color: #000 !default;
 /// Typography settings of links in page content text
 $page-anchor-typography: () !default;
 
-.contentText a {
+.page_text a {
   @extend %anchor;
   color: $page-anchor-color;
   pointer-events: all;
   @include typography($page-anchor-typography)
 }
 
-.invert .contentText a {
+.invert .page_text a {
   color: $page-anchor-inverted-color;
 }

--- a/app/assets/stylesheets/pageflow/themes/default/page/content_text_margin.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/content_text_margin.scss
@@ -1,4 +1,4 @@
-.contentText {
+.page_text {
   // This has to be the default behavior since all non-React pages
   // still do not apply additional modifier classes to the content
   // text

--- a/app/assets/stylesheets/pageflow/themes/default/page/header.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/header.scss
@@ -1,0 +1,172 @@
+////
+/// @group page-typography
+////
+
+/// Typography for header.
+$page-header-typography: () !default;
+
+/// Typography for header tagline.
+$page-header-tagline-typography: () !default;
+
+/// Typography for header tagline in phone layout.
+$page-header-tagline-phone-typography: () !default;
+
+/// Typography for header title.
+$page-header-title-typography: () !default;
+
+/// Typography for header title in phone layout.
+$page-header-title-phone-typography: () !default;
+
+/// Typography for title on first page.
+$page-header-first-page-title-typography: () !default;
+
+/// Typography for title on first page in phone layout.
+$page-header-first-page-title-phone-typography: () !default;
+
+/// Typography for title on first page of chapter.
+$page-header-chapter-beginning-title-typography: () !default;
+
+/// Typography for title on first page of chapter in phone layout.
+$page-header-chapter-beginning-title-phone-typography: () !default;
+
+/// Typography for header subtitle.
+$page-header-subtitle-typography: () !default;
+
+/// Typography for header subtitle in phone layout.
+$page-header-subtitle-phone-typography: () !default;
+
+// Deprecated. Use typography variables above.
+
+$page-header-font-family: $page-font-family !default;
+$page-header-font-size: 1.375em !default;
+$page-header-font-weight: normal !default;
+$page-header-tagline-font-size: 1em !default;
+$page-header-tagline-font-weight: $page-header-font-weight !default;
+$page-header-tagline-line-height: normal !default;
+$page-header-tagline-margin-top: 0 !default;
+$page-header-title-font-size: 2.3em !default;
+$page-header-title-phone-font-size: 1.8em !default;
+$page-header-first-page-title-font-size: 2.5em !default;
+$page-header-first-page-title-phone-font-size: 2em !default;
+$page-header-title-font-weight: $page-header-font-weight !default;
+$page-header-title-line-height: 1em !default;
+$page-header-first-page-title-line-height: 1em !default;
+$page-header-title-margin-top: 0.4em !default;
+$page-header-title-margin-bottom: 0.4em !default;
+$page-header-subtitle-font-size: 1em !default;
+$page-header-subtitle-font-weight: $page-header-font-weight !default;
+$page-header-subtitle-line-height: normal !default;
+$page-header-subtitle-margin-bottom: 1.875em !default;
+
+.page_header {
+  @include typography(
+    $page-header-typography,
+    (
+      font-family: $page-header-font-family,
+      font-size: $page-header-font-size
+    )
+  );
+
+  &-tagline {
+    display: block;
+
+    @include typography(
+      $page-header-tagline-typography,
+      (
+        font-size: $page-header-tagline-font-size,
+        font-weight: $page-header-tagline-font-weight,
+        line-height: $page-header-tagline-line-height,
+        margin-top: $page-header-tagline-margin-top,
+        letter-spacing: 0
+      )
+    );
+
+    @include phone {
+      @include typography(
+        $page-header-tagline-phone-typography
+      );
+    }
+  }
+
+  &-title {
+    display: block;
+
+    @include typography(
+      $page-header-title-typography,
+      (
+        font-size: $page-header-title-font-size,
+          font-weight: $page-header-title-font-weight,
+          line-height: $page-header-title-line-height,
+          margin-top: $page-header-title-margin-top,
+          margin-bottom: $page-header-title-margin-bottom,
+          letter-spacing: 0
+      )
+    );
+
+    @include phone {
+      @include typography(
+        $page-header-title-phone-typography,
+        (
+          font-size: $page-header-title-phone-font-size
+        )
+      );
+    }
+  }
+
+  &-subtitle {
+    display: block;
+
+    @include typography(
+      $page-header-subtitle-typography,
+      (
+        font-size: $page-header-subtitle-font-size,
+        font-weight: $page-header-subtitle-font-weight,
+        line-height: $page-header-subtitle-line-height,
+        margin-top: 0,
+        margin-bottom: $page-header-subtitle-margin-bottom
+      )
+    );
+
+    @include phone {
+      @include typography(
+        $page-header-subtitle-phone-typography
+      );
+    }
+  }
+}
+
+.page:first-child {
+  .page_header-title {
+    @include typography(
+      $page-header-first-page-title-typography,
+      (
+        font-size: $page-header-first-page-title-font-size,
+        line-height: $page-header-first-page-title-line-height,
+        letter-spacing: 0
+      )
+    );
+
+    @include phone {
+      @include typography(
+        $page-header-first-page-title-phone-typography,
+        (
+          font-size: $page-header-first-page-title-phone-font-size
+        )
+      );
+    }
+  }
+}
+
+.emphasize_chapter_beginning .page.chapter_beginning:nth-of-type(n+2) {
+  .page_header-title {
+    @include typography(
+      $page-header-chapter-beginning-title-typography
+    );
+
+    @include phone {
+      @include typography(
+        $page-header-chapter-beginning-title-phone-typography
+      );
+    }
+  }
+}

--- a/app/assets/stylesheets/pageflow/themes/default/page/hyphenate.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/hyphenate.scss
@@ -9,7 +9,7 @@
 $page-hyphenate-header: "narrow" !default;
 
 .page {
-  h2 {
+  .page_header {
     @if $page-hyphenate-header == "always" {
 
       hyphens: auto;

--- a/app/assets/stylesheets/pageflow/themes/default/page/line_lengths.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/line_lengths.scss
@@ -19,10 +19,9 @@ $page-header-title-min-width-for-split-layout: 525px !default;
 $page-content-width: 60% !default;
 
 .page {
-  h1,
-  h2 .subtitle,
-  h2 .tagline,
-  h3,
+  &_header-subtitle,
+  &_header-tagline,
+  &_sub_header,
   p {
     max-width: $page-content-max-width;
     width: $page-content-width;
@@ -32,7 +31,7 @@ $page-content-width: 60% !default;
     }
   }
 
-  h2 .title {
+  &_header-title {
     max-width: $page-header-title-max-width;
     width: 100%;
   }
@@ -70,10 +69,10 @@ $page-content-width: 60% !default;
 
   @media screen and (min-width: $page-min-width-for-split-layout) {
     &-with_split_layout {
-      h2 .subtitle,
-      h2 .title,
-      h2 .tagline,
-      h3,
+      .page_header-subtitle,
+      .page_header-title,
+      .page_header-tagline,
+      .page_sub_header,
       p {
         width: $page-content-split-layout-width;
       }
@@ -81,11 +80,10 @@ $page-content-width: 60% !default;
   }
 
   &.text_position_right {
-    h1,
-    h2 .subtitle,
-    h2 .title,
-    h2 .tagline,
-    h3,
+    .page_header-subtitle,
+    .page_header-title,
+    .page_header-tagline,
+    .page_sub_header,
     p {
       @include margin-start(auto);
       max-width: $page-content-position-right-max-width;

--- a/app/assets/stylesheets/pageflow/themes/default/player_controls/vjs_mapping.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/player_controls/vjs_mapping.scss
@@ -1,8 +1,8 @@
 // Map placeholder names to concrete vjs css class names.
 
 $vjs-selector-mapping: (
-  page-with_progress_bar: ".audioPage, .videoPage",
-  page-audio: ".audioPage",
+  page-with_progress_bar: ".audio_page, .video_page",
+  page-audio: ".audio_page",
 
   background: ".page_background-for_page_with_player_controls",
 
@@ -14,12 +14,12 @@ $vjs-selector-mapping: (
   // Use playing class that is removed with delay to prevent
   // mask image on scroller from being removed too early in slim
   // player controls.
-  scroller-playing: ".videoPage .scroller.is_playing_delayed, .audioPage .scroller.is_playing_delayed",
+  scroller-playing: ".video_page .scroller.is_playing_delayed, .audio_page .scroller.is_playing_delayed",
 
   // If video has played, content is faded immediately. This can be
   // used by the slim player controls to not display the scroller mask
   // if the content fades anyway.
-  scroller-fading: ".videoPage.has_played .scroller",
+  scroller-fading: ".video_page.has_played .scroller",
 
   container: ".controls",
 
@@ -31,8 +31,8 @@ $vjs-selector-mapping: (
   container-hover: ".is_control_bar_hovered .controls",
   container-focused: ".is_control_bar_focused .controls",
 
-  container-video: ".videoPage .controls",
-  container-fading: ".videoPage .controls",
+  container-video: ".video_page .controls",
+  container-fading: ".video_page .controls",
 
   container-unplayed: ".unplayed .controls",
 

--- a/app/assets/stylesheets/pageflow/themes/default/uncropped_media_wrapper.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/uncropped_media_wrapper.scss
@@ -1,4 +1,4 @@
-.videoWrapper {
+.uncropped_media_wrapper {
   @extend %pageflow_widget_margin_right !optional;
 
   position: relative;

--- a/app/helpers/pageflow/pages_helper.rb
+++ b/app/helpers/pageflow/pages_helper.rb
@@ -21,6 +21,37 @@ module Pageflow
       classes.join(' ')
     end
 
+    def page_default_content(page)
+      safe_join([
+                  page_header(page),
+                  page_print_image(page),
+                  page_text(page)
+                ])
+    end
+
+    def page_header(page)
+      content_tag(:h3, class: 'page_header') do
+        safe_join([
+                    content_tag(:span, page.configuration['tagline'],
+                                class: 'page_header-tagline'),
+                    content_tag(:span, page.configuration['title'],
+                                class: 'page_header-title'),
+                    content_tag(:span, page.configuration['subtitle'],
+                                class: 'page_header-subtitle')
+                  ])
+      end
+    end
+
+    def page_print_image(page)
+      background_image_tag(page.configuration['background_image_id'], 'class' => 'print_image')
+    end
+
+    def page_text(page)
+      content_tag(:div, class: 'page_text') do
+        content_tag(:p, raw(page.configuration['text']))
+      end
+    end
+
     # @api private
     def page_has_content(page)
       has_title = ['title','subtitle','tagline'].any? do |attribute|

--- a/node_package/src/builtInPageTypes/audio.jsx
+++ b/node_package/src/builtInPageTypes/audio.jsx
@@ -22,7 +22,7 @@ function AudioPage(props) {
   const playerControlsVariant = props.page.audioPlayerControlsVariant;
 
   return (
-    <MediaPage className="audioPage"
+    <MediaPage className="audio_page"
                page={props.page}
                file={props.audioFile}
                playerState={props.playerState}

--- a/node_package/src/builtInPageTypes/video.jsx
+++ b/node_package/src/builtInPageTypes/video.jsx
@@ -19,7 +19,7 @@ const qualities = ['auto', '4k', 'fullhd', 'medium'];
 
 function VideoPage(props) {
   return (
-    <MediaPage className="videoPage"
+    <MediaPage className="video_page"
                page={props.page}
                file={props.videoFile}
                qualities={qualities}

--- a/node_package/src/components/PageBackground.jsx
+++ b/node_package/src/components/PageBackground.jsx
@@ -26,7 +26,7 @@ PageBackground.propTypes = {
 };
 
 function className({pageHasPlayerControls}) {
-  return classNames('backgroundArea page_background', {
+  return classNames('page_background', {
     'page_background-for_page_with_player_controls': pageHasPlayerControls
   });
 }

--- a/node_package/src/components/PageHeader.jsx
+++ b/node_package/src/components/PageHeader.jsx
@@ -15,13 +15,11 @@ import React from 'react';
 export default class extends React.Component {
   render() {
     return (
-      <div className="page_header">
-        <h2>
-          <span className="tagline">{this.props.page.tagline}</span>
-          <span className="title">{this.props.page.title}</span>
-          <span className="subtitle">{this.props.page.subtitle}</span>
-        </h2>
-      </div>
+      <h3 className="page_header">
+        <span className="page_header-tagline">{this.props.page.tagline}</span>
+        <span className="page_header-title">{this.props.page.title}</span>
+        <span className="page_header-subtitle">{this.props.page.subtitle}</span>
+      </h3>
     );
   }
-};
+}

--- a/node_package/src/components/PageScroller.jsx
+++ b/node_package/src/components/PageScroller.jsx
@@ -50,7 +50,7 @@ export class PageScroller extends React.Component {
   render() {
     return (
       <Scroller ref="scroller" className={className(this.props)} style={style(this.props)}>
-        <div className="contentWrapper">
+        <div className="content_wrapper">
           {this.props.children}
         </div>
       </Scroller>

--- a/node_package/src/components/PageText.jsx
+++ b/node_package/src/components/PageText.jsx
@@ -33,8 +33,8 @@ PageText.propTypes = {
 };
 
 function className(props) {
-  return classNames('contentText', {
-    [`contentText-margin_${props.marginBottom}`]: props.marginBottom != PageText.defaultProps.marginBottom
+  return classNames('page_text', {
+    [`page_text-margin_${props.marginBottom}`]: props.marginBottom != PageText.defaultProps.marginBottom
   });
 }
 

--- a/node_package/src/components/__spec__/PageBackground-spec.jsx
+++ b/node_package/src/components/__spec__/PageBackground-spec.jsx
@@ -4,12 +4,6 @@ import {expect} from 'support/chai';
 import {shallow} from 'enzyme';
 
 describe('PageBackground', () => {
-  it('has backgroundArea class', () => {
-    const wrapper = shallow(<PageBackground />);
-
-    expect(wrapper).to.have.className('backgroundArea');
-  });
-
   it('has page_background class', () => {
     const wrapper = shallow(<PageBackground />);
 

--- a/node_package/src/interactivePageBackground/components/Page.jsx
+++ b/node_package/src/interactivePageBackground/components/Page.jsx
@@ -63,7 +63,7 @@ class PageWithInteractiveBackground extends React.Component {
                  hiddenOnPhone={this.props.textHasBeenHidden && !this.props.textIsHidden} />
 
         <PageBackground pageHasPlayerControls={true}>
-          <div className="videoWrapper">
+          <div className="uncropped_media_wrapper">
             {this.props.children}
           </div>
           <PageShadow page={page} />

--- a/node_package/src/media/components/VideoFilePlayer/Positioner/index.jsx
+++ b/node_package/src/media/components/VideoFilePlayer/Positioner/index.jsx
@@ -24,7 +24,7 @@ function renderWrapper(props, wrapperDimensions) {
                                    props.position,
                                    wrapperDimensions);
   return (
-    <div className="videoWrapper">
+    <div className="uncropped_media_wrapper">
       <div className={getCueOffsetClassName(dimensions, wrapperDimensions)}
            style={style(dimensions)}>
         {props.children}

--- a/spec/helpers/pageflow/pages_helper_spec.rb
+++ b/spec/helpers/pageflow/pages_helper_spec.rb
@@ -106,5 +106,67 @@ module Pageflow
         expect(css_class).to eq("pageflow_image_file_link_thumbnail_large_#{image_file.id}")
       end
     end
+
+    describe '#page_default_content' do
+      before { helper.extend(BackgroundImageHelper) }
+
+      it 'renders header, print image and page text' do
+        image_file = create(:image_file)
+        page = build(:page, configuration: {
+                       'background_image_id' => image_file.id,
+                       'title' => 'Title',
+                       'tagline' => 'Tagline',
+                       'subtitle' => 'Subtitle'
+                     })
+
+        html = helper.page_default_content(page)
+
+        expect(html).to have_selector('.page_header')
+        expect(html).to have_selector('.print_image')
+        expect(html).to have_selector('.page_text')
+      end
+    end
+
+    describe '#page_header' do
+      it 'renders h3 tag with tagline, title and subtitle' do
+        page = build(:page, configuration: {
+                       'title' => 'Title',
+                       'tagline' => 'Tagline',
+                       'subtitle' => 'Subtitle'
+                     })
+
+        html = helper.page_header(page)
+
+        expect(html).to have_selector('h3.page_header')
+        expect(html).to have_selector('.page_header-tagline', text: 'Tagline')
+        expect(html).to have_selector('.page_header-title', text: 'Title')
+        expect(html).to have_selector('.page_header-subtitle', text: 'Subtitle')
+      end
+    end
+
+    describe '#page_print_image' do
+      before { helper.extend(BackgroundImageHelper) }
+
+      it 'renders img tag' do
+        image_file = create(:image_file)
+        page = build(:page, configuration: {
+                       'background_image_id' => image_file.id
+                     })
+
+        html = helper.page_print_image(page)
+
+        expect(html).to have_selector('img.print_image')
+      end
+    end
+
+    describe '#page_text' do
+      it 'renders content_text div with html content' do
+        page = build(:page, configuration: {'text' => '<b>Text</b>'})
+
+        html = helper.page_text(page)
+
+        expect(html).to have_selector('.page_text p b', text: 'Text')
+      end
+    end
   end
 end

--- a/spec/support/pageflow/lint/page_type.rb
+++ b/spec/support/pageflow/lint/page_type.rb
@@ -16,10 +16,13 @@ module Pageflow
             end
           end
 
-          it 'renderer page template without error' do
-            expect {
-              render_page(page_type)
-            }.not_to raise_error
+          it 'rendered page has valid DOM structure' do
+            html = render_page(page_type)
+
+            expect(html).to have_selector('div.content_and_background')
+            expect(html).to have_selector('div.content_and_background > div.page_background')
+            expect(html).to have_selector('div.content_and_background > div.content')
+            expect(html).to have_selector('div.scroller > div > div.content_wrapper')
           end
 
           it 'renders json seed template without error' do


### PR DESCRIPTION
Turn page header into h3.  Since we need to touch all legacy page
templates anyway to turn h2 tags into h3 tags we can finally clean
this up.

The following CSS classes need to be changed in page templates:

* `blackLayer` -> `black_layer`
* `backgroundArea` -> `page_background`
* `contentWrapper` -> `content_wrapper`
* `videoWrapper` -> `uncropped_media_wrapper`

The default header and content snippet

    <div class="page_header">
     <h2>
       <span class="tagline"><%= configuration['tagline'] %></span>
       <span class="title"><%= configuration['title'] %></span>
       <span class="subtitle"><%= configuration['subtitle'] %></span>
     </h2>
     <%= background_image_tag(configuration['background_image_id'], {class:
"print_image"}) %>
   </div>
   <div class="contentText">
     <p><%= raw configuration['text'] %></p>
   </div>

should be replaced with the following helper call:

    <%= page_default_content(page) %>

REDMINE-16511