### PR TITLE
Prevent duplicate network requests for video preload

### DIFF
--- a/node_package/package-lock.json
+++ b/node_package/package-lock.json
@@ -4478,6 +4478,10 @@
         "is-property": "^1.0.0"
       }
     },
+    "get-node-dimensions": {
+      "version": "github:tf/get-node-dimensions#ec276e5d41657edbf52804933fa1108b22157316",
+      "from": "github:tf/get-node-dimensions#no-clone-on-zero-dimension"
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -7387,113 +7391,12 @@
       }
     },
     "react-measure": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-1.4.7.tgz",
-      "integrity": "sha1-odLKDc/vBJeLesJjp2XctqCTb9s=",
+      "version": "github:tf/react-measure#1648593680c9ec4ddb23f4554142098820098bac",
+      "from": "github:tf/react-measure#no-clone-on-zero-dimension",
       "requires": {
-        "get-node-dimensions": "^1.2.0",
+        "get-node-dimensions": "github:tf/get-node-dimensions#no-clone-on-zero-dimension",
         "prop-types": "^15.5.4",
         "resize-observer-polyfill": "^1.4.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-          "requires": {
-            "iconv-lite": "~0.4.13"
-          }
-        },
-        "fbjs": {
-          "version": "0.8.16",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-          "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.9"
-          }
-        },
-        "get-node-dimensions": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/get-node-dimensions/-/get-node-dimensions-1.2.0.tgz",
-          "integrity": "sha1-lSmOMqdSoVXynrcQ4GlVe0p/6Yw="
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-          "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-          "requires": {
-            "node-fetch": "^1.0.1",
-            "whatwg-fetch": ">=0.10.0"
-          }
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-          "requires": {
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "prop-types": {
-          "version": "15.6.0",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-          "requires": {
-            "fbjs": "^0.8.16",
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "resize-observer-polyfill": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz",
-          "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-          "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-        }
       }
     },
     "react-redux": {
@@ -7669,6 +7572,11 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-2.5.4.tgz",
       "integrity": "sha1-t9I/3wC4P6etAnlUb427vXZccEc="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.3.3",

--- a/node_package/package.json
+++ b/node_package/package.json
@@ -63,7 +63,7 @@
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "react-draggable": "^2.2.2",
-    "react-measure": "^1.4.5",
+    "react-measure": "tf/react-measure#no-clone-on-zero-dimension",
     "react-redux": "^5.0.3",
     "react-wavesurfer": "tf/react-wavesurfer#patches",
     "redux": "^3.6.0",

--- a/node_package/src/media/components/VideoFilePlayer/Positioner/index.jsx
+++ b/node_package/src/media/components/VideoFilePlayer/Positioner/index.jsx
@@ -6,7 +6,7 @@ import Measure from 'react-measure';
 
 export default function Positioner(props) {
   return (
-    <Measure whitelist={['width', 'height']}>
+    <Measure whitelist={['width', 'height']} cloneOptions={{noCloneOnZeroDimension: true}}>
       {wrapperDimensions => renderWrapper(props, wrapperDimensions)}
     </Measure>
   );

--- a/node_package/src/media/components/createFilePlayer/MediaTag.jsx
+++ b/node_package/src/media/components/createFilePlayer/MediaTag.jsx
@@ -68,7 +68,7 @@ export default class MediaTag extends React.Component {
     const wrapper = document.createElement('div');
     const mediaElement = document.createElement(this.props.tagName);
 
-    mediaElement.setAttribute('preload', 'auto');
+    mediaElement.setAttribute('preload', 'none');
     mediaElement.setAttribute('crossorigin', 'anonymous');
     mediaElement.setAttribute('alt', this.props.alt);
 
@@ -110,7 +110,7 @@ export default class MediaTag extends React.Component {
     });
 
     wrapper.appendChild(mediaElement);
-    return {__html: wrapper.innerHTML};
+    return {__html: wrapper.innerHTML.replace('preload="none"', 'preload="auto"')};
   }
 }
 

--- a/node_package/src/media/components/createFilePlayer/__spec__/MediaTag-spec.jsx
+++ b/node_package/src/media/components/createFilePlayer/__spec__/MediaTag-spec.jsx
@@ -58,6 +58,12 @@ describe('MediaTag', () => {
     expect(wrapper).to.have.descendants('video[playsinline]');
   });
 
+  it('sets preload attribute to auto', () => {
+    const wrapper = render(<MediaTag />);
+
+    expect(wrapper).to.have.descendants('video[preload="auto"]');
+  });
+
   it('re-renders when source changes', () => {
     const sources = [{type: 'video/mp4', src: 'some.mp4'}];
     const changedSources = [{type: 'video/mp4', src: 'new.mp4'}];


### PR DESCRIPTION
- Update `react-measure` to version that uses patched
  `get-node-dimensions` which does not clone nodes. Nodes were cloned
  in some cases when trying to measure hidden elements, leading to
  additional network connections in Firefox 67.

- A detached DOM element is used to build the HTML for
  `MediaTag`. Setting `preload` to `auto` in the detached element,
  triggers a separate request in Firefox 67 which afterwards keeps a
  network connection open.

  Set `preload` to `none` and perform text replacement in the string
  which is passed to `dangerouslySetInnerHTML`.

REDMINE-16834