### PR TITLE
Touch revision on file or usage change

### DIFF
--- a/app/models/concerns/pageflow/reusable_file.rb
+++ b/app/models/concerns/pageflow/reusable_file.rb
@@ -13,6 +13,10 @@ module Pageflow
       has_many :using_accounts, :through => :using_entries, :source => :account
 
       validate :parent_allows_type_for_nesting, :parent_belongs_to_same_entry
+
+      after_save do
+        usages.each(&:touch) if ready?
+      end
     end
 
     def parent_allows_type_for_nesting

--- a/lib/pageflow/revision_component.rb
+++ b/lib/pageflow/revision_component.rb
@@ -8,7 +8,7 @@ module Pageflow
     extend ActiveSupport::Concern
 
     included do
-      belongs_to :revision, class_name: 'Pageflow::Revision'
+      belongs_to :revision, class_name: 'Pageflow::Revision', touch: true
       before_save :ensure_perma_id
     end
 

--- a/spec/pageflow/revision_component_spec.rb
+++ b/spec/pageflow/revision_component_spec.rb
@@ -2,6 +2,16 @@ require 'spec_helper'
 
 module Pageflow
   describe RevisionComponent do
+    it 'touches revision on create' do
+      revision = create(:revision)
+
+      expect {
+        Timecop.freeze(1.minute.from_now) do
+          TestRevisionComponent.create!(revision: revision)
+        end
+      }.to(change { revision.reload.updated_at })
+    end
+
     describe '#perma_id' do
       it 'is set on creation' do
         revision = create(:revision)


### PR DESCRIPTION
Ensure caching of generated CSS is busted when:

* A usage is edited
* A file becomes ready

REDMINE-16809