### PR TITLE
Allow passing custom query params for collection.create

### DIFF
--- a/app/assets/javascripts/pageflow/editor/collections/files_collection.js
+++ b/app/assets/javascripts/pageflow/editor/collections/files_collection.js
@@ -27,7 +27,8 @@ pageflow.FilesCollection = Backbone.Collection.extend({
   findOrCreateBy: function(attributes) {
     return this.findWhere(attributes) ||
       this.create(attributes, {
-        fileType: this.fileType
+        fileType: this.fileType,
+        queryParams: { no_upload: true }
       });
   },
 

--- a/app/assets/javascripts/pageflow/editor/sync.js
+++ b/app/assets/javascripts/pageflow/editor/sync.js
@@ -3,7 +3,7 @@
 
   Backbone.sync = function(method, model, options) {
     if (model.paramRoot && !options.attrs) {
-      options.attrs = {};
+      options.attrs = options.queryParams || {};
       options.attrs[model.paramRoot] = model.toJSON(options);
     }
 

--- a/app/controllers/pageflow/editor/files_controller.rb
+++ b/app/controllers/pageflow/editor/files_controller.rb
@@ -20,6 +20,7 @@ module Pageflow
         verify_edit_lock!(entry)
 
         @file = entry.create_file!(file_type.model, create_params)
+        @file.publish! if params[:no_upload]
 
         respond_with(:editor, @file)
       rescue ActiveRecord::RecordInvalid => e

--- a/spec/controllers/pageflow/editor/files_controller_spec.rb
+++ b/spec/controllers/pageflow/editor/files_controller_spec.rb
@@ -342,6 +342,43 @@ module Pageflow
         expect(parent_file.nested_files(Pageflow::TextTrackFile)).to be_empty
         expect(response.status).to eq(422)
       end
+
+      it 'does not publish newly created file' do
+        user = create(:user)
+        entry = create(:entry, with_editor: user)
+
+        sign_in(user, scope: :user)
+        acquire_edit_lock(user, entry)
+
+        post(:create,
+             params: {
+               entry_id: entry,
+               collection_name: 'image_files',
+               image_file: {file_name: 'image.jpg'}
+             },
+             format: 'json')
+
+        expect(entry.image_files.first).to be_uploading
+      end
+
+      it 'publishes file directly when no_upload param is present' do
+        user = create(:user)
+        entry = create(:entry, with_editor: user)
+
+        sign_in(user, scope: :user)
+        acquire_edit_lock(user, entry)
+
+        post(:create,
+             params: {
+               no_upload: true,
+               entry_id: entry,
+               collection_name: 'image_files',
+               image_file: {file_name: 'image.jpg'}
+             },
+             format: 'json')
+
+        expect(entry.image_files.first).to be_processing
+      end
     end
 
     describe '#reuse' do


### PR DESCRIPTION
To allow for conditional publishing of files without attachment.
Needed for linkmap page color map files to start processing.

REDMINE-16119