### PR TITLE
Always lookup files by revisions usage scope

### DIFF
--- a/app/controllers/pageflow/files_controller.rb
+++ b/app/controllers/pageflow/files_controller.rb
@@ -8,10 +8,10 @@ module Pageflow
     def show
       respond_to do |format|
         format.html do
-          entry = PublishedEntry.find(params[:entry_id], entry_request_scope)
-          @file = entry.find_file(file_type.model, params[:id])
+          @entry = PublishedEntry.find(params[:entry_id], entry_request_scope)
+          @file = @entry.find_file(file_type.model, params[:id])
 
-          check_entry_password_protection(entry)
+          check_entry_password_protection(@entry)
         end
       end
     end

--- a/app/helpers/pageflow/audio_files_helper.rb
+++ b/app/helpers/pageflow/audio_files_helper.rb
@@ -1,32 +1,36 @@
 module Pageflow
   module AudioFilesHelper
+    include RevisionFileHelper
+
     def audio_file_audio_tag(audio_file_id, options = {})
       options.merge!(class: ['audio-js', options.delete(:class)].compact * ' ',
                      controls: true,
                      preload: 'none')
       url_options = {unique_id: options.delete(:unique_id)}
 
-      if (audio_file = AudioFile.find_by_id(audio_file_id))
-        content_tag(:audio, options) do
-          audio_file_sources(audio_file, url_options).each do |source|
-            concat(tag(:source, source.slice(:src, :type)))
-          end
+      audio_file = find_file_in_entry(AudioFile, audio_file_id)
+      return unless audio_file
+      content_tag(:audio, options) do
+        audio_file_sources(audio_file, url_options).each do |source|
+          concat(tag(:source, source.slice(:src, :type)))
         end
       end
     end
 
     def audio_file_script_tag(audio_file_id, options = {})
-      if (audio_file = AudioFile.find_by_id(audio_file_id))
-        render('pageflow/audio_files/script_tag',
-               audio_file: audio_file,
-               audio_file_sources: audio_file_sources(audio_file, options))
-      end
+      audio_file = find_file_in_entry(AudioFile, audio_file_id)
+      return unless audio_file
+
+      render('pageflow/audio_files/script_tag',
+             audio_file: audio_file,
+             audio_file_sources: audio_file_sources(audio_file, options))
     end
 
     def audio_file_non_js_link(entry, audio_file_id)
-      if (audio_file = AudioFile.find_by_id(audio_file_id))
-        link_to(t('pageflow.audio.open'), short_audio_file_path(entry, audio_file))
-      end
+      audio_file = find_file_in_entry(AudioFile, audio_file_id)
+      return unless audio_file
+
+      link_to(t('pageflow.audio.open'), short_audio_file_path(entry, audio_file))
     end
 
     def audio_file_sources(audio_file, options = {})

--- a/app/helpers/pageflow/background_image_helper.rb
+++ b/app/helpers/pageflow/background_image_helper.rb
@@ -1,5 +1,7 @@
 module Pageflow
   module BackgroundImageHelper
+    include RevisionFileHelper
+
     def background_image_div(configuration, property_base_name, options = {})
       Div.new(self, configuration, property_base_name, options).render
     end
@@ -9,12 +11,12 @@ module Pageflow
     end
 
     def background_image_tag(image_id, options = {})
-      image = ImageFile.find_by_id(image_id)
-      if image&.ready?
-        options = options.merge(:'data-src' => image.attachment.url(:medium))
-        options = options.merge(:'data-printsrc' => image.attachment.url(:print))
-        image_tag('', options)
-      end
+      image = find_file_in_entry(ImageFile, image_id)
+      return unless image&.ready?
+
+      options = options.merge('data-src': image.attachment.url(:medium))
+      options = options.merge('data-printsrc': image.attachment.url(:print))
+      image_tag('', options)
     end
 
     def background_image_lazy_loading_css_class(prefix, model)
@@ -25,7 +27,7 @@ module Pageflow
     class Div
       attr_reader :configuration, :property_base_name, :options
 
-      delegate :content_tag, :to => :@template
+      delegate :content_tag, to: :@template
 
       def initialize(template, configuration, property_base_name, options)
         @template = template
@@ -35,7 +37,7 @@ module Pageflow
       end
 
       def render
-        content_tag(:div, '', :class => css_class, :style => inline_style, :data => data_attributes)
+        content_tag(:div, '', class: css_class, style: inline_style, data: data_attributes)
       end
 
       protected
@@ -80,7 +82,7 @@ module Pageflow
     class DivWithSizeAttributes < Div
       def data_attributes
         if file
-          super.merge(:width => file.width, :height => file.height)
+          super.merge(width: file.width, height: file.height)
         else
           super
         end

