### PR TITLE
Do not require content_wrapper in page type lint specs

### DIFF
--- a/spec/support/pageflow/lint/page_type.rb
+++ b/spec/support/pageflow/lint/page_type.rb
@@ -22,7 +22,6 @@ module Pageflow
             expect(html).to have_selector('div.content_and_background')
             expect(html).to have_selector('div.content_and_background > div.page_background')
             expect(html).to have_selector('div.content_and_background > div.content')
-            expect(html).to have_selector('div.scroller > div > div.content_wrapper')
           end
 
           it 'renders json seed template without error' do


### PR DESCRIPTION
The linkmap page is an example of a page that does not have a content
wrapper.

REDMINE-16580