### PR TITLE
Ensure remove link button is show in text editor (14.1 Backport)

### DIFF
--- a/app/assets/javascripts/pageflow/ui/templates/inputs/text_area_input.jst.ejs
+++ b/app/assets/javascripts/pageflow/ui/templates/inputs/text_area_input.jst.ejs
@@ -10,11 +10,11 @@
   <a data-wysihtml5-command="bold" title="<%= I18n.t('pageflow.ui.templates.inputs.text_area_input.bold') %>"></a>
   <a data-wysihtml5-command="italic" title="<%= I18n.t('pageflow.ui.templates.inputs.text_area_input.italic') %>"></a>
   <a data-wysihtml5-command="underline" title="<%= I18n.t('pageflow.ui.templates.inputs.text_area_input.underline') %>"></a>
-  <a data-wysihtml5-command="createLink" title="<%= I18n.t('pageflow.ui.templates.inputs.text_area_input.create_link') %>"></a>
+  <a data-wysihtml5-command="createLink" class="link_button" title="<%= I18n.t('pageflow.ui.templates.inputs.text_area_input.create_link') %>"></a>
   <a data-wysihtml5-command="insertOrderedList" title="<%= I18n.t('pageflow.ui.templates.inputs.text_area_input.insert_ordered_list') %>"></a>
   <a data-wysihtml5-command="insertUnorderedList" title="<%= I18n.t('pageflow.ui.templates.inputs.text_area_input.insert_unordered_list') %>"></a>
 
-  <div data-wysihtml5-dialog="createLink" class="dialog" style="display: none;">
+  <div data-wysihtml5-dialog="createLink" class="dialog link_dialog" style="display: none;">
     <div class="link_type_select">
       <label>
         <input type="radio" name="link_type" class="url_link_radio_button">

--- a/app/assets/javascripts/pageflow/ui/views/inputs/text_area_input_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/inputs/text_area_input_view.js
@@ -34,6 +34,9 @@ pageflow.TextAreaInputView = Backbone.Marionette.ItemView.extend({
     input: 'textarea',
     toolbar: '.toolbar',
 
+    linkButton: '.link_button',
+    linkDialog: '.link_dialog',
+
     urlInput: '.current_url',
     targetInput: '.current_target',
 
@@ -103,7 +106,7 @@ pageflow.TextAreaInputView = Backbone.Marionette.ItemView.extend({
       this.ui.toolbar.find('a[data-wysihtml5-command="insertOrderedList"]').hide();
       this.ui.toolbar.find('a[data-wysihtml5-command="insertUnorderedList"]').hide();
     }
-    
+
     if (this.options.disableLinks) {
       this.ui.toolbar.find('a[data-wysihtml5-command="createLink"]').hide();
     }
@@ -130,6 +133,9 @@ pageflow.TextAreaInputView = Backbone.Marionette.ItemView.extend({
 
   setupUrlLinkPanel: function() {
     this.editor.on('show:dialog', _.bind(function() {
+      this.ui.linkDialog.toggleClass('for_existing_link',
+                                     this.ui.linkButton.hasClass('wysihtml5-command-active'));
+
       var currentUrl = this.ui.urlInput.val();
 
       if (currentUrl.startsWith('#')) {

--- a/app/assets/stylesheets/pageflow/editor/wysihtml5.scss
+++ b/app/assets/stylesheets/pageflow/editor/wysihtml5.scss
@@ -48,15 +48,15 @@
 
   [data-wysihtml5-command="createLink"] {
     @include link-icon;
+  }
 
-    &.wysihtml5-command-active + .dialog {
-      [data-wysihtml5-dialog-action="cancel"] {
-        display: none;
-      }
+  .link_dialog.for_existing_link {
+    [data-wysihtml5-dialog-action="cancel"] {
+      display: none;
+    }
 
-      [data-wysihtml5-command="removeLink"] {
-        display: block;
-      }
+    [data-wysihtml5-command="removeLink"] {
+      display: block;
     }
   }
 


### PR DESCRIPTION
Backport of #1160 

Do not depend on link dialog and link button to be siblings in the
DOM. Instead of using an adjacent CSS selector, explicitly set a CSS
class when the dialog is shown.

REDMINE-16728