### PR TITLE
Structured data changes

### DIFF
--- a/app/helpers/pageflow/entry_json_seed_helper.rb
+++ b/app/helpers/pageflow/entry_json_seed_helper.rb
@@ -15,7 +15,7 @@ module Pageflow
       {
         title: entry.title,
         slug: entry.slug,
-        published_at: entry.published_at.try(:iso8601, 0)
+        published_at: entry.published_at.try(:utc).try(:iso8601, 0)
       }
     end
 

--- a/app/views/pageflow/audio_files/_audio_file.json.jbuilder
+++ b/app/views/pageflow/audio_files/_audio_file.json.jbuilder
@@ -1,2 +1,2 @@
 json.call(audio_file, :duration_in_ms)
-json.created_at audio_file.created_at.try(:iso8601, 0)
+json.created_at audio_file.created_at.try(:utc).try(:iso8601, 0)

--- a/app/views/pageflow/image_files/_image_file.json.jbuilder
+++ b/app/views/pageflow/image_files/_image_file.json.jbuilder
@@ -1,2 +1,2 @@
 json.call(image_file, :width, :height)
-json.created_at image_file.created_at.try(:iso8601, 0)
+json.created_at image_file.created_at.try(:utc).try(:iso8601, 0)

--- a/app/views/pageflow/structured_data/_entry.json.jbuilder
+++ b/app/views/pageflow/structured_data/_entry.json.jbuilder
@@ -4,21 +4,22 @@ json.set! '@context', 'http://schema.org'
 json.set! '@type', 'Article'
 
 json.headline pretty_entry_title(entry)
+json.url structured_data_normalize_protocol(social_share_entry_url(entry))
 json.description social_share_entry_description(entry)
 
-json.keywords(meta_data[:keywords]) if meta_data[:keywords].present?
+json.keywords(meta_data[:keywords].split(',').map(&:squish)) if meta_data[:keywords].present?
 
 if meta_data[:author].present?
   json.author do
     json.set! '@type', 'Organization'
-    json.name meta_data[:author]
+    json.name meta_data[:author].split(',').map(&:squish)
   end
 end
 
 if meta_data[:publisher].present?
   json.publisher do
     json.set! '@type', 'Organization'
-    json.name meta_data[:publisher]
+    json.name meta_data[:publisher].split(',').map(&:squish)
     json.logo do
       json.set! '@type', 'ImageObject'
       json.url structured_data_normalize_protocol(asset_url(entry.theme.print_logo_path))
@@ -26,8 +27,10 @@ if meta_data[:publisher].present?
   end
 end
 
-json.date_published entry.first_published_at.try(:iso8601, 0)
-json.date_modified entry.published_at.try(:iso8601, 0)
+json.date_published entry.first_published_at.try(:utc).try(:iso8601, 0)
+json.date_modified entry.published_at.try(:utc).try(:iso8601, 0)
+
+json.article_section 'longform'
 
 json.main_entity_of_page do
   json.set! '@type', 'WebPage'
@@ -43,4 +46,8 @@ if thumbnail_file.present?
     json.width 560
     json.height 315
   end
+
+  json.thumbnail_url structured_data_normalize_protocol(
+    thumbnail_file.thumbnail_url(:thumbnail_large)
+  )
 end

--- a/app/views/pageflow/video_files/_video_file.json.jbuilder
+++ b/app/views/pageflow/video_files/_video_file.json.jbuilder
@@ -1,3 +1,3 @@
 json.call(video_file, :width, :height, :duration_in_ms)
-json.created_at video_file.created_at.try(:iso8601, 0)
+json.created_at video_file.created_at.try(:utc).try(:iso8601, 0)
 json.variants video_file.present_outputs + [:poster_medium, :poster_large, :poster_ultra, :print]

--- a/spec/helpers/pageflow/structured_data_helper_spec.rb
+++ b/spec/helpers/pageflow/structured_data_helper_spec.rb
@@ -25,22 +25,24 @@ module Pageflow
       expect(html).to have_json_ld('@context' => 'http://schema.org',
                                    '@type' => 'Article',
                                    'headline' => 'Some entry',
+                                   'url' => 'https://example.com',
                                    'description' => 'Summary text',
                                    'author' => {
                                      '@type' => 'Organization',
-                                     'name' => 'Some author'
+                                     'name' => ['Some author']
                                    },
                                    'publisher' => {
                                      '@type' => 'Organization',
-                                     'name' => 'Some publisher',
+                                     'name' => ['Some publisher'],
                                      'logo' => {
                                        '@type' => 'ImageObject',
                                        'url' => a_string_including('default/logo_print')
                                      }
                                    },
-                                   'keywords' => 'Some, key, words',
+                                   'keywords' => %w[Some key words],
                                    'datePublished' => first_publication_date.iso8601,
                                    'dateModified' => last_publication_date.iso8601,
+                                   'articleSection' => 'longform',
                                    'mainEntityOfPage' => {
                                      '@type' => 'WebPage',
                                      '@id' => 'https://example.com'
@@ -51,7 +53,8 @@ module Pageflow
                                        .thumbnail_url(:thumbnail_large),
                                      'width' => 560,
                                      'height' => 315
-                                   })
+                                   },
+                                   'thumbnailUrl' => image_file.thumbnail_url(:thumbnail_large))
     end
 
     it 'skips metadata if not present' do
@@ -81,9 +84,27 @@ module Pageflow
 
       html = helper.structured_data_for_entry(PublishedEntry.new(entry))
 
-      expect(html).to have_json_ld('keywords' => 'some keywords',
-                                   'author' => a_hash_including('name' => 'some author'),
-                                   'publisher' => a_hash_including('name' => 'some publisher'))
+      expect(html).to have_json_ld('keywords' => ['some keywords'],
+                                   'author' => a_hash_including('name' => ['some author']),
+                                   'publisher' => a_hash_including('name' => ['some publisher']))
+    end
+
+    it 'renders authors and publishers separated by commas as individual items' do
+      entry = create(:entry,
+                     :published,
+                     published_revision_attributes: {
+                       author: 'Alice Adminson, Alina Publisha, Ed Edison',
+                       publisher: 'Alice Adminson, Alina Publisha, Ed Edison'
+                     })
+
+      html = helper.structured_data_for_entry(PublishedEntry.new(entry))
+
+      expect(html).to have_json_ld('author' => a_hash_including('name' => ['Alice Adminson',
+                                                                           'Alina Publisha',
+                                                                           'Ed Edison']),
+                                   'publisher' => a_hash_including('name' => ['Alice Adminson',
+                                                                              'Alina Publisha',
+                                                                              'Ed Edison']))
     end
 
     it 'skips image if share image not present' do
@@ -92,6 +113,14 @@ module Pageflow
       html = helper.structured_data_for_entry(PublishedEntry.new(entry))
 
       expect(html).not_to have_json_ld('image' => a_hash_including('@type' => 'ImageObject'))
+    end
+
+    it 'skips thumbnailUrl if share image not present' do
+      entry = create(:entry, :published)
+
+      html = helper.structured_data_for_entry(PublishedEntry.new(entry))
+
+      expect(html).not_to have_json_ld('thumbnailUrl' => a_string_including('image_files'))
     end
 
     it 'renders nothing if feature is disabled' do


### PR DESCRIPTION
- include url
- include articleSection "longform"
- include thumbnailUrl if thumbnail file is present
- format all dates as UTC,
- render keywords, authors and publishers separated by commas as individual items

REDMINE-16909