### PR TITLE
Add text position center option

### DIFF
--- a/app/assets/javascripts/pageflow/editor/models/page.js
+++ b/app/assets/javascripts/pageflow/editor/models/page.js
@@ -104,7 +104,8 @@ function conditionMet(condition, configuration) {
 }
 
 pageflow.Page.linkedPagesLayouts = ['default', 'hero_top_left', 'hero_top_right'];
-pageflow.Page.textPositions = ['left', 'right'];
+pageflow.Page.textPositions = ['left', 'center', 'right'];
+pageflow.Page.textPositionsWithoutCenterOption = ['left', 'right'];
 
 pageflow.Page.scrollIndicatorModes = ['all', 'only_back', 'only_next', 'non'];
 pageflow.Page.scrollIndicatorOrientations = ['vertical', 'horizontal'];

--- a/app/assets/javascripts/pageflow/editor/views/configuration_editors/audio.js
+++ b/app/assets/javascripts/pageflow/editor/views/configuration_editors/audio.js
@@ -1,7 +1,7 @@
 pageflow.ConfigurationEditorView.register('audio', {
   configure: function() {
     this.tab('general', function() {
-      this.group('general');
+      this.group('general', {supportsTextPositionCenter: true});
 
       this.input('additional_title', pageflow.TextInputView);
       this.input('additional_description', pageflow.TextAreaInputView, {size: 'short'});

--- a/app/assets/javascripts/pageflow/editor/views/configuration_editors/background_image.js
+++ b/app/assets/javascripts/pageflow/editor/views/configuration_editors/background_image.js
@@ -1,7 +1,7 @@
 pageflow.ConfigurationEditorView.register('background_image', {
   configure: function() {
     this.tab('general', function() {
-      this.group('general');
+      this.group('general', {supportsTextPositionCenter: true});
     });
 
     this.tab('files', function() {

--- a/app/assets/javascripts/pageflow/editor/views/configuration_editors/groups/general.js
+++ b/app/assets/javascripts/pageflow/editor/views/configuration_editors/groups/general.js
@@ -1,4 +1,4 @@
-pageflow.ConfigurationEditorTabView.groups.define('general', function() {
+pageflow.ConfigurationEditorTabView.groups.define('general', function(options) {
   this.input('title', pageflow.TextInputView, {required: true, maxLength: 5000});
   this.input('hide_title', pageflow.CheckBoxInputView);
   this.input('tagline', pageflow.TextInputView, {maxLength: 5000});
@@ -7,7 +7,11 @@ pageflow.ConfigurationEditorTabView.groups.define('general', function() {
     fragmentLinkInputView: pageflow.PageLinkInputView,
     enableLists: true
   });
-  this.input('text_position', pageflow.SelectInputView, {values: pageflow.Page.textPositions});
+  this.input('text_position', pageflow.SelectInputView, {
+    values: options.supportsTextPositionCenter ?
+            pageflow.Page.textPositions :
+            pageflow.Page.textPositionsWithoutCenterOption
+  });
   this.input('gradient_opacity', pageflow.SliderInputView);
   this.input('invert', pageflow.CheckBoxInputView);
 });

--- a/app/assets/javascripts/pageflow/editor/views/configuration_editors/video.js
+++ b/app/assets/javascripts/pageflow/editor/views/configuration_editors/video.js
@@ -1,7 +1,7 @@
 pageflow.ConfigurationEditorView.register('video', {
   configure: function() {
     this.tab('general', function() {
-      this.group('general');
+      this.group('general', {supportsTextPositionCenter: true});
 
       this.input('additional_title', pageflow.TextInputView);
       this.input('additional_description', pageflow.TextAreaInputView, {size: 'short'});

--- a/app/assets/javascripts/pageflow/ui/views/inputs/select_input_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/inputs/select_input_view.js
@@ -211,8 +211,11 @@ pageflow.SelectInputView = Backbone.Marionette.ItemView.extend({
 
   load: function() {
     if (!this.isClosed) {
-      if (this.model.has(this.options.propertyName)) {
-        this.ui.select.val(this.model.get(this.options.propertyName));
+      var value = this.model.get(this.options.propertyName);
+
+      if (this.model.has(this.options.propertyName) &&
+          this.ui.select.find('option[value="' + value +'"]').length) {
+        this.ui.select.val(value);
       }
       else {
         this.ui.select.val(this.ui.select.find('option:first').val());

--- a/app/assets/stylesheets/pageflow/themes/default/page/line_lengths.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/line_lengths.scss
@@ -10,6 +10,9 @@ $page-header-title-max-width: 700px !default;
 /// Maximal width for right positioned headlines and content text.
 $page-content-position-right-max-width: 500px !default;
 
+/// Maximal width for center positioned headlines and content text.
+$page-content-position-center-max-width: $page-content-max-width !default;
+
 /// Min width the header title is supposed to have in a split layout
 /// (i.e. when the page has two columns and some kind of embed is
 /// displayed on the right) with text positioned on the left.
@@ -79,7 +82,12 @@ $page-content-width: 60% !default;
     }
   }
 
-  &.text_position_right {
+  // Not all page types support text position "center" so far. Make
+  // sure styles only apply to those that explicitly opt in by setting
+  // a class on their wrapper element.
+
+  &.text_position_right,
+  &.text_position_center .supports_text_position_center {
     .page_header-subtitle,
     .page_header-title,
     .page_header-tagline,
@@ -101,6 +109,16 @@ $page-content-width: 60% !default;
       @include mobile {
         width: 100%;
       }
+    }
+  }
+
+  &.text_position_center .supports_text_position_center {
+    .page_header-subtitle,
+    .page_header-title,
+    .page_header-tagline,
+    .paragraph {
+      @include margin-end(auto);
+      max-width: $page-content-position-center-max-width;
     }
   }
 }

--- a/app/assets/stylesheets/pageflow/themes/default/page/shadow.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/shadow.scss
@@ -11,17 +11,29 @@ $page-shadow-inverted-color: #fff !default;
     @include shadow-start($page-shadow-color);
   }
 
-  &.invert {
-    .shadow {
-      @include shadow-start($page-shadow-inverted-color);
-    }
-  }
-
   &.text_position_right .shadow {
     @include shadow-end($page-shadow-color);
   }
 
-  &.invert.text_position_right .shadow {
-    @include shadow-end($page-shadow-inverted-color);
+  // Not all page types support text position "center" so far. Make
+  // sure styles only apply to those that explicitly opt in by setting
+  // a class on their wrapper element.
+
+  &.text_position_center .supports_text_position_center .shadow {
+    background: transparentize($page-shadow-color, 0.3);
+  }
+
+  &.invert {
+    .shadow {
+      @include shadow-start($page-shadow-inverted-color);
+    }
+
+    &.text_position_right .shadow {
+      @include shadow-end($page-shadow-inverted-color);
+    }
+
+    &.text_position_center .supports_text_position_center .shadow {
+      background: transparentize($page-shadow-inverted-color, 0.3);
+    }
   }
 }

--- a/config/locales/new/text_position_center.de.yml
+++ b/config/locales/new/text_position_center.de.yml
@@ -1,0 +1,6 @@
+de:
+  activerecord:
+    values:
+      pageflow/page:
+        text_position:
+          center: Mittig

--- a/config/locales/new/text_position_center.en.yml
+++ b/config/locales/new/text_position_center.en.yml
@@ -1,0 +1,6 @@
+en:
+  activerecord:
+    values:
+      pageflow/page:
+        text_position:
+          center: Center

--- a/node_package/src/builtInPageTypes/audio.jsx
+++ b/node_package/src/builtInPageTypes/audio.jsx
@@ -22,7 +22,7 @@ function AudioPage(props) {
   const playerControlsVariant = props.page.audioPlayerControlsVariant;
 
   return (
-    <MediaPage className="audio_page"
+    <MediaPage className="audio_page supports_text_position_center"
                page={props.page}
                file={props.audioFile}
                playerState={props.playerState}

--- a/node_package/src/builtInPageTypes/plain.jsx
+++ b/node_package/src/builtInPageTypes/plain.jsx
@@ -21,7 +21,7 @@ function PlainPage(props) {
   const page = props.page;
 
   return (
-    <PageWrapper>
+    <PageWrapper className="supports_text_position_center">
       <PageBackground page={page} />
 
       <PageForeground>

--- a/node_package/src/builtInPageTypes/video.jsx
+++ b/node_package/src/builtInPageTypes/video.jsx
@@ -19,7 +19,7 @@ const qualities = ['auto', '4k', 'fullhd', 'medium'];
 
 function VideoPage(props) {
   return (
-    <MediaPage className="video_page"
+    <MediaPage className="video_page supports_text_position_center"
                page={props.page}
                file={props.videoFile}
                qualities={qualities}


### PR DESCRIPTION
Page types can now opt in to a new text position variant called
"center" by passing the `supportsTextPositionCenter` option to the
`general` configuration editor inputs group and setting the
`supports_text_position_center` class on their wrapper element.

Text stays left aligned but is moved to the center of the page. The
shadow turns into a transparent single-color overlay.

So far only the built in page types support this.

Adapt select input view to display the default option if the current
value is not among the options. This ensures that the drop down
displays "Left" even if "Center" has been selected before changing the
page type.

REDMINE-16909