### PR TITLE
Assign @entry attribute in render_page test helper

### DIFF
--- a/app/helpers/pageflow/page_background_asset_helper.rb
+++ b/app/helpers/pageflow/page_background_asset_helper.rb
@@ -3,9 +3,9 @@ module Pageflow
     include EntryJsonSeedHelper
     include ReactServerSideRenderingHelper
 
-    def page_background_asset(page, entry = @entry)
+    def page_background_asset(page)
       render('pageflow/page_background_asset/element',
-             entry: entry,
+             entry: @entry,
              page: page)
     end
   end

--- a/spec/helpers/pageflow/page_background_asset_helper_spec.rb
+++ b/spec/helpers/pageflow/page_background_asset_helper_spec.rb
@@ -10,7 +10,8 @@ module Pageflow
                       revision: entry.published_revision,
                       configuration: {background_image_id: image_file.id})
 
-        html = helper.page_background_asset(page, PublishedEntry.new(entry))
+        assign(:entry, PublishedEntry.new(entry))
+        html = helper.page_background_asset(page)
 
         expect(html).to have_selector("div.background_image.image_#{image_file.id}")
       end
@@ -22,7 +23,8 @@ module Pageflow
                       revision: entry.published_revision,
                       configuration: {background_image_id: image_file.id})
 
-        html = helper.page_background_asset(page, PublishedEntry.new(entry))
+        assign(:entry, PublishedEntry.new(entry))
+        html = helper.page_background_asset(page)
 
         expect(html).to have_json_ld('@type' => 'ImageObject')
       end
@@ -37,7 +39,8 @@ module Pageflow
                         video_file_id: video_file.id
                       })
 
-        html = helper.page_background_asset(page, PublishedEntry.new(entry))
+        assign(:entry, PublishedEntry.new(entry))
+        html = helper.page_background_asset(page)
 
         expect(html).to have_json_ld('@type' => 'VideoObject')
       end
@@ -49,7 +52,8 @@ module Pageflow
                       revision: entry.published_revision,
                       configuration: {background_image_id: image_file.id})
 
-        html = helper.page_background_asset(page, PublishedEntry.new(entry))
+        assign(:entry, PublishedEntry.new(entry))
+        html = helper.page_background_asset(page)
 
         expect(html).not_to have_json_ld('@type' => 'ImageObject')
       end

--- a/spec/support/pageflow/render_page_test_helper.rb
+++ b/spec/support/pageflow/render_page_test_helper.rb
@@ -26,6 +26,8 @@ module Pageflow
         helper.extend(page_type_helper)
       end
 
+      assign(:entry, entry)
+
       helper.render_page_template(page, entry: entry)
     end
   end


### PR DESCRIPTION
REDMINE-16580

Ensure page types can use helpers like `page_background_asset` which
depend on `@entry` being assigned.