### PR TITLE
Add sassc-rails as development dependency

### DIFF
--- a/spec/support/pageflow-support.gemspec
+++ b/spec/support/pageflow-support.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'redis', '~> 3.0'
   s.add_runtime_dependency 'redis-namespace', '~> 1.5'
+
+  s.add_runtime_dependency 'sassc-rails', '~> 1.0'
 end

--- a/spec/support/pageflow/support.rb
+++ b/spec/support/pageflow/support.rb
@@ -1,4 +1,5 @@
 require 'factory_bot'
+require 'sassc-rails'
 
 require 'pageflow/dummy'
 require 'pageflow/dom'


### PR DESCRIPTION
Normally the host application needs to either depend on either
`sassc-rails` or `sass-rails`. Ensure gem is present in plugin test
suites.