### PR TITLE
Prevent perma_id clashes for concurrently created revision components

### DIFF
--- a/lib/pageflow/engine.rb
+++ b/lib/pageflow/engine.rb
@@ -10,6 +10,7 @@ require 'jbuilder'
 require 'htmlentities'
 require 'kramdown'
 require 'react-rails'
+require 'with_advisory_lock'
 
 require 'active_admin'
 require 'activeadmin-searchable_select'

--- a/lib/pageflow/revision_component.rb
+++ b/lib/pageflow/revision_component.rb
@@ -7,6 +7,10 @@ module Pageflow
   module RevisionComponent
     extend ActiveSupport::Concern
 
+    ADVISORY_LOCK_TIMEOUT_SECONDS = 5
+
+    class PermaIdGenerationAdvisoryLockTimeout < StandardError; end
+
     included do
       belongs_to :revision, class_name: 'Pageflow::Revision'
       before_save :ensure_perma_id
@@ -20,6 +24,35 @@ module Pageflow
 
     def ensure_perma_id
       self.perma_id ||= (self.class.maximum(:perma_id) || 0) + 1
+    end
+
+    def save(*)
+      with_advisory_lock_for_perma_id_generation! do
+        super
+      end
+    end
+
+    def save!(*)
+      with_advisory_lock_for_perma_id_generation! do
+        super
+      end
+    end
+
+    private
+
+    def with_advisory_lock_for_perma_id_generation!(&block)
+      return yield if perma_id.present?
+
+      r = with_advisory_lock_result_for_perma_id_generation(&block)
+      raise(PermaIdGenerationAdvisoryLockTimeout) unless r.lock_was_acquired?
+
+      r.result
+    end
+
+    def with_advisory_lock_result_for_perma_id_generation(&block)
+      self.class.with_advisory_lock_result("#{self.class.table_name}_perma_id",
+                                           timeout_seconds: ADVISORY_LOCK_TIMEOUT_SECONDS,
+                                           &block)
     end
 
     module ClassMethods

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -41,6 +41,9 @@ Gem::Specification.new do |s|
   # File attachments
   s.add_dependency 'paperclip', '~> 6.1'
 
+  # MySQL/Postgres advisory locks
+  s.add_dependency 'with_advisory_lock', '~> 4.6'
+
   # zencoder
   s.add_dependency 'zencoder', '~> 2.5'
 

--- a/spec/pageflow/revision_component_spec.rb
+++ b/spec/pageflow/revision_component_spec.rb
@@ -31,7 +31,7 @@ module Pageflow
       end
     end
 
-    describe '#from_perma_ids' do
+    describe '.from_perma_ids' do
       it 'returns list of RevisionComponents' do
         revision = create(:revision)
         revision_component = TestRevisionComponent.create!(revision: revision)
@@ -39,6 +39,76 @@ module Pageflow
         components = TestRevisionComponent.from_perma_ids(revision, [revision_component.perma_id])
 
         expect(components).to eq([revision_component])
+      end
+    end
+
+    describe 'creating records concurrently' do
+      # It is important to use different revisions inside threads to
+      # prevent deadlocks. Each test is wrapped in a
+      # transaction. Creating a revision creates a lock for its row.
+      # Creating a revision component tries to touch the revision. The
+      # update waits for the lock to be released, which does not
+      # happen before the test ends.
+      #
+      # See also
+      # https://dev.mysql.com/doc/refman/5.5/en/innodb-locks-set.html.
+
+      it 'does not assign duplicate perma_ids' do
+        perma_ids = Array.new(3) {
+          Thread.new do
+            revision = create(:revision)
+            TestRevisionComponent.create(revision: revision)
+          end
+        }.map(&:join).map(&:value).map(&:perma_id)
+
+        expect(perma_ids.uniq).to have(3).items
+      end
+
+      it 'acquires advisory lock to prevent perma id generation race condition' do
+        stub_const('Pageflow::RevisionComponent::ADVISORY_LOCK_TIMEOUT_SECONDS', 0)
+
+        revision = create(:revision)
+        component = TestRevisionComponent.new(revision: revision)
+
+        component.during_save_transaction do
+          Thread.new {
+            other_revision = create(:revision)
+            TestRevisionComponent.create(revision: other_revision)
+          }.join
+        end
+
+        expect {
+          component.save
+        }.to raise_error(RevisionComponent::PermaIdGenerationAdvisoryLockTimeout)
+      end
+
+      it 'does not acquire advisory lock if perma_id is already present' do
+        stub_const('Pageflow::RevisionComponent::ADVISORY_LOCK_TIMEOUT_SECONDS', 0)
+
+        revision = create(:revision)
+        component = TestRevisionComponent.new(perma_id: 5, revision: revision)
+
+        component.during_save_transaction do
+          Thread.new {
+            other_revision = create(:revision)
+            TestRevisionComponent.create(revision: other_revision)
+          }.join
+        end
+
+        expect { component.save }.not_to raise_error
+      end
+
+      it 'allows nested creates from same thread' do
+        stub_const('Pageflow::RevisionComponent::ADVISORY_LOCK_TIMEOUT_SECONDS', 0)
+        revision = create(:revision)
+
+        component = TestRevisionComponent.new(revision: revision)
+
+        component.during_save_transaction do
+          TestRevisionComponent.create(revision: revision)
+        end
+
+        expect { component.save }.not_to raise_error
       end
     end
   end

--- a/spec/support/helpers/test_revision_component.rb
+++ b/spec/support/helpers/test_revision_component.rb
@@ -3,6 +3,14 @@ module Pageflow
     include RevisionComponent
     self.table_name = :test_revision_components
 
+    before_save do
+      @during_save_transaction_block&.call
+    end
+
+    def during_save_transaction(&block)
+      @during_save_transaction_block = block
+    end
+
     def self.register(config)
       page_type = TestPageType.new(name: :test,
                                    revision_components: [TestRevisionComponent])


### PR DESCRIPTION
Use advisory lock to ensure only a single thread/passenger process
calculates the next perma_id at a time. Otherwise the same maximum
perma_id can be used to set the perma_ids of two concurrently created
components.

REDMINE-16809