### PR TITLE
Update chromedriver-helper to fix Travis build

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -138,7 +138,7 @@ Gem::Specification.new do |s|
 
   # Chrome Headless browser testing
   s.add_development_dependency 'selenium-webdriver', '~> 3.6.x'
-  s.add_development_dependency 'chromedriver-helper', '~> 1.1.x'
+  s.add_development_dependency 'chromedriver-helper', '~> 2.1.x'
 
   # View abstraction fro integration testing
   s.add_development_dependency 'domino', '~> 0.7.0'

--- a/spec/support/config/capybara.rb
+++ b/spec/support/config/capybara.rb
@@ -1,6 +1,7 @@
 require 'capybara/rspec'
 require 'selenium-webdriver'
 require 'capybara/chromedriver/logger'
+require 'chromedriver-helper'
 
 Capybara.register_driver :selenium_chrome_headless_no_sandbox do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -1,4 +1,5 @@
 require 'selenium-webdriver'
+require 'chromedriver-helper'
 
 # Set RAILS_ROOT and load the environment if it's not already loaded.
 unless defined?(Rails)


### PR DESCRIPTION
Old setup lead errors of the form

   This version of ChromeDriver only supports Chrome version 74