### PR TITLE
Restrict sprockets as runtime depenency

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -88,6 +88,10 @@ Gem::Specification.new do |s|
   # Scss compiler
   s.add_dependency 'sass', '~> 3.4'
 
+  # Sprockets 4 does not support procs in config.assets.precompile
+  # which we currently depend on in pageflow/engine.rb
+  s.add_dependency 'sprockets', '< 4'
+
   # Using translations from rails locales in javascript code.
   s.add_dependency 'i18n-js', '~> 2.1'
 
@@ -123,10 +127,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ar_after_transaction', '~> 0.5.0'
   s.add_development_dependency 'redis', '~> 3.0'
   s.add_development_dependency 'redis-namespace', '~> 1.5'
-
-  # Sprockets 4 does not support procs in config.assets.precompile
-  # which we currently depend on in pageflow/engine.rb
-  s.add_development_dependency 'sprockets', '< 4'
 
   # Faster scss compilation
   s.add_development_dependency 'sassc-rails', '~> 1.0'


### PR DESCRIPTION
In #1217 it was added as development dependency by accident.

REDMINE-17098