### PR TITLE
Make tabs in mobile editor touchable

### DIFF
--- a/app/assets/javascripts/pageflow/ui/views/tabs_view.js
+++ b/app/assets/javascripts/pageflow/ui/views/tabs_view.js
@@ -64,7 +64,8 @@ pageflow.TabsView = Backbone.Marionette.Layout.extend({
       scrollX: true,
       scrollY: false,
       bounce: false,
-      mouseWheel: true
+      mouseWheel: true,
+      preventDefault: false,
     });
 
     this.changeTab(this.defaultTab());


### PR DESCRIPTION
It seems that on mobile devices, iScroll's preventDefault setting
prevents tab click and touch events from having an effect, rendering
tabs unreachable. Changing iScroll's setting fixes this.

REDMINE-17050