### PR TITLE
Facebook open graph image share changes

### DIFF
--- a/app/helpers/pageflow/social_share_helper.rb
+++ b/app/helpers/pageflow/social_share_helper.rb
@@ -54,24 +54,26 @@ module Pageflow
     end
 
     def social_share_entry_image_tags(entry)
-      image_urls = []
+      share_images = []
       image_file = find_file_in_entry(ImageFile, entry.share_image_id)
 
       if image_file
-        image_urls << image_file.thumbnail_url(:medium)
+        image_url = image_file.thumbnail_url(:medium)
+        share_images.push(image_url: image_url, width: image_file.width, height: image_file.height)
       else
         entry.pages.each do |page|
-          if image_urls.size >= 4
-            break
-          else
-            url = page.social_share_url(:medium)
-            image_urls << url if url.present?
-            image_urls.uniq!
-          end
+          break if share_images.size >= 4
+          thumbnail_file = page_thumbnail_file(page)
+          next unless thumbnail_file.present?
+          image_url = thumbnail_file.thumbnail_url(:medium)
+          share_images.push(image_url: image_url,
+                            width: thumbnail_file.file.width,
+                            height: thumbnail_file.file.height)
+          share_images.uniq!
         end
       end
 
-      render 'pageflow/social_share/image_tags', image_urls: image_urls
+      render 'pageflow/social_share/image_tags', share_images: share_images
     end
 
     def social_share_normalize_protocol(url)

--- a/app/helpers/pageflow/social_share_helper.rb
+++ b/app/helpers/pageflow/social_share_helper.rb
@@ -64,7 +64,8 @@ module Pageflow
           if image_urls.size >= 4
             break
           else
-            image_urls << page_thumbnail_url(page, :medium)
+            url = page.social_share_url(:medium)
+            image_urls << url if url.present?
             image_urls.uniq!
           end
         end

--- a/app/models/pageflow/page.rb
+++ b/app/models/pageflow/page.rb
@@ -16,6 +16,18 @@ module Pageflow
       configuration['title'].presence || configuration['additional_title']
     end
 
+    def social_share_url(*args)
+      thumbnail_file.thumbnail_url(*args) unless thumbnail_file.blank?
+    end
+
+    def thumbnail_url(*args)
+      thumbnail_file.thumbnail_url(*args)
+    end
+
+    def thumbnail_file
+      ThumbnailFileResolver.new(page_type.thumbnail_candidates, configuration).find
+    end
+
     def page_type
       Pageflow.config.page_types.find_by_name!(template)
     end

--- a/app/models/pageflow/page.rb
+++ b/app/models/pageflow/page.rb
@@ -16,18 +16,6 @@ module Pageflow
       configuration['title'].presence || configuration['additional_title']
     end
 
-    def social_share_url(*args)
-      thumbnail_file.thumbnail_url(*args) unless thumbnail_file.blank?
-    end
-
-    def thumbnail_url(*args)
-      thumbnail_file.thumbnail_url(*args)
-    end
-
-    def thumbnail_file
-      ThumbnailFileResolver.new(page_type.thumbnail_candidates, configuration).find
-    end
-
     def page_type
       Pageflow.config.page_types.find_by_name!(template)
     end

--- a/app/views/pageflow/social_share/_image_tags.html.erb
+++ b/app/views/pageflow/social_share/_image_tags.html.erb
@@ -1,9 +1,9 @@
-<% image_urls.each do |image_url| %>
-  <%= tag :meta, property: "og:image", content: social_share_normalize_protocol(image_url) %>
-  <%= tag :meta, property: "og:image:width", content: 1200 %>
-  <%= tag :meta, property: "og:image:height", content: 630 %>
+<% share_images.each do |share_image| %>
+  <%= tag :meta, property: "og:image", content: social_share_normalize_protocol(share_image[:image_url]) %>
+  <%= tag :meta, property: "og:image:width", content: share_image[:width] %>
+  <%= tag :meta, property: "og:image:height", content: share_image[:height] %>
 <% end %>
 
-<% if image_urls.first.present? %>
-  <%= tag :meta, name: "twitter:image:src", content: social_share_normalize_protocol(image_urls.first) %>
+<% if share_images.first.present? %>
+  <%= tag :meta, name: "twitter:image:src", content: social_share_normalize_protocol(share_images.first[:image_url]) %>
 <% end %>

