### PR TITLE
WIP: Introduce perma_ids for ID-agnostic referencing

### DIFF
--- a/app/helpers/pageflow/audio_files_helper.rb
+++ b/app/helpers/pageflow/audio_files_helper.rb
@@ -1,32 +1,29 @@
 module Pageflow
   module AudioFilesHelper
-    def audio_file_audio_tag(audio_file_id, options = {})
+    def audio_file_audio_tag(audio_file_perma_id, options = {})
       options.merge!(class: ['audio-js', options.delete(:class)].compact * ' ',
                      controls: true,
                      preload: 'none')
       url_options = {unique_id: options.delete(:unique_id)}
 
-      if (audio_file = AudioFile.find_by_id(audio_file_id))
-        content_tag(:audio, options) do
-          audio_file_sources(audio_file, url_options).each do |source|
-            concat(tag(:source, source.slice(:src, :type)))
-          end
+      return unless audio_file = AudioFile.find_in_entry(@entry, audio_file_perma_id)
+      content_tag(:audio, options) do
+        audio_file_sources(audio_file, url_options).each do |source|
+          concat(tag(:source, source.slice(:src, :type)))
         end
       end
     end
 
-    def audio_file_script_tag(audio_file_id, options = {})
-      if (audio_file = AudioFile.find_by_id(audio_file_id))
-        render('pageflow/audio_files/script_tag',
-               audio_file: audio_file,
-               audio_file_sources: audio_file_sources(audio_file, options))
-      end
+    def audio_file_script_tag(audio_file_perma_id, options = {})
+      return unless audio_file = AudioFile.find_in_entry(@entry, audio_file_perma_id)
+      render('pageflow/audio_files/script_tag',
+             audio_file: audio_file,
+             audio_file_sources: audio_file_sources(audio_file, options))
     end
 
-    def audio_file_non_js_link(entry, audio_file_id)
-      if (audio_file = AudioFile.find_by_id(audio_file_id))
-        link_to(t('pageflow.audio.open'), short_audio_file_path(entry, audio_file))
-      end
+    def audio_file_non_js_link(entry, audio_file_perma_id)
+      return unless audio_file = AudioFile.find_in_entry(@entry, audio_file_perma_id)
+      link_to(t('pageflow.audio.open'), short_audio_file_path(entry, audio_file))
     end
 
     def audio_file_sources(audio_file, options = {})

--- a/app/helpers/pageflow/video_files_helper.rb
+++ b/app/helpers/pageflow/video_files_helper.rb
@@ -25,9 +25,9 @@ module Pageflow
                   style: "background-position: #{position[:x]}% #{position[:y]}%;")
     end
 
-    def poster_image_tag(video_id, poster_image_id, options = {})
-      video_file = VideoFile.find_by_id(video_id)
-      poster = ImageFile.find_by_id(poster_image_id)
+    def poster_image_tag(video_perma_id, poster_image_perma_id, options = {})
+      video_file = VideoFile.find_in_entry(@entry, video_perma_id)
+      poster = ImageFile.find_in_entry(@entry, poster_image_perma_id)
 
       if poster&.ready?
         options = options.merge('data-src' => poster.attachment.url(:medium))
@@ -53,8 +53,8 @@ module Pageflow
       options.reverse_merge! defaults
       url_options = {unique_id: options.delete(:unique_id)}
 
-      poster = ImageFile.find_by_id(options.delete(:poster_image_id))
-      mobile_poster = ImageFile.find_by_id(options.delete(:mobile_poster_image_id))
+      poster = ImageFile.find_in_entry(@entry, options.delete(:poster_image_perma_id))
+      mobile_poster = ImageFile.find_in_entry(@entry, options.delete(:mobile_poster_image_perma_id))
 
       options[:data] = {}
 
@@ -82,13 +82,8 @@ module Pageflow
              url_options: url_options)
     end
 
-    # @deprecated
-    def lookup_video_tag(video_id, poster_image_id, options = {})
-      video_file_script_tag(video_id, options.merge(poster_image_id: poster_image_id))
-    end
-
-    def video_file_script_tag(video_id, options = {})
-      video_file = VideoFile.find_by_id(video_id)
+    def video_file_script_tag(video_perma_id, options = {})
+      video_file = VideoFile.find_in_entry(@entry, video_perma_id)
 
       script_tag_data = {template: 'video'}
 
@@ -103,12 +98,11 @@ module Pageflow
              options: options)
     end
 
-    def video_file_non_js_link(entry, video_file_id)
-      if (video_file = VideoFile.find_by_id(video_file_id))
-        link_to(t('pageflow.public.play_video'),
-                short_video_file_path(entry, video_file),
-                class: 'hint')
-      end
+    def video_file_non_js_link(entry, video_file_perma_id)
+      return unless video_file = VideoFile.find_in_entry(@entry, video_file_perma_id)
+      link_to(t('pageflow.public.play_video'),
+              short_video_file_path(entry, video_file),
+              class: 'hint')
     end
 
     def video_file_sources(video_file, options = {})

