### PR TITLE
Add failed? method to file models

### DIFF
--- a/app/models/concerns/pageflow/hosted_file.rb
+++ b/app/models/concerns/pageflow/hosted_file.rb
@@ -66,6 +66,10 @@ module Pageflow
       attachment.present?
     end
 
+    def failed?
+      uploading_failed?
+    end
+
     def basename
       File.basename(attachment.original_filename, '.*')
     end

--- a/app/state_machines/pageflow/encoded_file_state_machine.rb
+++ b/app/state_machines/pageflow/encoded_file_state_machine.rb
@@ -78,5 +78,11 @@ module Pageflow
     def ready?
       encoded?
     end
+
+    def failed?
+      super ||
+        fetching_meta_data_failed? ||
+        encoding_failed?
+    end
   end
 end

--- a/app/state_machines/pageflow/processed_file_state_machine.rb
+++ b/app/state_machines/pageflow/processed_file_state_machine.rb
@@ -34,5 +34,9 @@ module Pageflow
     def ready?
       processed?
     end
+
+    def failed?
+      super || processing_failed?
+    end
   end
 end

--- a/spec/factories/audio_files.rb
+++ b/spec/factories/audio_files.rb
@@ -48,6 +48,10 @@ module Pageflow
         state { 'waiting_for_confirmation' }
       end
 
+      trait :fetching_meta_data_failed do
+        state { 'fetching_meta_data_failed' }
+      end
+
       trait :encoding_failed do
         state { 'encoding_failed' }
       end

--- a/spec/factories/image_files.rb
+++ b/spec/factories/image_files.rb
@@ -40,6 +40,10 @@ module Pageflow
         state { 'uploaded' }
       end
 
+      trait :uploading_failed do
+        state { 'uploading_failed' }
+      end
+
       trait :processing do
         state { 'processing' }
       end

--- a/spec/factories/video_files.rb
+++ b/spec/factories/video_files.rb
@@ -48,6 +48,10 @@ module Pageflow
         state { 'waiting_for_confirmation' }
       end
 
+      trait :fetching_meta_data_failed do
+        state { 'fetching_meta_data_failed' }
+      end
+
       trait :encoding_failed do
         state { 'encoding_failed' }
       end

--- a/spec/models/concerns/pageflow/hosted_file_spec.rb
+++ b/spec/models/concerns/pageflow/hosted_file_spec.rb
@@ -48,13 +48,33 @@ module Pageflow
         end
       end
     end
-  end
 
-  describe 'basename' do
-    it 'returns the original file name without extention' do
-      hosted_file = create(:hosted_file, file_name: 'video.mp4')
+    describe 'basename' do
+      it 'returns the original file name without extention' do
+        hosted_file = create(:hosted_file, file_name: 'video.mp4')
 
-      expect(hosted_file.basename).to eq('video')
+        expect(hosted_file.basename).to eq('video')
+      end
+    end
+
+    describe '#failed?' do
+      it 'returns false if file is uploading' do
+        hosted_file = build(:hosted_file, :uploading)
+
+        expect(hosted_file).not_to be_failed
+      end
+
+      it 'returns false if file is uploaded' do
+        hosted_file = build(:hosted_file, :uploaded)
+
+        expect(hosted_file).not_to be_failed
+      end
+
+      it 'returns true if upload failed' do
+        hosted_file = build(:hosted_file, :uploading_failed)
+
+        expect(hosted_file).to be_failed
+      end
     end
   end
 end

--- a/spec/state_machines/pageflow/encoded_file_state_machine_examples.rb
+++ b/spec/state_machines/pageflow/encoded_file_state_machine_examples.rb
@@ -205,5 +205,37 @@ shared_examples 'encoded file state machine' do |model|
         expect(file).not_to be_retryable
       end
     end
+
+    describe '#failed?' do
+      it 'returns false if file is uploading' do
+        file = build(model, :uploading)
+
+        expect(file).not_to be_failed
+      end
+
+      it 'returns false if file is encoded' do
+        file = build(model, :encoded)
+
+        expect(file).not_to be_failed
+      end
+
+      it 'returns true if upload failed' do
+        file = build(model, :uploading_failed)
+
+        expect(file).to be_failed
+      end
+
+      it 'returns true if fetching metadata failed' do
+        file = build(model, :fetching_meta_data_failed)
+
+        expect(file).to be_failed
+      end
+
+      it 'returns true if encoding failed' do
+        file = build(model, :encoding_failed)
+
+        expect(file).to be_failed
+      end
+    end
   end
 end

--- a/spec/state_machines/pageflow/processed_file_state_machine_spec.rb
+++ b/spec/state_machines/pageflow/processed_file_state_machine_spec.rb
@@ -93,5 +93,31 @@ module Pageflow
         expect(file).not_to be_retryable
       end
     end
+
+    describe '#failed?' do
+      it 'returns false if file is uploading' do
+        image_file = build(:image_file, :uploading)
+
+        expect(image_file).not_to be_failed
+      end
+
+      it 'returns false if file is processed' do
+        image_file = build(:image_file, :processed)
+
+        expect(image_file).not_to be_failed
+      end
+
+      it 'returns true if upload failed' do
+        image_file = build(:image_file, :uploading_failed)
+
+        expect(image_file).to be_failed
+      end
+
+      it 'returns true if processing failed' do
+        image_file = build(:image_file, :processing_failed)
+
+        expect(image_file).to be_failed
+      end
+    end
   end
 end


### PR DESCRIPTION
Provide a generic way to find out if the state machine of a file is in
a failed state. This can be used to prevent waiting forever when
waiting for a file to get ready.

REDMINE-16880