### PR TITLE
Reset background color in fullscreen Safari

### DIFF
--- a/app/assets/stylesheets/pageflow/base.scss
+++ b/app/assets/stylesheets/pageflow/base.scss
@@ -1,3 +1,5 @@
+// scss-lint:disable IdSelector
+
 html, body, #outer_wrapper {
   margin: 0;
   padding: 0;
@@ -25,6 +27,11 @@ body {
 
 body.js, .js #outer_wrapper {
   overflow: hidden;
+}
+
+// Safari sets background color of fullscreen elements to white.
+#outer_wrapper:-webkit-full-screen {
+  background-color: transparent;
 }
 
 // Apps like Twitter and Facebook displays a toolbar at the bottom of


### PR DESCRIPTION
Safari sets background color of fullscreen elements to white via user
agent styles. This can be seen on before/after pages when switching to
fullscreen mode.

REDMINE-16802