### PR TITLE
Make TabsView tabs scrollable

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,6 +16,7 @@
     "videojs",
     "Audio5js",
     "I18n",
+    "IScroll",
 
     "pageflow",
     "editor",

--- a/app/assets/javascripts/pageflow/editor/views/edit_page_view.js
+++ b/app/assets/javascripts/pageflow/editor/views/edit_page_view.js
@@ -40,13 +40,17 @@ pageflow.EditPageView = Backbone.Marionette.Layout.extend({
     this.model.trigger('edit', this.model);
   },
 
+  onShow: function() {
+    this.configurationEditor.refreshScroller();
+  },
+
   load: function() {
-    var configurationEditor = this.model.pageType().createConfigurationEditorView({
+    this.configurationEditor = this.model.pageType().createConfigurationEditorView({
       model: this.model.configuration,
       tab: this.options.tab
     });
 
-    this.configurationContainer.show(configurationEditor);
+    this.configurationContainer.show(this.configurationEditor);
   },
 
   destroy: function() {

--- a/app/assets/javascripts/pageflow/slideshow/scroller_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/scroller_widget.js
@@ -1,4 +1,3 @@
-/*global IScroll*/
 (function($) {
   /**
    * Wrapper widget around iScroll adding special bump events which

--- a/app/assets/javascripts/pageflow/ui/templates/tabs_view.jst.ejs
+++ b/app/assets/javascripts/pageflow/ui/templates/tabs_view.jst.ejs
@@ -1,2 +1,4 @@
-<ul></ul>
-<div></div>
+<div class="tabs_view-scroller">
+  <ul class="tabs_view-headers"></ul>
+</div>
+<div class="tabs_view-container"></div>

--- a/app/assets/javascripts/pageflow/ui/views/configuration_editor_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/configuration_editor_view.js
@@ -25,8 +25,18 @@ pageflow.ConfigurationEditorView = Backbone.Marionette.View.extend({
     }, this));
   },
 
+  /**
+   * Rerender current tab.
+   */
   refresh: function() {
     this.tabsView.refresh();
+  },
+
+  /**
+   * Adjust tabs scroller to changed width of view.
+   */
+  refreshScroller: function() {
+    this.tabsView.refreshScroller();
   },
 
   render: function() {

--- a/app/assets/javascripts/pageflow/ui/views/tabs_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/tabs_view.js
@@ -3,15 +3,16 @@ pageflow.TabsView = Backbone.Marionette.Layout.extend({
   className: 'tabs_view',
 
   ui: {
-    headers: '> ul',
+    headers: '.tabs_view-headers',
+    scroller: '.tabs_view-scroller'
   },
 
   regions: {
-    container: '> div'
+    container: '.tabs_view-container'
   },
 
   events: {
-    'click > ul > li': function(event) {
+    'click .tabs_view-headers > li': function(event) {
       this.changeTab($(event.target).data('tab-name'));
     }
   },
@@ -20,6 +21,8 @@ pageflow.TabsView = Backbone.Marionette.Layout.extend({
     this.tabFactoryFns = {};
     this.tabNames = [];
     this.currentTabName = null;
+
+    this._refreshScrollerOnSideBarResize();
   },
 
   tab: function(name, factoryFn) {
@@ -35,6 +38,13 @@ pageflow.TabsView = Backbone.Marionette.Layout.extend({
           .text(I18n.t(this.options.i18n + '.' + name))
       );
     }, this);
+
+    this.scroller = new IScroll(this.ui.scroller[0], {
+      scrollX: true,
+      scrollY: false,
+      bounce: false,
+      mouseWheel: true
+    });
 
     this.changeTab(this.defaultTab());
   },
@@ -54,8 +64,18 @@ pageflow.TabsView = Backbone.Marionette.Layout.extend({
     }
   },
 
+  /**
+   * Rerender current tab.
+   */
   refresh: function() {
     this.changeTab(this.currentTabName);
+  },
+
+  /**
+   * Adjust tabs scroller to changed width of view.
+   */
+  refreshScroller: function() {
+    this.scroller.refresh();
   },
 
   toggleSpinnerOnTab: function(name, visible) {
@@ -63,8 +83,22 @@ pageflow.TabsView = Backbone.Marionette.Layout.extend({
   },
 
   _updateActiveHeader: function(activeTabName) {
+    var scroller = this.scroller;
+
     this.ui.headers.children().each(function() {
-      $(this).toggleClass('active', $(this).data('tab-name') === activeTabName);
+      if ($(this).data('tab-name') === activeTabName) {
+        scroller.scrollToElement(this, 200, true);
+        $(this).addClass('active');
+      }
+      else {
+        $(this).removeClass('active');
+      }
+    });
+  },
+
+  _refreshScrollerOnSideBarResize: function() {
+    this.listenTo(pageflow.app, 'resize', function() {
+      this.scroller.refresh();
     });
   }
 });

--- a/app/assets/javascripts/pageflow/widgets/navigation.js
+++ b/app/assets/javascripts/pageflow/widgets/navigation.js
@@ -1,5 +1,3 @@
-/*global IScroll*/
-
 (function($) {
   $.widget('pageflow.navigation', {
     _create: function() {

--- a/app/assets/javascripts/pageflow/widgets/navigation_mobile.js
+++ b/app/assets/javascripts/pageflow/widgets/navigation_mobile.js
@@ -1,5 +1,3 @@
-/*global IScroll*/
-
 (function($) {
   $.widget('pageflow.navigationMobile', {
     _create: function() {

--- a/app/assets/javascripts/pageflow/widgets/overview.js
+++ b/app/assets/javascripts/pageflow/widgets/overview.js
@@ -1,5 +1,3 @@
-/*global pageflow, IScroll, jQuery*/
-
 jQuery(function($) {
   $.widget('pageflow.overview', {
     _create: function() {

--- a/app/assets/javascripts/pageflow/widgets/scroll_button.js
+++ b/app/assets/javascripts/pageflow/widgets/scroll_button.js
@@ -1,5 +1,3 @@
-/*global IScroll*/
-
 (function($) {
   var ENTER_KEY = 13;
   var SPACE_KEY = 32;

--- a/app/assets/stylesheets/pageflow/ui/tabs_view.scss
+++ b/app/assets/stylesheets/pageflow/ui/tabs_view.scss
@@ -1,32 +1,38 @@
 .tabs_view {
-  > ul {
-    background-color: #e5e5e5;
-    width: 100%;
-    white-space: nowrap;
+  &-scroller {
+    position: relative;
     overflow: hidden;
-    padding: 0;
+    height: 35px;
   }
 
-  > ul > li {
-    display: inline-block;
-    padding: 10px 10px;
+  &-headers {
     background-color: #e5e5e5;
-    cursor: pointer;
+    white-space: nowrap;
+    padding: 0;
+    position: absolute;
 
-    &.active {
-      background-color: #fff;
+    li {
+      display: inline-block;
+      padding: 10px 10px;
+      background-color: #e5e5e5;
+      cursor: pointer;
+
+      &.active {
+        background-color: #fff;
+      }
+
+      &.spinner {
+        padding-left: 27px;
+        @include background-icon-left;
+        @include background-icon-animation(blink);
+        @include up-bold-icon;
+      }
     }
   }
 
-  > div {
+  &-container {
     background-color: #fff;
     padding: 10px;
   }
 
-  > ul > li.spinner {
-    padding-left: 27px;
-    @include background-icon-left;
-    @include background-icon-animation(blink);
-    @include up-bold-icon;
-  }
 }

--- a/vendor/assets/javascripts/iscroll.js
+++ b/vendor/assets/javascripts/iscroll.js
@@ -141,7 +141,7 @@ var utils = (function () {
 
 	me.isDirLtr = function (el) {
 		var styles = window.getComputedStyle(el);
-		return styles.direction == 'ltr';
+		return styles.direction != 'rtl';
 	};
 
 	me.offsetRight = function (e) {


### PR DESCRIPTION
Now that plugins can add additional tabs to page configuration editors, tabs will overflow more often. Add scroller and always bring current tab into view port.

Declare `IScroll` as global in JSHint config, instead of using `global` comments.

REDMINE-16823