### PR TITLE
Add entry type concept

### DIFF
--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -7,6 +7,7 @@ module Pageflow
     attr_reader :entry, :draft
 
     delegate(:id, :slug,
+             :entry_type,
              :edit_lock, :account, :theming, :slug,
              :enabled_feature_names,
              :published_until, :published?,

--- a/app/models/pageflow/entry.rb
+++ b/app/models/pageflow/entry.rb
@@ -52,6 +52,10 @@ module Pageflow
       theming.copy_defaults_to(draft)
     end
 
+    def entry_type
+      Pageflow.config_for(self).entry_types.find_by_name!(type_name)
+    end
+
     def edit_lock
       super || EditLock::Null.new(self)
     end

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -7,6 +7,7 @@ module Pageflow
     attr_accessor :share_target
 
     delegate(:id, :slug,
+             :entry_type,
              :account, :theming,
              :enabled_feature_names,
              :to_model, :to_key, :persisted?,

--- a/db/migrate/20191113124400_add_type_name_to_entries.rb
+++ b/db/migrate/20191113124400_add_type_name_to_entries.rb
@@ -1,0 +1,5 @@
+class AddTypeNameToEntries < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pageflow_entries, :type_name, :string, after: 'title', default: 'paged'
+  end
+end

--- a/doc/creating_entry_types.md
+++ b/doc/creating_entry_types.md
@@ -1,0 +1,23 @@
+# Creating Entry Types
+
+Pageflow supports managing and publishing which use different
+rendering logic and editor features. Entry types are packaged as Rails
+engines just like other types of Pageflow plugins.
+
+Conventionally, new entry types are registered in a plugin class:
+
+```
+module Rainbow
+  class Plugin < Pageflow::Plugin
+    def configure(config)
+      config.entry_types.register(entry_type)
+    end
+
+    private
+
+    def entry_type
+      Pageflow::EntryType.new(name: 'rainbow', # ... further options)
+    end
+  end
+end
+```

--- a/doc/index.md
+++ b/doc/index.md
@@ -11,6 +11,7 @@ extend Pageflow.
 
 * [Understanding Plugins and Features](./understanding_plugins_and_features.md)
 * [Creating a Rails Engine for a Pageflow Plugin](creating_a_pageflow_plugin_rails_engine.md)
+* [Creating Entry Types](./creating_entry_types.md)
 * [Creating File Types](./creating_file_types.md)
 * [Creating Page types](./creating_page_types.md)
 * [Adding common page configuration tabs](./adding_common_page_configuration_tabs.md)

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -86,6 +86,11 @@ module Pageflow
     # @return [Themes]
     attr_reader :themes
 
+    # Register new types of entries.
+    # @return [EntryTypes]
+    # @since edge
+    attr_reader :entry_types
+
     # Register new types of pages.
     # @return [PageTypes]
     # @since 0.9
@@ -351,6 +356,7 @@ module Pageflow
       @hooks = Hooks.new
       @quotas = Quotas.new
       @themes = Themes.new
+      @entry_types = EntryTypes.new
       @page_types = PageTypes.new
       @file_types = FileTypes.new(page_types)
       @widget_types = WidgetTypes.new

--- a/lib/pageflow/entry_type.rb
+++ b/lib/pageflow/entry_type.rb
@@ -1,0 +1,14 @@
+module Pageflow
+  # Captures details of how to render entries of a certain type
+  #
+  # @since edge
+  class EntryType
+    # @api private
+    attr_reader :name
+
+    # @param name [String] A unique name.
+    def initialize(name:)
+      @name = name
+    end
+  end
+end

--- a/lib/pageflow/entry_types.rb
+++ b/lib/pageflow/entry_types.rb
@@ -1,0 +1,25 @@
+module Pageflow
+  # A collection of {EntryType} objects.
+  #
+  # @since edge
+  class EntryTypes
+    # @api private
+    def initialize
+      @entry_types_by_name = {}
+    end
+
+    # Register an entry type.
+    #
+    # @param entry_type [EntryType]
+    def register(entry_type)
+      @entry_types_by_name[entry_type.name] = entry_type
+    end
+
+    # @api private
+    def find_by_name!(name)
+      @entry_types_by_name.fetch(name) do
+        raise "Unknown entry type with name #{name}."
+      end
+    end
+  end
+end

--- a/spec/models/pageflow/entry_spec.rb
+++ b/spec/models/pageflow/entry_spec.rb
@@ -60,6 +60,18 @@ module Pageflow
       end
     end
 
+    describe '#entry_type' do
+      it 'returns entry type' do
+        pageflow_configure do |config|
+          TestEntryType.register(config, name: 'test')
+        end
+
+        entry = create(:entry, type_name: 'test')
+
+        expect(entry.entry_type.name).to eq('test')
+      end
+    end
+
     context 'validation' do
       it 'ensures folder belongs to same account' do
         folder = build(:folder, account: build_stubbed(:account))

--- a/spec/pageflow/entry_types_spec.rb
+++ b/spec/pageflow/entry_types_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+module Pageflow
+  describe EntryTypes do
+    describe '#find_by_name!' do
+      it 'returns entry type with given name' do
+        entry_types = EntryTypes.new
+        entry_type = EntryType.new(name: 'test')
+
+        entry_types.register(entry_type)
+        result = entry_types.find_by_name!('test')
+
+        expect(result).to be(entry_type)
+      end
+
+      it 'raises helpful error if entry type is not found' do
+        entry_types = EntryTypes.new
+
+        expect {
+          entry_types.find_by_name!('not_there')
+        }.to raise_error(/Unknown entry type/)
+      end
+    end
+  end
+end

--- a/spec/support/helpers/test_entry_type.rb
+++ b/spec/support/helpers/test_entry_type.rb
@@ -1,0 +1,8 @@
+module Pageflow
+  module TestEntryType
+    def self.register(config, options = {})
+      config.entry_types.register(EntryType.new(name: 'test',
+                                                **options))
+    end
+  end
+end


### PR DESCRIPTION
Allow registering entry types in the Pageflow configuration. Add a
`type_name` attribute to `Entry` which can be used to look up the
corresponding `EntryType` object.

REDMINE-17208, REDMINE-17213