### PR TITLE
Update Twitter share URL (14.x backport)

### DIFF
--- a/app/helpers/pageflow/social_share_links_helper.rb
+++ b/app/helpers/pageflow/social_share_links_helper.rb
@@ -8,7 +8,7 @@ module Pageflow
       google: 'https://plus.google.com/share?url=%{url}',
       linked_in: 'https://www.linkedin.com/shareArticle?mini=true&url=%{url}',
       telegram: 'tg://msg?text=%{url}',
-      twitter: 'http://twitter.com/home?status=%{url}',
+      twitter: 'https://twitter.com/intent/tweet?url=%{url}',
       whats_app: 'WhatsApp://send?text=%{url}'
     }.freeze
 


### PR DESCRIPTION
Backport of #1202

Current URL only redirects to user's home page. It seems Twitter
currently offers a Web Intent API for our use case. See [1].

REDMINE-16999

[1] https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/guides/web-intent.html