--- a/app/views/pageflow/social_share/_image_tags.html.erb
+++ b/app/views/pageflow/social_share/_image_tags.html.erb
@@ -1,5 +1,7 @@
 <% image_urls.each do |image_url| %>
   <%= tag :meta, property: "og:image", content: social_share_normalize_protocol(image_url) %>
+  <%= tag :meta, property: "og:image:width", content: 1200 %>
+  <%= tag :meta, property: "og:image:height", content: 630 %>
 <% end %>
 
 <% if image_urls.first.present? %>

--- a/spec/factories/image_files.rb
+++ b/spec/factories/image_files.rb
@@ -3,7 +3,6 @@ module Pageflow
     factory :image_file, :class => ImageFile do
       entry
       uploader { create(:user) }
-
       attachment { File.open(Engine.root.join('spec', 'fixtures', 'image.jpg')) }
       state { 'processed' }
 

--- a/spec/helpers/pageflow/social_share_helper_spec.rb
+++ b/spec/helpers/pageflow/social_share_helper_spec.rb
@@ -135,20 +135,23 @@ module Pageflow
 
       it 'renders share image meta tags if share image was chosen' do
         entry = PublishedEntry.new(create(:entry, :published))
-        image_file = create_used_file(:image_file, entry: entry)
+        image_file = create_used_file(:image_file, entry: entry, width: 1200, height: 600)
         entry.revision.share_image_id = image_file.perma_id
 
         html = helper.social_share_entry_image_tags(entry)
 
         expect(html).to have_css("meta[content=\"#{image_file.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
+        expect(html).to have_css("meta[content=\"#{image_file.width}\"][property=\"og:image:width\"]", visible: false, count: 1)
+        expect(html).to have_css("meta[content=\"#{image_file.height}\"][property=\"og:image:height\"]", visible: false, count: 1)
+
         expect(html).to have_css("meta[content=\"#{image_file.thumbnail_url(:medium)}\"][name=\"twitter:image:src\"]", visible: false, count: 1)
       end
 
       it 'renders up to three open graph image meta tags for page thumbnails' do
         entry = PublishedEntry.new(create(:entry, :published))
-        image_file1 = create_used_file(:image_file, entry: entry)
-        image_file2 = create_used_file(:image_file, entry: entry)
-        image_file3 = create_used_file(:image_file, entry: entry)
+        image_file1 = create_used_file(:image_file, entry: entry, width: 1200, height: 600)
+        image_file2 = create_used_file(:image_file, entry: entry, width: 1200, height: 600)
+        image_file3 = create_used_file(:image_file, entry: entry, width: 600, height: 300)
         storyline = create(:storyline, revision: entry.revision)
         chapter = create(:chapter, storyline: storyline)
         create(:page, configuration: {thumbnail_image_id: image_file1.perma_id}, chapter: chapter)
@@ -160,7 +163,14 @@ module Pageflow
         expect(html).to have_css("meta[content=\"#{image_file1.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
         expect(html).to have_css("meta[content=\"#{image_file2.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
         expect(html).to have_css("meta[content=\"#{image_file3.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
+        expect(html).to have_css("meta[content=\"#{image_file1.width}\"][property=\"og:image:width\"]", visible: false, count: 2)
+        expect(html).to have_css("meta[content=\"#{image_file1.height}\"][property=\"og:image:height\"]", visible: false, count: 2)
+        expect(html).to have_css("meta[content=\"#{image_file3.width}\"][property=\"og:image:width\"]", visible: false, count: 1)
+        expect(html).to have_css("meta[content=\"#{image_file3.height}\"][property=\"og:image:height\"]", visible: false, count: 1)
+
         expect(html).to have_css('meta[property="og:image"]', visible: false, maximum: 3)
+        expect(html).to have_css('meta[property="og:image:width"]', visible: false, maximum: 3)
+        expect(html).to have_css('meta[property="og:image:height"]', visible: false, maximum: 3)
       end
 
       it 'renders one twitter image meta tag with first page thumbnail' do


### PR DESCRIPTION
REDMINE-16972
+added og:image:height and width meta properties.
-removed placeholder images for social share