### PR TITLE
Improve header structure

### DIFF
--- a/app/assets/javascripts/pageflow/page_types/mixins/default_page_content.js
+++ b/app/assets/javascripts/pageflow/page_types/mixins/default_page_content.js
@@ -1,0 +1,8 @@
+pageflow.defaultPageContent = {
+  updateDefaultPageContent: function(pageElement, configuration) {
+    pageElement.find('.page_header-tagline').text(configuration.get('tagline') || '');
+    pageElement.find('.page_header-title').text(configuration.get('title') || '');
+    pageElement.find('.page_header-subtitle').text(configuration.get('subtitle') || '');
+    pageElement.find('.page_text p').html(configuration.get('text') || '');
+  }
+};

--- a/app/assets/javascripts/pageflow/slideshow.js
+++ b/app/assets/javascripts/pageflow/slideshow.js
@@ -113,7 +113,7 @@ pageflow.Slideshow = function($el, configurations) {
           this.scrollNavigator.getDefaultTransition(previousPage, currentPage, pages);
 
         var direction =
-          this.scrollNavigator.getTransitionDirection(previousPage, currentPage, options);
+          this.scrollNavigator.getTransitionDirection(previousPage, currentPage, pages, options);
 
         var outDuration = previousPage.page('deactivate', {
           direction: direction,

--- a/app/assets/javascripts/pageflow/slideshow/dom_order_scroll_navigator.js
+++ b/app/assets/javascripts/pageflow/slideshow/dom_order_scroll_navigator.js
@@ -32,7 +32,8 @@ pageflow.DomOrderScrollNavigator = function(slideshow, entryData) {
   };
 
   this.getNextPage = function(currentPage, pages) {
-    var nextPage = currentPage.next('.page');
+    var currentPageIndex = pages.index(currentPage);
+    var nextPage = currentPageIndex < pages.length - 1 ? $(pages.get(currentPageIndex + 1)) : $();
 
     if (sameStoryline(currentPage, nextPage)) {
       return nextPage;
@@ -48,7 +49,8 @@ pageflow.DomOrderScrollNavigator = function(slideshow, entryData) {
   };
 
   this.getPreviousPage = function(currentPage, pages) {
-    var previousPage =  currentPage.prev('.page');
+    var currentPageIndex = pages.index(currentPage);
+    var previousPage = currentPageIndex > 0 ? $(pages.get(currentPageIndex - 1)) : $();
 
     if (sameStoryline(currentPage, previousPage)) {
       return previousPage;
@@ -57,8 +59,8 @@ pageflow.DomOrderScrollNavigator = function(slideshow, entryData) {
     return getParentPage(currentPage, pages);
   };
 
-  this.getTransitionDirection = function(previousPage, currentPage, options) {
-    return (currentPage.index() > previousPage.index() ? 'forwards' : 'backwards');
+  this.getTransitionDirection = function(previousPage, currentPage, pages, options) {
+    return (pages.index(currentPage) > pages.index(previousPage) ? 'forwards' : 'backwards');
   };
 
   this.getDefaultTransition = function(previousPage, currentPage, pages) {

--- a/app/assets/stylesheets/pageflow/overview.scss
+++ b/app/assets/stylesheets/pageflow/overview.scss
@@ -64,7 +64,7 @@
     @include transition(0.5s ease);
     @include transform(translate(200%,0));
 
-    h2 {
+    .overview_headline {
       @include margin-start(10px);
       margin-bottom: 0;
       margin-top: 0;

--- a/app/assets/stylesheets/pageflow/themes/default/overview/colors.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/overview/colors.scss
@@ -54,7 +54,7 @@ $overview-pictogram-visibility: $standard-page-pictogram-visibility !default;
   color: $overview-text-color;
 }
 
-h2 {
+.overview_headline {
   color: $overview-header-text-color;
 }
 

--- a/app/assets/stylesheets/pageflow/themes/default/overview/typography.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/overview/typography.scss
@@ -19,11 +19,12 @@ $overview-close-button-typography: () !default;
 
 @include standard-typography($overview-typography, ());
 
-h2 {
+.overview_headline {
   @include typography(
     $overview-header-typography,
     (
       font-size: 3em,
+      font-weight: bold
     )
   );
 }

--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -53,7 +53,7 @@ module Pageflow
       end
 
       if links.any?
-        content_tag(:h2, I18n.t('pageflow.helpers.entries.global_links'), :class => 'hidden') + safe_join(links, ''.html_safe)
+        content_tag(:span, I18n.t('pageflow.helpers.entries.global_links'), class: 'hidden') + safe_join(links, ''.html_safe)
       else
         ''
       end

--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -6,6 +6,11 @@ module Pageflow
       'pageflow_pages.position ASC'
     ].join(',')
 
+    CHAPTER_ORDER = [
+      'pageflow_storylines.position ASC',
+      'pageflow_chapters.position ASC'
+    ].join(',')
+
     include ThemeReferencer
 
     belongs_to :entry, touch: :edited_at
@@ -15,7 +20,7 @@ module Pageflow
     has_many :widgets, as: :subject, dependent: :destroy
 
     has_many :storylines, -> { order('pageflow_storylines.position ASC') }, dependent: :destroy
-    has_many :chapters, -> { order('position ASC') }, through: :storylines
+    has_many :chapters, -> { order(CHAPTER_ORDER) }, through: :storylines
     has_many :pages, -> { reorder(PAGE_ORDER) }, through: :storylines
 
     has_many :file_usages, dependent: :destroy

--- a/app/views/pageflow/chapters/_chapter.html.erb
+++ b/app/views/pageflow/chapters/_chapter.html.erb
@@ -1,0 +1,5 @@
+<section class="chapter">
+  <h2><%= chapter.title %></h2>
+
+  <%= render chapter.pages, entry: entry %>
+</section>

--- a/app/views/pageflow/entries/_entry.html.erb
+++ b/app/views/pageflow/entries/_entry.html.erb
@@ -11,7 +11,7 @@
   <span class="print_only page_url"><%= request.original_url %></span>
 
   <%= content_tag :div, :id => 'content', :class => 'entry', :data => {:role => 'slideshow'} do %>
-    <%= render entry.pages, entry: entry %>
+    <%= render entry.chapters, entry: entry %>
     <%= render 'pageflow/entries/indicators', :theme => entry.theme %>
   <% end %>
 

--- a/app/views/pageflow/entries/_multimedia_alert.html.erb
+++ b/app/views/pageflow/entries/_multimedia_alert.html.erb
@@ -1,7 +1,7 @@
 <div class="multimedia_alert">
   <div class="multimedia_alert_box">
     <div class="alert_block">
-    <h1 class="alert_headline"><%= t('pageflow.public.notice') %></h1>
+    <div class="alert_headline"><%= t('pageflow.public.notice') %></div>
     <div class="alert_icon speaker"></div>
       <p>
         <%= t('pageflow.public.sound_hint') %>

--- a/app/views/pageflow/entries/overview/_entry.html.erb
+++ b/app/views/pageflow/entries/overview/_entry.html.erb
@@ -1,9 +1,9 @@
-<section class="overview">
+<div class="overview">
   <div class="content">
     <a class="close button">
       <span class="label"><%= t('pageflow.public.close') %></span>
     </a>
-    <h2><%= t('pageflow.public.overview') %></h2>
+    <div class="overview_headline"><%= t('pageflow.public.overview') %></div>
 
     <a class="overview_scroll_indicator left button"
        tabindex="1"
@@ -25,4 +25,4 @@
       <span class="hint"><%= t('pageflow.public.scroll_right') %></span>
     </a>
   </div>
-</section>
+</div>

--- a/app/views/pageflow/pages/_page.html.erb
+++ b/app/views/pageflow/pages/_page.html.erb
@@ -1,6 +1,12 @@
 <%= cache page do %>
-  <%= content_tag :section, :id => page.perma_id, :class => page_css_class(page), :data => {:template => page.template, :id => page.id, :chapter_id => page.chapter_id} do %>
-    <%= render_page_template(page, entry: entry) %>
-    <a class="to_top" href="#content"><%= t('pageflow.public.goto_top') %></a>
+  <%= content_tag(:section,
+                  id: page.perma_id,
+                  class: page_css_class(page),
+                  data: {
+                    template: page.template,
+                    id: page.id, chapter_id: page.chapter_id
+                  }) do -%>
+    <% concat(render_page_template(page, entry: entry)) -%>
   <% end %>
+  <a class="to_top" href="#content"><%= t('pageflow.public.goto_top') %></a>
 <% end %>


### PR DESCRIPTION
* Move top links out of page sections

* Add chapters to document outline

* Clean up header structure by removing non-essential headers from
  widgets.

REDMINE-16511