### PR TITLE
Tweak import/export zip options

### DIFF
--- a/lib/pageflow/entry_export_import/zip_archive.rb
+++ b/lib/pageflow/entry_export_import/zip_archive.rb
@@ -5,6 +5,9 @@ module Pageflow
     # Read and write files from and to zip archives
     class ZipArchive
       def initialize(file_name)
+        Zip.force_entry_names_encoding = 'UTF-8'
+        Zip.write_zip64_support = true
+
         @file = Zip::File.open(file_name, Zip::File::CREATE)
       end
 

--- a/spec/pageflow/entry_export_import/zip_archive_spec.rb
+++ b/spec/pageflow/entry_export_import/zip_archive_spec.rb
@@ -74,6 +74,19 @@ module Pageflow
           expect(archive).not_to include('not/there/file')
         end
       end
+
+      it 'can handle UTF8 character is file paths' do
+        Dir.mktmpdir do |dir|
+          archive_file_name = File.join(dir, 'archive.zip')
+          archive = ZipArchive.new(archive_file_name)
+
+          archive.add('öäü/1/file', StringIO.new('File 1'))
+          archive.close
+          archive = ZipArchive.new(archive_file_name)
+
+          expect(archive).to include('öäü/1/file')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
* Support UTF-8 characters in archive entry file names

* Use zip64 to support achrives that are larger than 4GB.

REDMINE-16810