### PR TITLE
Fix first page selectors in themes

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/page.js
+++ b/app/assets/javascripts/pageflow/editor/models/page.js
@@ -44,7 +44,17 @@ pageflow.Page = Backbone.Model.extend({
   },
 
   chapterPosition: function() {
-    return (this.chapter && this.chapter.get('position')) || -1;
+    return this.chapter && this.chapter.has('position') ? this.chapter.get('position') : -1;
+  },
+
+  isFirstPage: function() {
+    return this.isChapterBeginning() &&
+           this.chapterPosition() === 0 &&
+           this.storylinePosition() === 1;
+  },
+
+  isChapterBeginning: function() {
+    return this.get('position') === 0;
   },
 
   title: function() {

--- a/app/assets/javascripts/pageflow/editor/views/page_preview_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/page_preview_view.js
@@ -7,7 +7,7 @@ pageflow.PagePreviewView = Backbone.Marionette.View.extend({
 
     'change:configuration': 'update',
 
-    'change:position': 'updateChapterBeginningClass',
+    'change:position': 'updatePositionClassNames',
 
     'change:id': function() {
       this.$el.attr('data-id', this.model.id);
@@ -67,12 +67,12 @@ pageflow.PagePreviewView = Backbone.Marionette.View.extend({
     pageflow.events.trigger('page:update', this.model);
 
     this.refreshScroller();
-    this.updateChapterBeginningClass();
+    this.updatePositionClassNames();
   },
 
-  updateChapterBeginningClass: function() {
-    var chapterBeginning = this.model.get('position') === 0;
-    this.$el.toggleClass('chapter_beginning', chapterBeginning);
+  updatePositionClassNames: function() {
+    this.$el.toggleClass('chapter_beginning', this.model.isChapterBeginning());
+    this.$el.toggleClass('first_page', this.model.isFirstPage());
   },
 
   pageTypeHooks: function() {

--- a/app/assets/stylesheets/pageflow/print_view.scss
+++ b/app/assets/stylesheets/pageflow/print_view.scss
@@ -44,7 +44,7 @@ body {
       z-index: 1;
     }
 
-    &:first-child {
+    &.first_page {
       .content_and_background .scroller > div:after {
         content: " ";
         position: absolute;
@@ -167,7 +167,7 @@ body {
     background-color: white !important;
   }
 
-  &.js .page:first-child.invert .content_and_background .scroller > div:after {
+  &.js .first_page.invert .content_and_background .scroller > div:after {
     background-image: none !important;
   }
 

--- a/app/assets/stylesheets/pageflow/themes/default/logo/variant/background_image.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/logo/variant/background_image.scss
@@ -30,7 +30,7 @@ $logo-background-image-variant-banner-phone-height: null !default;
   $phone-height,
   $phone-top
 ) {
-  $page-selector: if($first-page-only, ":first-child", "");
+  $page-selector: if($first-page-only, ".first_page", ".page");
 
   %background_logo {
     top: $top;
@@ -65,7 +65,7 @@ $logo-background-image-variant-banner-phone-height: null !default;
     @include logo-alignment;
   }
 
-  .page#{$page-selector} {
+  #{$page-selector} {
     .content_and_background .scroller > div:after {
       @extend %background_logo;
 
@@ -107,7 +107,7 @@ $logo-background-image-variant-banner-phone-height: null !default;
     opacity: $logo-background-image-variant-opacity;
   }
 
-  .page:first-child .scroller > div:after {
+  .first_page .scroller > div:after {
     opacity: $logo-background-image-variant-first-page-opacity;
   }
 }

--- a/app/assets/stylesheets/pageflow/themes/default/page/header.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/header.scss
@@ -135,7 +135,7 @@ $page-header-subtitle-margin-bottom: 1.875em !default;
   }
 }
 
-.page:first-child {
+.first_page {
   .page_header-title {
     @include typography(
       $page-header-first-page-title-typography,
@@ -157,7 +157,7 @@ $page-header-subtitle-margin-bottom: 1.875em !default;
   }
 }
 
-.emphasize_chapter_beginning .page.chapter_beginning:nth-of-type(n+2) {
+.emphasize_chapter_beginning .page.chapter_beginning:not(.first_page) {
   .page_header-title {
     @include typography(
       $page-header-chapter-beginning-title-typography

--- a/app/assets/stylesheets/pageflow/themes/default/page/paddings.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/paddings.scss
@@ -53,7 +53,7 @@ $page-scroller-first-page-phone-padding-top: null !default;
   }
 }
 
-.page:first-child {
+.first_page {
   .scroller > div {
     padding-top: $page-scroller-first-page-padding-top;
 

--- a/app/helpers/pageflow/pages_helper.rb
+++ b/app/helpers/pageflow/pages_helper.rb
@@ -17,6 +17,7 @@ module Pageflow
       classes << "scroll_indicator_orientation_#{page.configuration['scroll_indicator_orientation']}" if page.configuration['scroll_indicator_orientation'].present?
       classes << "delayed_text_fade_in_#{page.configuration['delayed_text_fade_in']}" if page.configuration['delayed_text_fade_in'].present?
       classes << 'chapter_beginning' if page.position == 0
+      classes << 'first_page' if page.is_first
       classes << 'no_text_content' if !page_has_content(page)
       classes.join(' ')
     end

--- a/app/models/pageflow/chapter.rb
+++ b/app/models/pageflow/chapter.rb
@@ -5,7 +5,13 @@ module Pageflow
     belongs_to :storyline, touch: true
     has_many :pages, -> { order('position ASC') }, dependent: :destroy, inverse_of: :chapter
 
+    attr_accessor :is_first
+
     delegate :entry, to: :storyline
+
+    def pages
+      super.tap { |p| p.first.is_first = true if is_first && p.present? }
+    end
 
     def copy_to(storyline)
       chapter = dup

--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -103,6 +103,10 @@ module Pageflow
       super.tap { |p| p.first.is_first = true if p.present? }
     end
 
+    def chapters
+      super.tap { |c| c.first.is_first = true if c.present? }
+    end
+
     def published?
       (published_at.present? && Time.now >= published_at) &&
         (published_until.blank? || Time.now < published_until)

--- a/spec/controllers/pageflow/entries_controller_spec.rb
+++ b/spec/controllers/pageflow/entries_controller_spec.rb
@@ -202,6 +202,16 @@ module Pageflow
           expect(response.body).to have_selector('html[lang=de]')
         end
 
+        it 'sets first_page css class on first page' do
+          entry = create(:entry, :published)
+          create(:page, revision: entry.published_revision)
+          create(:page, revision: entry.published_revision)
+
+          get(:show, params: {id: entry})
+
+          expect(response.body).to have_selector('.first_page', count: 1)
+        end
+
         it 'renders widgets at bottom of entry' do
           widget_type = TestWidgetType.new(name: 'test_widget',
                                            rendered: '<div class="test_widget"></div>')

--- a/spec/helpers/pageflow/pages_helper_spec.rb
+++ b/spec/helpers/pageflow/pages_helper_spec.rb
@@ -83,6 +83,22 @@ module Pageflow
         expect(css_classes).to include('page')
         expect(css_classes).to include('text_position_right')
       end
+
+      it 'does not contain first_page class by default' do
+        page = build(:page)
+
+        css_classes = helper.page_css_class(page).split(' ')
+
+        expect(css_classes).not_to include('first_page')
+      end
+
+      it 'contains first_page class if page has is_first attribute set' do
+        page = build(:page, is_first: true)
+
+        css_classes = helper.page_css_class(page).split(' ')
+
+        expect(css_classes).to include('first_page')
+      end
     end
 
     describe '#page_thumbnail_image_class' do

--- a/spec/models/pageflow/revision_spec.rb
+++ b/spec/models/pageflow/revision_spec.rb
@@ -280,6 +280,42 @@ module Pageflow
         expect(pages[2]).to eq(page_3)
         expect(pages[3]).to eq(page_4)
       end
+
+      it 'sets is_first on first page' do
+        revision = create(:revision)
+        storyline1 = create(:storyline, revision: revision, position: 1)
+        storyline2 = create(:storyline, revision: revision, position: 2)
+        chapter1 = create(:chapter, storyline: storyline1, position: 1)
+        chapter2 = create(:chapter, storyline: storyline1, position: 1)
+        chapter3 = create(:chapter, storyline: storyline2, position: 1)
+        create(:page, chapter: chapter1, position: 1)
+        create(:page, chapter: chapter1, position: 2)
+        create(:page, chapter: chapter2, position: 1)
+        create(:page, chapter: chapter3, position: 1)
+
+        pages = revision.pages
+
+        expect(pages.map(&:is_first)).to eq([true, nil, nil, nil])
+      end
+    end
+
+    describe '#chapters' do
+      it 'sets is_first on first page' do
+        revision = create(:revision)
+        storyline1 = create(:storyline, revision: revision, position: 1)
+        storyline2 = create(:storyline, revision: revision, position: 2)
+        chapter1 = create(:chapter, storyline: storyline1, position: 1)
+        chapter2 = create(:chapter, storyline: storyline1, position: 1)
+        chapter3 = create(:chapter, storyline: storyline2, position: 1)
+        create(:page, chapter: chapter1, position: 1)
+        create(:page, chapter: chapter1, position: 2)
+        create(:page, chapter: chapter2, position: 1)
+        create(:page, chapter: chapter3, position: 1)
+
+        pages = revision.chapters.map(&:pages).flatten
+
+        expect(pages.map(&:is_first)).to eq([true, nil, nil, nil])
+      end
     end
 
     describe '#main_storyline_chapters' do


### PR DESCRIPTION
Using `:first-child` no longer works since pages are now wrapped in
chapter sections in published entries.

Make theme more robust by setting a `first_page` css class instead.

REDMINE-16708