### PR TITLE
Fix hide text on swipe

### DIFF
--- a/app/assets/javascripts/pageflow/slideshow/page_widget.js
+++ b/app/assets/javascripts/pageflow/slideshow/page_widget.js
@@ -193,7 +193,12 @@
           !pageflow.navigationDirection.isHorizontal() &&
           !this.pageType.noHideTextOnSwipe) {
         this.element.hideTextOnSwipe({
-          eventTargetSelector: '.content > .scroller'
+          eventTargetSelector: // legacy ERB pages
+                               '.content > .scroller,' +
+                               // React based pages
+                               '.content > .scroller-wrapper > .scroller,' +
+                               // internal links/text page
+                               '.content.scroller'
         });
       }
     },


### PR DESCRIPTION
The used CSS selector no longer applies for React based pages since an
additional wrapper div has been added around the scroller.

For internal link and text pages the selector never matched.

REDMINE-16835