### PR TITLE
Add theme option for alternative content link icon

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/anchors.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/anchors.scss
@@ -2,6 +2,8 @@
 /// color by default.
 $anchor-icon-color: null !default;
 
+$anchor-external-links-icon: false !default;
+
 %anchor {
   @include fa-caret-right-icon;
 
@@ -30,5 +32,17 @@ $anchor-icon-color: null !default;
     width: 10px;
     height: 12px;
     color: $anchor-icon-color;
+  }
+
+  @if $anchor-external-links-icon {
+    &[target="_blank"] {
+      @include fa-external-link-icon;
+
+      &:before {
+        width: 18px;
+        font-size: 12px;
+        font-weight: bold;
+      }
+    }
   }
 }


### PR DESCRIPTION
Allow displaying an external link icon for content text links that
open in a new tab.

REDMINE-16909