### PR TITLE
Update bundler in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ services:
 
 before_install:
   - nvm install stable
+  - gem update bundler
 
 before_script:
   - bin/npm ci


### PR DESCRIPTION
Default bundler cannot handle Ruby version requirements correctly and
just fails if a gem requires a newer version. For example, `capybara`
requires Ruby 2.4 starting with version 3.16. Current version of
bundler handles this correctly and only installs 3.15.1 for Ruby 2.3.