### PR TITLE
Prevent "element click intercepted" errors in feature specs

### DIFF
--- a/spec/features/visitor/reading_entry_spec.rb
+++ b/spec/features/visitor/reading_entry_spec.rb
@@ -37,7 +37,9 @@ feature 'as visitor, reading entry' do
            configuration: {title: 'Page two'})
 
     visit(pageflow.entry_path(entry))
-    Dom::Entry.find!.go_to_next_page
+    entry = Dom::Entry.find!
+    entry.wait_until_loading_spinner_disappears
+    entry.go_to_next_page
 
     expect(Dom::Page.active).to have_text('Page two')
   end

--- a/spec/support/dominos/editor/publish_entry_panel.rb
+++ b/spec/support/dominos/editor/publish_entry_panel.rb
@@ -55,6 +55,8 @@ module Dom
 
       def blur_input_fields
         node.find('h2').click
+        # Wait for date drop down to fade out
+        sleep 1
       end
     end
   end

--- a/spec/support/dominos/entry.rb
+++ b/spec/support/dominos/entry.rb
@@ -2,6 +2,11 @@ module Dom
   class Entry < Domino
     selector '#outer_wrapper'
 
+    def wait_until_loading_spinner_disappears
+      wait = Selenium::WebDriver::Wait.new(timeout: 5)
+      wait.until { node.all('.loading_spinner').empty? }
+    end
+
     def go_to_next_page
       node.find('.scroll_indicator').click
     end


### PR DESCRIPTION
* Wait for loading spinner to disappear.

* Fix hiding of depublication date drop down.