### PR TITLE
Prevent creating storyline twice

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/storyline.js
+++ b/app/assets/javascripts/pageflow/editor/models/storyline.js
@@ -14,7 +14,9 @@ pageflow.Storyline = Backbone.Model.extend({
     this.configuration = new pageflow.StorylineConfiguration(this.get('configuration') || {});
 
     this.listenTo(this.configuration, 'change', function() {
-      this.save();
+      if (!this.isNew()) {
+        this.save();
+      }
       this.trigger('change:configuration', this);
     });
 


### PR DESCRIPTION
When using the "Add storyline button" above the entry outline in the
editor a duplicate storyline is created on the server. Since it's not
known in the client side, it is not included in `/order` updated. This
means `position` stays `nil` and moves the storyline to the top of the
list, making it the main storyline. After reloading the editor, the
next storyline order update fixes the problem.

This happens because `StorylineScaffold` triggers a
`scaffold:storyline` event before the storyline is persisted. The
sitemap plugin listens for this event and updates the configuration to
ensure `lane` and `row` are set. This causes the storyline to auto
save. Since Scaffold uses `Backbone.sync` directly, a second create
request is dispatched and only a single storyline model is added in
the client, while two have been added on the server.

Disable auto save until record has been persisted.

REDMINE-16819