### PR TITLE
Setup visited pages before resolving ready

### DIFF
--- a/app/assets/javascripts/pageflow/ready.js
+++ b/app/assets/javascripts/pageflow/ready.js
@@ -8,12 +8,12 @@ pageflow.ready = new $.Deferred(function(readyDeferred) {
       var slideshow = $('[data-role=slideshow]');
       var body = $('body');
 
+      pageflow.Visited.setup();
+
       pagePreloaded.then(function() {
         readyDeferred.resolve();
         pageflow.events.trigger('ready');
       });
-
-      pageflow.Visited.setup();
 
       slideshow.each(function() {
         pageflow.events.trigger('seed:loaded');


### PR DESCRIPTION
Ensure `pageflow.visited` is present when `pageflow.ready` is
resolved. Since we also resolve `pageflow.ready` in the editor now,
this lead to errors when navigation widgets tried to used
`pageflow.visited`.