--- a/app/models/concerns/pageflow/uploaded_file.rb
+++ b/app/models/concerns/pageflow/uploaded_file.rb
@@ -13,6 +13,14 @@ module Pageflow
       has_many :using_accounts, :through => :using_entries, :source => :account
 
       validate :parent_allows_type_for_nesting, :parent_belongs_to_same_entry
+
+      after_create { update_column(:perma_id, id) }
+    end
+
+    class_methods do
+      def find_in_entry(entry, perma_id)
+        find_by(entry_id: entry.id, perma_id: perma_id)
+      end
     end
 
     def parent_allows_type_for_nesting

--- a/app/views/pageflow/audio_files/_audio_file.html.erb
+++ b/app/views/pageflow/audio_files/_audio_file.html.erb
@@ -1,1 +1,1 @@
-<%= audio_file_audio_tag(audio_file.id, unique_id: 'single') %>
+<%= audio_file_audio_tag(audio_file.perma_id, unique_id: 'single') %>

--- a/db/migrate/20190523074434_introduce_perma_ids_for_id_agnostic_referencing.rb
+++ b/db/migrate/20190523074434_introduce_perma_ids_for_id_agnostic_referencing.rb
@@ -1,0 +1,15 @@
+class IntroducePermaIdsForIdAgnosticReferencing < ActiveRecord::Migration[5.2]
+  def up
+    %w(audio image text_track video).each do |uploaded_file_type|
+      add_column "pageflow_#{uploaded_file_type}_files", :perma_id, :integer, after: 'id'
+      add_index :"pageflow_#{uploaded_file_type}_files", :perma_id
+      execute("UPDATE pageflow_#{uploaded_file_type}_files SET perma_id = id;")
+    end
+  end
+
+  def down
+    %w(audio image text_track video).each do |uploaded_file_type|
+      remove_column "pageflow_#{uploaded_file_type}_files", :perma_id
+    end
+  end
+end

--- a/spec/helpers/pageflow/audio_files_helper_spec.rb
+++ b/spec/helpers/pageflow/audio_files_helper_spec.rb
@@ -2,11 +2,14 @@ require 'spec_helper'
 
 module Pageflow
   describe AudioFilesHelper do
+    before(:all) do
+      @audio_file = create(:audio_file)
+      @entry = @audio_file.entry
+    end
+
     describe '#audio_file_audio_tag' do
       it 'renders audio tag for audio file with sources' do
-        audio_file = create(:audio_file)
-
-        html = helper.audio_file_audio_tag(audio_file.id)
+        html = helper.audio_file_audio_tag(@audio_file.perma_id)
 
         expect(html).to have_selector('audio source')
       end
@@ -14,9 +17,7 @@ module Pageflow
 
     describe '#audio_file_script_tag' do
       it 'renders json script tag' do
-        audio_file = create(:audio_file)
-
-        html = helper.audio_file_script_tag(audio_file.id)
+        html = helper.audio_file_script_tag(@audio_file.perma_id)
 
         expect(html).to have_selector('script', text: 'src', visible: false)
       end

--- a/spec/helpers/pageflow/video_files_helper_spec.rb
+++ b/spec/helpers/pageflow/video_files_helper_spec.rb
@@ -79,12 +79,16 @@ module Pageflow
     end
 
     describe '#poster_image_tag' do
+      before(:all) do
+        @video_file = create(:video_file)
+        @entry = @video_file.entry
+      end
+
       context 'with separate poster image' do
         it 'includes the poster image url' do
-          video_file = create(:video_file)
-          poster_image = create(:image_file)
+          poster_image = create(:image_file, entry: @entry)
 
-          html = helper.poster_image_tag(video_file.id, poster_image.id)
+          html = helper.poster_image_tag(@video_file.perma_id, poster_image.perma_id)
 
           expect(html).to include(poster_image.attachment.url(:medium))
           expect(html).to include(poster_image.attachment.url(:print))
@@ -93,43 +97,40 @@ module Pageflow
 
       context 'with unknown poster image id' do
         it 'includes the video file poster url' do
-          video_file = create(:video_file)
+          html = helper.poster_image_tag(@video_file.perma_id, 'unknown')
 
-          html = helper.poster_image_tag(video_file.id, 'unknown')
-
-          expect(html).to include(video_file.poster.url(:medium))
-          expect(html).to include(video_file.poster.url(:print))
+          expect(html).to include(@video_file.poster.url(:medium))
+          expect(html).to include(@video_file.poster.url(:print))
         end
       end
     end
 
     describe '#video_file_video_tag' do
-      it 'sets class as css class' do
-        video_file = build(:video_file)
+      before(:all) do
+        @video_file = build(:video_file)
+        @entry = @video_file.entry
+      end
 
-        html = helper.video_file_video_tag(video_file, class: 'large')
+      it 'sets class as css class' do
+        html = helper.video_file_video_tag(@video_file, class: 'large')
 
         expect(html).to have_selector('video.large')
       end
 
       it 'passes controls option to tag' do
-        video_file = build(:video_file)
-
-        html = helper.video_file_video_tag(video_file, controls: 'controls')
+        html = helper.video_file_video_tag(@video_file, controls: 'controls')
 
         expect(html).to have_selector('video[controls]')
       end
 
       it 'sets preload to metadata if preload options is true' do