--- a/app/helpers/pageflow/revision_file_helper.rb
+++ b/app/helpers/pageflow/revision_file_helper.rb
@@ -1,0 +1,23 @@
+module Pageflow
+  module RevisionFileHelper
+    # Instead of finding a file directly by its ID (stored in configuration hashes for example),
+    # finds the file within the scope of the revisions usages.
+    # The @entry instance variable (of type DraftEntry or PublishedEntry)
+    # must always be available in views using this helper, otherwise an exception is raised.
+    #
+    # When testing helpers which use the RevisionFileHelper to find their respective files,
+    # you can stub its functionality using the RevisionFileTestHelpers `entry_has_file`-method:
+    #
+    #     image_file = create(:image_file)
+    #     entry_has_file(image_file)
+    #
+    # This simplifies spec setup by eliminating the need to set up the entry and usages first.
+    #
+    # @since edge
+    # @returns UsedFile
+    def find_file_in_entry(file_type, file_id)
+      raise 'No entry of type PublishedEntry or DraftEntry set.' unless @entry.present?
+      @entry.find_file_by_id(file_type, file_id)
+    end
+  end
+end

--- a/app/helpers/pageflow/revision_file_helper.rb
+++ b/app/helpers/pageflow/revision_file_helper.rb
@@ -6,7 +6,8 @@ module Pageflow
     # must always be available in views using this helper, otherwise an exception is raised.
     #
     # When testing helpers which use the RevisionFileHelper to find their respective files,
-    # you can stub its functionality using the RevisionFileTestHelpers `entry_has_file`-method:
+    # you can stub its functionality by including the shared context
+    # "usage agnostic file association" and specifying `entry_has_file` for the file:
     #
     #     image_file = create(:image_file)
     #     entry_has_file(image_file)

--- a/app/helpers/pageflow/social_share_helper.rb
+++ b/app/helpers/pageflow/social_share_helper.rb
@@ -1,6 +1,7 @@
 module Pageflow
   module SocialShareHelper
     include EntriesHelper
+    include RevisionFileHelper
 
     def social_share_meta_tags_for(target)
       if target.is_a?(Page)
@@ -53,7 +54,7 @@ module Pageflow
 
     def social_share_entry_image_tags(entry)
       image_urls = []
-      image_file = ImageFile.find_by_id(entry.share_image_id)
+      image_file = find_file_in_entry(ImageFile, entry.share_image_id)
 
       if image_file
         image_urls << image_file.thumbnail_url(:medium)

--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -20,7 +20,7 @@ module Pageflow
              :emphasize_new_pages,
              :share_url, :share_image_id, :share_image_x, :share_image_y,
              :share_providers, :active_share_providers,
