### PR TITLE
Support CDN that redirects to HTTPS

### DIFF
--- a/app/helpers/pageflow/social_share_helper.rb
+++ b/app/helpers/pageflow/social_share_helper.rb
@@ -72,7 +72,7 @@ module Pageflow
     end
 
     def social_share_normalize_protocol(url)
-      url.gsub(/^(\/\/|https:\/\/)/, 'http://')
+      url.gsub(%r{^//}, 'https://')
     end
 
     private

--- a/app/jobs/pageflow/poll_zencoder_job.rb
+++ b/app/jobs/pageflow/poll_zencoder_job.rb
@@ -41,8 +41,8 @@ module Pageflow
 
     def fetch_thumbnail(file)
       return unless file.respond_to?(:thumbnail)
-      file.thumbnail = URI.parse(file.zencoder_thumbnail.url(default_protocol: 'http'))
-      file.poster = URI.parse(file.zencoder_poster.url(default_protocol: 'http'))
+      file.thumbnail = URI.parse(file.zencoder_thumbnail.url(default_protocol: 'https'))
+      file.poster = URI.parse(file.zencoder_poster.url(default_protocol: 'https'))
     rescue OpenURI::HTTPError
       throw(:halt, :pending)
     end


### PR DESCRIPTION
Previously, when using protocol relative URLs for paperclip and
zencoder attachments, HTTP was used as default protocol in social
share meta tag image URLs and when downloading thumbnails and posters
generated by Zencoder.

Also HTTPS URLs were actively rewritten to HTTP due to some cargo
culted workaround for a problem where Facebook had problems with HTTPS
urls.

In both cases a redirect to HTTPS served by the CDN caused problems:

* Facebook does not appear to follow redirects and instead complains
  about invalid content type.

* `open-uri` which is used by Paperclip to perform the image download
  also does not follow redirects. Video Files stay in `encoding` state
  forever since `PollZencoderJob` assumes thumbnails are not there
  yet.

It should be safe to assume that the CDN supports HTTPS if protocol
relative URLs were configured in the first place. We therefore use
HTTPS as default protocol to solve the issue.

It will be a good idea for the host application to use HTTPS
protocols instead of protocol relative URLs to prevent extra redirects,
but still this change ensures Pageflow at least works in this case.

There is a third place that supplies HTTP as default protocol: URLs in
SMIL files used to have Akamai generate HLS files (see
`ZencoderVideoOutputDefinition`). Since the known Akamai setups using
this option do not redirect to HTTPS, the default protocol was left
unchanged to prevent regressions.

REDMINE-16967