-        video_file = build(:video_file)
-
-        html = helper.video_file_video_tag(video_file, preload: true)
+        html = helper.video_file_video_tag(@video_file, preload: true)
 
         expect(html).to have_selector('video[preload=metadata]')
       end
 
       it 'includes sources and high sources for the video file' do
-        video_file = build(:video_file, id: 200)
+        video_file = build(:video_file, id: 200, entry: @entry)
 
         html = helper.video_file_video_tag(video_file)
 
@@ -138,15 +139,13 @@ module Pageflow
       end
 
       it 'includes unique id in source urls' do
-        video_file = build(:video_file)
-
-        html = helper.video_file_video_tag(video_file, unique_id: 'something-unique')
+        html = helper.video_file_video_tag(@video_file, unique_id: 'something-unique')
 
         expect(html).to have_selector('source[src*="something-unique"]')
       end
 
       it 'sets data-poster and data-large-poster attribute by video file poster' do
-        video_file = build(:video_file, poster_file_name: 'poster.jpg')
+        video_file = build(:video_file, poster_file_name: 'poster.jpg', entry: @entry)
 
         html = helper.video_file_video_tag(video_file)
 
@@ -155,27 +154,25 @@ module Pageflow
       end
 
       it 'sets data-poster and data-large-poster attribute by custom poster image' do
-        video_file = build(:video_file)
-        image_file = create(:image_file)
+        image_file = create(:image_file, entry: @entry)
 
-        html = helper.video_file_video_tag(video_file, poster_image_id: image_file.id)
+        html = helper.video_file_video_tag(@video_file, poster_image_perma_id: image_file.perma_id)
 
         expect(html).to have_selector('video[data-poster*="medium/image"]')
         expect(html).to have_selector('video[data-large-poster*="large/image"]')
       end
 
       it 'sets data-mobile-poster and data-mobile-large-poster attribute by custom mobile image' do
-        video_file = build(:video_file)
-        image_file = create(:image_file)
+        image_file = create(:image_file, entry: @entry)
 
-        html = helper.video_file_video_tag(video_file, mobile_poster_image_id: image_file.id)
+        html = helper.video_file_video_tag(@video_file, mobile_poster_image_perma_id: image_file.perma_id)
 
         expect(html).to have_selector('video[data-mobile-poster*="medium/image"]')
         expect(html).to have_selector('video[data-mobile-large-poster*="large/image"]')
       end
 
       it 'sets width and height data attributes' do
-        video_file = build(:video_file, width: 100, height: 50)
+        video_file = build(:video_file, width: 100, height: 50, entry: @entry)
 
         html = helper.video_file_video_tag(video_file)
 
@@ -184,34 +181,33 @@ module Pageflow
     end
 
     describe '#video_file_script_tag' do
-      it 'renders script tag containing video tag html' do
-        video_file = create(:video_file)
+      before(:all) do
+        @video_file = create(:video_file)
+        @entry = @video_file.entry
+      end
 
-        html = helper.video_file_script_tag(video_file.id)
+      it 'renders script tag containing video tag html' do
+        html = helper.video_file_script_tag(@video_file.perma_id)
 
         expect(html).to have_selector('script', visible: false, text: /<video/)
       end
 
       it 'sets data-template attribute' do
-        video_file = create(:video_file)
-
-        html = helper.video_file_script_tag(video_file.id)
+        html = helper.video_file_script_tag(@video_file.perma_id)
 
         expect(html).to have_selector('script[data-template=video]', visible: false)
       end
 
       it 'sets width and height data attributes' do
-        video_file = create(:video_file, width: 100, height: 50)
+        video_file = create(:video_file, width: 100, height: 50, entry: @entry)
 
-        html = helper.video_file_script_tag(video_file.id)
+        html = helper.video_file_script_tag(video_file.perma_id)
 
         expect(html).to have_selector('script[data-video-width="100"][data-video-height="50"]', visible: false)
       end
 
       it 'passes options to video tag helper' do
-        video_file = create(:video_file)
-
-        html = helper.video_file_script_tag(video_file.id, controls: true)
+        html = helper.video_file_script_tag(@video_file.perma_id, controls: true)
 
         expect(html).to have_selector('script', visible: false, text: /controls/)
       end
@@ -221,10 +217,11 @@ module Pageflow
       it 'renders link to short video file path' do
         entry = create(:entry)
         video_file = create(:video_file, id: 100)
+        @entry = video_file.entry
 
         expect(helper).to receive(:short_video_file_path).with(entry, video_file).and_return('/video')
 
-        html = helper.video_file_non_js_link(entry, video_file.id)
+        html = helper.video_file_non_js_link(entry, video_file.perma_id)
 
         expect(html).to have_selector('a[href*="/video"]')
       end


### PR DESCRIPTION
In order to be able to move entries from dedicated to hosted pageflow,
this introduces a perma_id for UploadedFiles which can be used to
reference files within the scope of their entries even when their
ID changes during import into the new database.

REDMINE-16809