-             :find_files, :find_file,
+             :find_files, :find_file, :find_file_by_id,
              :image_files, :video_files, :audio_files,
              :locale,
              :author, :publisher, :keywords,

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -16,7 +16,7 @@ module Pageflow
 
     delegate(:widgets,
              :storylines, :main_storyline_chapters, :chapters, :pages,
-             :find_files, :find_file,
+             :find_files, :find_file, :find_file_by_id,
              :image_files, :video_files, :audio_files,
              :summary, :credits, :manual_start,
              :emphasize_chapter_beginning,

--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -93,6 +93,12 @@ module Pageflow
       UsedFile.new(file)
     end
 
+    def find_file_by_id(model, id)
+      file = files(model).find_by(id: id)
+      return unless file
+      UsedFile.new(file)
+    end
+
     def share_providers
       self[:share_providers] || entry.theming.default_share_providers
     end

--- a/spec/factories/used_file.rb
+++ b/spec/factories/used_file.rb
@@ -1,0 +1,17 @@
+module Pageflow
+  FactoryBot.define do
+    factory :used_file, class: UsedFile do
+      transient do
+        model { nil }
+        revision { nil }
+      end
+
+      initialize_with do
+        file = build(model)
+        usage = file.usages.build(revision: revision)
+
+        UsedFile.new(file, usage)
+      end
+    end
+  end
+end

--- a/spec/helpers/pageflow/audio_files_helper_spec.rb
+++ b/spec/helpers/pageflow/audio_files_helper_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require 'pageflow/revision_file_test_helper'
+require 'shared_contexts/usage_agnostic_file_association'
 
 module Pageflow
   describe AudioFilesHelper do
-    include RevisionFileTestHelper
+    include_context 'usage agnostic file association'
 
     describe '#audio_file_audio_tag' do
       it 'renders audio tag for audio file with sources' do

--- a/spec/helpers/pageflow/audio_files_helper_spec.rb
+++ b/spec/helpers/pageflow/audio_files_helper_spec.rb
@@ -1,10 +1,14 @@
 require 'spec_helper'
+require 'pageflow/revision_file_test_helper'
 
 module Pageflow
   describe AudioFilesHelper do
+    include RevisionFileTestHelper
+
     describe '#audio_file_audio_tag' do
       it 'renders audio tag for audio file with sources' do
         audio_file = create(:audio_file)
+        entry_has_file(audio_file)
 
         html = helper.audio_file_audio_tag(audio_file.id)
 
@@ -15,6 +19,7 @@ module Pageflow
     describe '#audio_file_script_tag' do
       it 'renders json script tag' do
         audio_file = create(:audio_file)
+        entry_has_file(audio_file)
 
         html = helper.audio_file_script_tag(audio_file.id)
 

--- a/spec/helpers/pageflow/pages_helper_spec.rb
+++ b/spec/helpers/pageflow/pages_helper_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
+require 'pageflow/revision_file_test_helper'
 
 module Pageflow
   describe PagesHelper do
+    include RevisionFileTestHelper
+
     describe '#render_page_template' do
       let(:page_type_class) do
         Class.new(Pageflow::PageType) do
@@ -128,6 +131,8 @@ module Pageflow
 
       it 'renders header, print image and page text' do
         image_file = create(:image_file)
+        entry_has_file(image_file)
+
         page = build(:page, configuration: {
                        'background_image_id' => image_file.id,
                        'title' => 'Title',
@@ -165,6 +170,8 @@ module Pageflow
 
       it 'renders img tag' do
         image_file = create(:image_file)
+        entry_has_file(image_file)
+
         page = build(:page, configuration: {
                        'background_image_id' => image_file.id
                      })

--- a/spec/helpers/pageflow/pages_helper_spec.rb
+++ b/spec/helpers/pageflow/pages_helper_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require 'pageflow/revision_file_test_helper'
+require 'shared_contexts/usage_agnostic_file_association'
 
 module Pageflow
   describe PagesHelper do
-    include RevisionFileTestHelper
+    include_context 'usage agnostic file association'
 
     describe '#render_page_template' do
       let(:page_type_class) do

--- a/spec/helpers/pageflow/revision_file_helper_spec.rb
+++ b/spec/helpers/pageflow/revision_file_helper_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+module Pageflow
+  describe RevisionFileHelper do
+    describe '#find_file_in_entry' do
+      it 'raises exception when no entry is set' do
+        expect { helper.find_file_in_entry(ImageFile, 1) }.to(
+          raise_error('No entry of type PublishedEntry or DraftEntry set.')
+        )
+      end
+
+      it 'returns nil if file specified by id can not be found' do
+        @entry = DraftEntry.new(create(:entry))
+
+        result = helper.find_file_in_entry(ImageFile, 1)
+        expect(result).to be_nil
+      end
+
+      it 'returns nil if the file with the specified id is not used by the entry' do
+        @entry = DraftEntry.new(create(:entry))
+        image_file = create(:image_file)
+
+        result = helper.find_file_in_entry(ImageFile, image_file.id)
+        expect(result).to be_nil
+      end
+
+      context 'draft' do
+        it 'finds a file specified by id within the revisions usage scope' do
+          entry = create(:entry)
+          revision = entry.draft
+          image_file = create(:image_file)
+          create(:file_usage, revision: revision, file: image_file)
+          @entry = DraftEntry.new(entry)
+
+          result = helper.find_file_in_entry(ImageFile, image_file.id)
+          expect(result).to eq(image_file)
+        end
+      end
+
+      context 'published entry' do
+        it 'finds a file specified by id within the revisions usage scope' do
+          entry = create(:entry)
+          revision = create(:revision, :published, entry: entry)
+          image_file = create(:image_file)
+          create(:file_usage, revision: revision, file: image_file)
+          @entry = PublishedEntry.new(entry)
+
+          result = helper.find_file_in_entry(ImageFile, image_file.id)
+          expect(result).to eq(image_file)
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/pageflow/social_share_helper_spec.rb
+++ b/spec/helpers/pageflow/social_share_helper_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require 'pageflow/revision_file_test_helper'
+require 'shared_contexts/usage_agnostic_file_association'
 
 module Pageflow
   describe SocialShareHelper do
-    include RevisionFileTestHelper
+    include_context 'usage agnostic file association'
 
     describe '#social_share_entry_url' do
       it 'returns share_url if present' do

--- a/spec/helpers/pageflow/video_files_helper_spec.rb
+++ b/spec/helpers/pageflow/video_files_helper_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
+require 'pageflow/revision_file_test_helper'
 
 module Pageflow
   describe VideoFilesHelper do
+    include RevisionFileTestHelper
+
     describe '#mobile_poster_image_div' do
       it 'has default css classes' do
         html = helper.mobile_poster_image_div
@@ -82,7 +85,10 @@ module Pageflow
       context 'with separate poster image' do
         it 'includes the poster image url' do
           video_file = create(:video_file)
+          entry_has_file(video_file)
+
           poster_image = create(:image_file)
+          entry_has_file(poster_image)
 
           html = helper.poster_image_tag(video_file.id, poster_image.id)
 
@@ -94,8 +100,9 @@ module Pageflow
       context 'with unknown poster image id' do
         it 'includes the video file poster url' do
           video_file = create(:video_file)
+          entry_has_file(video_file)
 
-          html = helper.poster_image_tag(video_file.id, 'unknown')
+          html = helper.poster_image_tag(video_file.id, nil)
 
           expect(html).to include(video_file.poster.url(:medium))
           expect(html).to include(video_file.poster.url(:print))
@@ -157,6 +164,7 @@ module Pageflow
       it 'sets data-poster and data-large-poster attribute by custom poster image' do
         video_file = build(:video_file)
         image_file = create(:image_file)
+        entry_has_file(image_file)
 
         html = helper.video_file_video_tag(video_file, poster_image_id: image_file.id)
 
@@ -167,6 +175,7 @@ module Pageflow
       it 'sets data-mobile-poster and data-mobile-large-poster attribute by custom mobile image' do
         video_file = build(:video_file)
         image_file = create(:image_file)
+        entry_has_file(image_file)
 
         html = helper.video_file_video_tag(video_file, mobile_poster_image_id: image_file.id)
 
@@ -186,6 +195,7 @@ module Pageflow
     describe '#video_file_script_tag' do
       it 'renders script tag containing video tag html' do
         video_file = create(:video_file)
+        entry_has_file(video_file)
 
         html = helper.video_file_script_tag(video_file.id)
 
@@ -194,6 +204,7 @@ module Pageflow
 
       it 'sets data-template attribute' do
         video_file = create(:video_file)
+        entry_has_file(video_file)
 
         html = helper.video_file_script_tag(video_file.id)
 
@@ -202,6 +213,7 @@ module Pageflow
 
       it 'sets width and height data attributes' do
         video_file = create(:video_file, width: 100, height: 50)
+        entry_has_file(video_file)
 
         html = helper.video_file_script_tag(video_file.id)
 
@@ -210,6 +222,7 @@ module Pageflow
 
       it 'passes options to video tag helper' do
         video_file = create(:video_file)
+        entry_has_file(video_file)
 
         html = helper.video_file_script_tag(video_file.id, controls: true)
 
@@ -221,6 +234,7 @@ module Pageflow
       it 'renders link to short video file path' do
         entry = create(:entry)
         video_file = create(:video_file, id: 100)
+        entry_has_file(video_file)
 
         expect(helper).to receive(:short_video_file_path).with(entry, video_file).and_return('/video')
 

--- a/spec/helpers/pageflow/video_files_helper_spec.rb
+++ b/spec/helpers/pageflow/video_files_helper_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require 'pageflow/revision_file_test_helper'
+require 'shared_contexts/usage_agnostic_file_association'
 
 module Pageflow
   describe VideoFilesHelper do
-    include RevisionFileTestHelper
+    include_context 'usage agnostic file association'
 
     describe '#mobile_poster_image_div' do
       it 'has default css classes' do

--- a/spec/support/pageflow/revision_file_test_helper.rb
+++ b/spec/support/pageflow/revision_file_test_helper.rb
@@ -1,7 +1,0 @@
-module Pageflow
-  module RevisionFileTestHelper
-    def entry_has_file(file)
-      allow(helper).to receive(:find_file_in_entry).with(file.class, file.id).and_return(file)
-    end
-  end
-end

--- a/spec/support/pageflow/revision_file_test_helper.rb
+++ b/spec/support/pageflow/revision_file_test_helper.rb
@@ -1,0 +1,7 @@
+module Pageflow
+  module RevisionFileTestHelper
+    def entry_has_file(file)
+      allow(helper).to receive(:find_file_in_entry).with(file.class, file.id).and_return(file)
+    end
+  end
+end

--- a/spec/support/shared_contexts/usage_agnostic_file_association.rb
+++ b/spec/support/shared_contexts/usage_agnostic_file_association.rb
@@ -1,0 +1,8 @@
+# In helper specs that test behavior independently of
+# how a file is being found, the find_file_in_entry-call can stubbed,
+# thus eliminating the need to setup the files usage first.
+RSpec.shared_context 'usage agnostic file association' do
+  def entry_has_file(file)
+    allow(helper).to receive(:find_file_in_entry).with(file.class, file.id).and_return(file)
+  end
+end


### PR DESCRIPTION
Introduce RevisionFileHelper and migrate all existing find_by_id calls
to find_file_in_entry(file_type, file_id) calls.
Stub finding files in usage scope for helper-specs by adding RevisionFileTestHelper.
Simplify lookup by usage scope by introducing UsedFile-factory.

REDMINE-16809

REDMINE-16877