### PR TITLE
Change revision#locale to always return string (15.0 Backport)

### DIFF
--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -124,7 +124,7 @@ module Pageflow
     end
 
     def locale
-      super.presence || I18n.default_locale
+      super.presence || I18n.default_locale.to_s
     end
 
     def pages

--- a/spec/models/pageflow/revision_spec.rb
+++ b/spec/models/pageflow/revision_spec.rb
@@ -585,10 +585,10 @@ module Pageflow
     end
 
     describe '#locale' do
-      it 'falls back to default_locale' do
+      it 'falls back to default_locale as string' do
         revision = build(:revision, locale: '')
 
-        expect(revision.locale).to eq(I18n.default_locale)
+        expect(revision.locale).to eq(I18n.default_locale.to_s)
       end
 
       it 'returns present attribute' do


### PR DESCRIPTION
Backport of #1239

Returning the locale as symbol causes errors in
Pageflow analytics interpolator