### PR TITLE
Prevent further cases of perma id clashes

### DIFF
--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -47,7 +47,8 @@ module Pageflow
         f.entry = entry
       end
 
-      usage = @draft.file_usages.create(file: file, configuration: attributes[:configuration])
+      usage = @draft.file_usages.create_with_lock!(file: file,
+                                                   configuration: attributes[:configuration])
       UsedFile.new(file, usage)
     end
 

--- a/spec/models/pageflow/draft_entry_spec.rb
+++ b/spec/models/pageflow/draft_entry_spec.rb
@@ -16,6 +16,18 @@ module Pageflow
     end
 
     describe '#create_file!' do
+      it 'prevents perma_id clashes when called concurrently', multithread: true do
+        entry = DraftEntry.new(create(:entry))
+
+        perma_ids = Array.new(3) {
+          Thread.new do
+            entry.create_file!(BuiltInFileType.image, attachment: fixture_file)
+          end
+        }.map(&:join).map(&:value).map(&:perma_id)
+
+        expect(perma_ids.uniq).to have(3).items
+      end
+
       it 'creates image_file on draft' do
         entry = create(:entry)
         draft_entry = DraftEntry.new(entry)

--- a/spec/support/config/database_cleaner.rb
+++ b/spec/support/config/database_cleaner.rb
@@ -9,7 +9,11 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
-  config.before(:each, :js => true) do
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each, multithread: true) do
     DatabaseCleaner.strategy = :truncation
   end
 

--- a/spec/support/helpers/test_revision_component.rb
+++ b/spec/support/helpers/test_revision_component.rb
@@ -3,14 +3,6 @@ module Pageflow
     include RevisionComponent
     self.table_name = :test_revision_components
 
-    before_save do
-      @during_save_transaction_block&.call
-    end
-
-    def during_save_transaction(&block)
-      @during_save_transaction_block = block
-    end
-
     def self.register(config)
       page_type = TestPageType.new(name: :test,
                                    revision_components: [TestRevisionComponent])


### PR DESCRIPTION
Wrapping `RevisionComponent#save` in an advisory lock, does not
suffice for cases where the revision component is created through an
association, i.e

    revision.file_usages.create!(...)

In this case `CollectionAssociation#_create_record` [1] already starts
the transaction before the lock is required. Since the transaction is
then committed only after the advisory lock is already released, the
following race condition can occur:

    Thread 1:                       Thread 2:
    |                               |
    BEGIN                           |
    GET LOCK                        |
    SELECT MAX perma_id             |
    INSERT revision component       |
    RELEASE LOCK                    |
    |                               BEGIN
    |                               GET LOCK
    |                               SELECT MAX perma_id
    COMMIT                          |
    |                               INSERT revision component
    |                               RELEASE LOCK
    |                               COMMIT

Since the first transaction is not yet finished, the second thread
does not yet see the newly inserted perma id and calculates the same
maximum.

To ensure that the lock is acquired before the transaction starts, we
add a new class method `create_with_lock!` which then delegates to
`create!`.

For existing revision components (and models that behave like revision
components like `Page`) this race condition has never been a problem
since concurrent inserts are not that likely within a revision (and we
do not care about non-unique perma ids accross entries). We only
noticed the problem for file usages now since those are created by a
batch of requests when multiple files are uploaded at the same time.
So for now we use the new `create_with_lock!` method only in
`DraftEntry.create_file!`.

[1] https://github.com/rails/rails/blob/b9ca94caea2ca6a6cc09abaffaad67b447134079/activerecord/lib/active_record/associations/collection_association.rb#L359

REDMINE-16809