### PR TITLE
Revert "Facebook open graph image share changes"

### DIFF
--- a/app/helpers/pageflow/social_share_helper.rb
+++ b/app/helpers/pageflow/social_share_helper.rb
@@ -54,26 +54,23 @@ module Pageflow
     end
 
     def social_share_entry_image_tags(entry)
-      share_images = []
+      image_urls = []
       image_file = find_file_in_entry(ImageFile, entry.share_image_id)
 
       if image_file
-        image_url = image_file.thumbnail_url(:medium)
-        share_images.push(image_url: image_url, width: image_file.width, height: image_file.height)
+        image_urls << image_file.thumbnail_url(:medium)
       else
         entry.pages.each do |page|
-          break if share_images.size >= 4
-          thumbnail_file = page_thumbnail_file(page)
-          next unless thumbnail_file.present?
-          image_url = thumbnail_file.thumbnail_url(:medium)
-          share_images.push(image_url: image_url,
-                            width: thumbnail_file.file.width,
-                            height: thumbnail_file.file.height)
-          share_images.uniq!
+          if image_urls.size >= 4
+            break
+          else
+            image_urls << page_thumbnail_url(page, :medium)
+            image_urls.uniq!
+          end
         end
       end
 
-      render 'pageflow/social_share/image_tags', share_images: share_images
+      render 'pageflow/social_share/image_tags', image_urls: image_urls
     end
 
     def social_share_normalize_protocol(url)

--- a/app/views/pageflow/social_share/_image_tags.html.erb
+++ b/app/views/pageflow/social_share/_image_tags.html.erb
@@ -1,9 +1,7 @@
-<% share_images.each do |share_image| %>
-  <%= tag :meta, property: "og:image", content: social_share_normalize_protocol(share_image[:image_url]) %>
-  <%= tag :meta, property: "og:image:width", content: share_image[:width] %>
-  <%= tag :meta, property: "og:image:height", content: share_image[:height] %>
+<% image_urls.each do |image_url| %>
+  <%= tag :meta, property: "og:image", content: social_share_normalize_protocol(image_url) %>
 <% end %>
 
-<% if share_images.first.present? %>
-  <%= tag :meta, name: "twitter:image:src", content: social_share_normalize_protocol(share_images.first[:image_url]) %>
+<% if image_urls.first.present? %>
+  <%= tag :meta, name: "twitter:image:src", content: social_share_normalize_protocol(image_urls.first) %>
 <% end %>

--- a/spec/factories/image_files.rb
+++ b/spec/factories/image_files.rb
@@ -3,6 +3,7 @@ module Pageflow
     factory :image_file, :class => ImageFile do
       entry
       uploader { create(:user) }
+
       attachment { File.open(Engine.root.join('spec', 'fixtures', 'image.jpg')) }
       state { 'processed' }
 

--- a/spec/helpers/pageflow/social_share_helper_spec.rb
+++ b/spec/helpers/pageflow/social_share_helper_spec.rb
@@ -135,23 +135,20 @@ module Pageflow
 
       it 'renders share image meta tags if share image was chosen' do
         entry = PublishedEntry.new(create(:entry, :published))
-        image_file = create_used_file(:image_file, entry: entry, width: 1200, height: 600)
+        image_file = create_used_file(:image_file, entry: entry)
         entry.revision.share_image_id = image_file.perma_id
 
         html = helper.social_share_entry_image_tags(entry)
 
         expect(html).to have_css("meta[content=\"#{image_file.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
-        expect(html).to have_css("meta[content=\"#{image_file.width}\"][property=\"og:image:width\"]", visible: false, count: 1)
-        expect(html).to have_css("meta[content=\"#{image_file.height}\"][property=\"og:image:height\"]", visible: false, count: 1)
-
         expect(html).to have_css("meta[content=\"#{image_file.thumbnail_url(:medium)}\"][name=\"twitter:image:src\"]", visible: false, count: 1)
       end
 
       it 'renders up to three open graph image meta tags for page thumbnails' do
         entry = PublishedEntry.new(create(:entry, :published))
-        image_file1 = create_used_file(:image_file, entry: entry, width: 1200, height: 600)
-        image_file2 = create_used_file(:image_file, entry: entry, width: 1200, height: 600)
-        image_file3 = create_used_file(:image_file, entry: entry, width: 600, height: 300)
+        image_file1 = create_used_file(:image_file, entry: entry)
+        image_file2 = create_used_file(:image_file, entry: entry)
+        image_file3 = create_used_file(:image_file, entry: entry)
         storyline = create(:storyline, revision: entry.revision)
         chapter = create(:chapter, storyline: storyline)
         create(:page, configuration: {thumbnail_image_id: image_file1.perma_id}, chapter: chapter)
@@ -163,14 +160,7 @@ module Pageflow
         expect(html).to have_css("meta[content=\"#{image_file1.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
         expect(html).to have_css("meta[content=\"#{image_file2.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
         expect(html).to have_css("meta[content=\"#{image_file3.thumbnail_url(:medium)}\"][property=\"og:image\"]", visible: false, count: 1)
-        expect(html).to have_css("meta[content=\"#{image_file1.width}\"][property=\"og:image:width\"]", visible: false, count: 2)
-        expect(html).to have_css("meta[content=\"#{image_file1.height}\"][property=\"og:image:height\"]", visible: false, count: 2)
-        expect(html).to have_css("meta[content=\"#{image_file3.width}\"][property=\"og:image:width\"]", visible: false, count: 1)
-        expect(html).to have_css("meta[content=\"#{image_file3.height}\"][property=\"og:image:height\"]", visible: false, count: 1)
-
         expect(html).to have_css('meta[property="og:image"]', visible: false, maximum: 3)
-        expect(html).to have_css('meta[property="og:image:width"]', visible: false, maximum: 3)
-        expect(html).to have_css('meta[property="og:image:height"]', visible: false, maximum: 3)
       end
 
       it 'renders one twitter image meta tag with first page thumbnail' do


### PR DESCRIPTION
Reverts codevise/pageflow#1193

If one of the first pages is a `pageflow-panorama` page, `thumbnail_file.file` is a [`Pageflow::Panorama::Package`](https://github.com/codevise/pageflow-panorama/blob/master/app/models/pageflow/panorama/package.rb) which does not implement `width`/`height`. 

The previous implementation (restored by this PR) already had the problem that `Pageflow::Panorama::Package.thumbnail_url` does not support the `:medium` style (only [the default thumbnail styles](https://github.com/codevise/pageflow/blob/337ebfb6815279c921a79f9ac37070f1f4b21969/lib/pageflow/configuration/defaults.rb#L22)), but this just lead to placeholder URLs instead of causing exceptions.

REDMINE-16972