### PR TITLE
Decouple revision components from page types

### DIFF
--- a/config/initializers/revision_components.rb
+++ b/config/initializers/revision_components.rb
@@ -1,0 +1,7 @@
+Pageflow.after_configure do |config|
+  config.page_types.each do |page_type|
+    page_type.revision_components.each do |component|
+      config.revision_components.register(component)
+    end
+  end
+end

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -104,6 +104,11 @@ module Pageflow
     # @return [FileTypes]
     attr_reader :file_types
 
+    # Used to register components whose current state must be
+    # persisted as part of a revision.
+    # @return [RevisionComponents]
+    attr_reader :revision_components
+
     # Used to register new types of widgets to be displayed in entries.
     # @return [WidgetTypes]
     attr_reader :widget_types
@@ -372,6 +377,7 @@ module Pageflow
       @widget_types = WidgetTypes.new
       @file_importers = FileImporters.new
       @help_entries = HelpEntries.new
+      @revision_components = RevisionComponents.new
 
       @thumbnail_styles = Defaults::THUMBNAIL_STYLES.dup
       @css_rendered_thumbnail_styles = Defaults::CSS_RENDERED_THUMBNAIL_STYLES.dup
@@ -435,10 +441,6 @@ module Pageflow
 
     def paperclip_filesystem_root=(_val)
       ActiveSupport::Deprecation.warn('Pageflow::Configuration#paperclip_filesystem_root is deprecated.', caller)
-    end
-
-    def revision_components
-      page_types.map(&:revision_components).flatten.uniq
     end
 
     # @api private

--- a/lib/pageflow/revision_components.rb
+++ b/lib/pageflow/revision_components.rb
@@ -1,0 +1,18 @@
+module Pageflow
+  class RevisionComponents
+    include Enumerable
+
+    def initialize
+      @revision_components = []
+    end
+
+    def register(revision_component)
+      @revision_components << revision_component unless
+        @revision_components.include?(revision_component)
+    end
+
+    def each(&block)
+      @revision_components.each(&block)
+    end
+  end
+end

--- a/spec/models/pageflow/revision_spec.rb
+++ b/spec/models/pageflow/revision_spec.rb
@@ -167,7 +167,7 @@ module Pageflow
 
       context 'with registered RevisionComponent' do
         it 'copies registered RevisionComponents' do
-          TestRevisionComponent.register(Pageflow.config)
+          Pageflow.config.revision_components.register(TestRevisionComponent)
           revision = create(:revision)
           TestRevisionComponent.create!(revision: revision)
 

--- a/spec/pageflow/configuration_spec.rb
+++ b/spec/pageflow/configuration_spec.rb
@@ -27,24 +27,20 @@ module Pageflow
     end
 
     describe '#revision_components' do
-      it 'returns all RevisionComponents of registered PageTypes' do
+      it 'returns all revision components' do
         conf = Configuration.new
-        conf.page_types.register(TestPageType.new(name: 'test',
-                                                  revision_components: [:component1]))
-        conf.page_types.register(TestPageType.new(name: 'test',
-                                                  revision_components: [:component2]))
+        conf.revision_components.register(:component)
 
-        expect(conf.revision_components).to eq([:component1, :component2])
+        expect(conf.revision_components.to_a).to eq([:component])
       end
 
-      it 'does not return duplicate RevisionComponents' do
+      it 'does not contain duplicate RevisionComponents' do
         conf = Configuration.new
-        conf.page_types.register(TestPageType.new(name: 'test',
-                                                  revision_components: [:component1]))
-        conf.page_types.register(TestPageType.new(name: 'test',
-                                                  revision_components: [:component1, :component2]))
+        conf.revision_components.register(:component1)
+        conf.revision_components.register(:component1)
+        conf.revision_components.register(:component2)
 
-        expect(conf.revision_components).to eq([:component1, :component2])
+        expect(conf.revision_components.to_a).to eq([:component1, :component2])
       end
     end
 

--- a/spec/pageflow/entry_export_import/revision_serialization_spec.rb
+++ b/spec/pageflow/entry_export_import/revision_serialization_spec.rb
@@ -209,7 +209,7 @@ module Pageflow
 
       it 'preserves revision components' do
         pageflow_configure do |config|
-          TestRevisionComponent.register(config)
+          config.revision_components.register(TestRevisionComponent)
         end
 
         exported_revision = create(:revision)

--- a/spec/support/helpers/test_revision_component.rb
+++ b/spec/support/helpers/test_revision_component.rb
@@ -2,12 +2,5 @@ module Pageflow
   class TestRevisionComponent < ActiveRecord::Base
     include RevisionComponent
     self.table_name = :test_revision_components
-
-    def self.register(config)
-      page_type = TestPageType.new(name: :test,
-                                   revision_components: [TestRevisionComponent])
-
-      config.page_types.register(page_type)
-    end
   end
 end


### PR DESCRIPTION
For entry types without the concept of pages, revision components are
needed as well. For this reason, revision components cannot remain
coupled to page types.

Page types can continue to define their own revision components,
however they are now registered globally.

REDMINE-17248 REDMINE-17243