### PR TITLE
Drop pageflow_accounts_themes table

### DIFF
--- a/db/migrate/20190820152900_drop_accounts_themes.rb
+++ b/db/migrate/20190820152900_drop_accounts_themes.rb
@@ -1,0 +1,8 @@
+class DropAccountsThemes < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :pageflow_accounts_themes, id: false, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+      t.integer 'account_id'
+      t.integer 'theme_name'
+    end
+  end
+end


### PR DESCRIPTION
Since d4073c17, Theme is a Ruby object instead of an ActiveRecord
model. This table is unused since then and can thus be dropped.

REDMINE-17005