### PR TITLE
Remove margin right of links in page text

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/default/page/anchors.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/anchors.scss
@@ -16,6 +16,7 @@ $page-anchor-typography: () !default;
     @extend %anchor;
     color: $page-anchor-color;
     pointer-events: all;
+    margin-right: 0;
     @include typography($page-anchor-typography)
   }
 


### PR DESCRIPTION
Prevent rendering a space between a link and a following comma etc.

REDMINE-16909