### PR TITLE
Prevent hiding links in credits menu

### DIFF
--- a/app/assets/stylesheets/pageflow/navigation_bar.scss
+++ b/app/assets/stylesheets/pageflow/navigation_bar.scss
@@ -106,7 +106,6 @@
 
   a {
     display: block;
-    @include hide-text;
 
     span {
       display: block;
@@ -134,6 +133,7 @@
   }
 
   .navigation_thumbnails a {
+    @include hide-text;
     position: relative;
     outline: none;
     direction: ltr;


### PR DESCRIPTION
Trying to hide the texts of thumbnail links in the default navigation
bar, links in the credit box got hidden as well by accident.

REDMINE-16923