### PR TITLE
Fix Capybara tests in Chrome 75

### DIFF
--- a/spec/support/config/capybara.rb
+++ b/spec/support/config/capybara.rb
@@ -10,7 +10,18 @@ Capybara.register_driver :selenium_chrome_headless_no_sandbox do |app|
   # Required for chrome to work in container based Travis environment
   # (see https://docs.travis-ci.com/user/chrome)
   browser_options.args << '--no-sandbox'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+
+  # see https://github.com/dbalatero/capybara-chromedriver-logger/issues/11
+  capabilities = {
+    chromeOptions: {
+      w3c: false
+    }
+  }
+
+  Capybara::Selenium::Driver.new(app,
+                                 browser: :chrome,
+                                 options: browser_options,
+                                 desired_capabilities: capabilities)
 end
 
 Capybara.javascript_driver = :selenium_chrome_headless_no_sandbox


### PR DESCRIPTION
As described in [1]:

With the release of Chrome 75 (and ChromeDriver 75) we started seeing
this error:

```
Capybara::Chromedriver::Logger::TestHooks.after_example! NoMethodError: private method `log' called for #<Selenium::WebDriver::Remote::W3C::Bridge:0x00007fad79f94218>
```

ChromeDriver 75 now runs in W3C standard compliant mode by default
[2]. Which ultimately means that
`driver.browser.manage.logs.get(:browser)` is not a compliant way to
get access to the logs.

[1] https://github.com/dbalatero/capybara-chromedriver-logger/issues/11

[2] http://chromedriver.chromium.org/downloads