### PR TITLE
Fix sassc-rails development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development do
 end
 
 # Required to make imports in Active Admin stylesheet work
-gem 'sassc-rails'
+gem 'sassc-rails', '~> 1.0'
 
 # Required for XML serialization in Active Admin
 gem 'activemodel-serializers-xml'


### PR DESCRIPTION
Ensure `Gemfile` entry (which is required to make Active Admin
stylesheets work) uses the same version constraint as
gemspec. Otherwise `Gemfile` wins allowing incompatible gem versions.