### PR TITLE
Decouple file types from page types

### DIFF
--- a/config/initializers/file_types.rb
+++ b/config/initializers/file_types.rb
@@ -1,0 +1,7 @@
+Pageflow.after_configure do |config|
+  config.page_types.each do |page_type|
+    page_type.file_types.each do |file_type|
+      config.file_types.register(file_type)
+    end
+  end
+end

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -100,7 +100,8 @@ module Pageflow
     # @since 0.9
     attr_reader :page_types
 
-    # List of {FileType} instances provided by page types.
+    # List of {FileType} instances.
+    # Can be registered globally or provided by page types.
     # @return [FileTypes]
     attr_reader :file_types
 
@@ -368,7 +369,7 @@ module Pageflow
       @themes = Themes.new
       @entry_types = EntryTypes.new
       @page_types = PageTypes.new
-      @file_types = FileTypes.new(page_types)
+      @file_types = FileTypes.new
       @widget_types = WidgetTypes.new
       @file_importers = FileImporters.new
       @help_entries = HelpEntries.new

--- a/lib/pageflow/file_types.rb
+++ b/lib/pageflow/file_types.rb
@@ -2,12 +2,20 @@ module Pageflow
   class FileTypes
     include Enumerable
 
-    def initialize(page_types)
-      @page_types = page_types
+    def initialize
+      @file_types = []
+    end
+
+    def register(file_type)
+      @file_types << file_type
+    end
+
+    def clear
+      @file_types = []
     end
 
     def each(&block)
-      first_level_file_types = @page_types.map(&:file_types).flatten
+      first_level_file_types = @file_types
       lower_level_file_types = search_for_nested_file_types(first_level_file_types)
       (first_level_file_types + lower_level_file_types).uniq(&:model).each(&block)
     end

--- a/spec/helpers/pageflow/files_helper_spec.rb
+++ b/spec/helpers/pageflow/files_helper_spec.rb
@@ -110,9 +110,8 @@ module Pageflow
                                       editor_partial: 'pageflow/editor/stub_files/stub_file',
                                       collection_name: 'stub_files',
                                       top_level_type: true)
-        Pageflow.config.page_types.clear
-        Pageflow.config.page_types.register(TestPageType.new(name: 'test',
-                                                             file_types: [stub_file_type]))
+        Pageflow.config.file_types.clear
+        Pageflow.config.file_types.register(stub_file_type)
 
         entry = PublishedEntry.new(create(:entry, :published))
         create(:video_file, used_in: entry.revision)
@@ -129,9 +128,8 @@ module Pageflow
                                       partial: 'pageflow/stub_files/stub_file',
                                       collection_name: 'stub_files',
                                       top_level_type: true)
-        Pageflow.config.page_types.clear
-        Pageflow.config.page_types.register(TestPageType.new(name: 'test',
-                                                             file_types: [stub_file_type]))
+        Pageflow.config.file_types.clear
+        Pageflow.config.file_types.register(stub_file_type)
 
         entry = PublishedEntry.new(create(:entry, :published))
         create(:video_file, used_in: entry.revision)

--- a/spec/pageflow/configuration_spec.rb
+++ b/spec/pageflow/configuration_spec.rb
@@ -49,12 +49,12 @@ module Pageflow
     end
 
     describe '#file_types' do
-      it 'returns all FileTypes of registered PageTypes' do
+      it 'returns all registered FileTypes' do
         file_type1 = FileType.new(model: ImageFile, collection_name: 'image_files', editor_partial: 'path')
         file_type2 = FileType.new(model: VideoFile, collection_name: 'video_files', editor_partial: 'path')
         conf = Configuration.new
-        conf.page_types.register(TestPageType.new(name: 'test1', file_types: [file_type1]))
-        conf.page_types.register(TestPageType.new(name: 'test2', file_types: [file_type2]))
+        conf.file_types.register(file_type1)
+        conf.file_types.register(file_type2)
 
         expect(conf.file_types.to_a).to eq([file_type1, file_type2])
       end

--- a/spec/pageflow/file_types_spec.rb
+++ b/spec/pageflow/file_types_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 module Pageflow
   describe FileTypes do
     describe 'as Enumerable' do
-      it 'returns all FileTypes and nested FileTypes of given PageTypes' do
+      it 'returns all registered FileTypes and nested FileTypes' do
+        config = Configuration.new
         nested_file_type = FileType.new(model: TextTrackFile,
                                         collection_name: 'text_track_files',
                                         editor_partial: 'path')
@@ -14,13 +15,15 @@ module Pageflow
                                   collection_name: 'video_files',
                                   editor_partial: 'path',
                                   nested_file_types: [nested_file_type])
-        file_types = FileTypes.new([TestPageType.new(name: 'test', file_types: [file_type1]),
-                                    TestPageType.new(name: 'test', file_types: [file_type2])])
 
-        expect(file_types.to_a).to eq([file_type1, file_type2, nested_file_type])
+        config.file_types.register(file_type1)
+        config.file_types.register(file_type2)
+
+        expect(config.file_types.to_a).to eq([file_type1, file_type2, nested_file_type])
       end
 
       it 'makes FileTypes unique by model' do
+        config = Configuration.new
         file_type1 = FileType.new(model: ImageFile,
                                   collection_name: 'image_files',
                                   editor_partial: 'path')
@@ -28,20 +31,22 @@ module Pageflow
                                   collection_name: 'video_files',
                                   editor_partial: 'path',
                                   nested_file_types: [file_type1])
-        file_types = FileTypes.new([TestPageType.new(name: 'test', file_types: [file_type1]),
-                                    TestPageType.new(name: 'test',
-                                                     file_types: [file_type1, file_type2])])
 
-        expect(file_types.to_a).to eq([file_type1, file_type2])
+        config.file_types.register(file_type1)
+        config.file_types.register(file_type2)
+
+        expect(config.file_types.to_a).to eq([file_type1, file_type2])
       end
     end
 
     describe '#find_by_collection_name!' do
       it 'finds FileType by collection_name' do
+        config = Configuration.new
         file_type = FileType.new(model: ImageFile,
                                  collection_name: 'image_files',
                                  editor_partial: 'path')
-        file_types = FileTypes.new([TestPageType.new(name: 'test', file_types: [file_type])])
+        config.file_types.register(file_type)
+        file_types = config.file_types
 
         result = file_types.find_by_collection_name!('image_files')
 
@@ -49,7 +54,7 @@ module Pageflow
       end
 
       it 'raises exception if FileType is not found' do
-        file_types = FileTypes.new([])
+        file_types = FileTypes.new
 
         expect {
           file_types.find_by_collection_name!('image_files')
@@ -59,10 +64,12 @@ module Pageflow
 
     describe '#find_by_model!' do
       it 'finds FileType by model' do
+        config = Configuration.new
         file_type = FileType.new(model: ImageFile,
                                  collection_name: 'image_files',
                                  editor_partial: 'path')
-        file_types = FileTypes.new([TestPageType.new(name: 'test', file_types: [file_type])])
+        config.file_types.register(file_type)
+        file_types = config.file_types
 
         result = file_types.find_by_model!(ImageFile)
 
@@ -70,16 +77,20 @@ module Pageflow
       end
 
       it 'raises exception if FileType is not found' do
-        file_types = FileTypes.new([])
+        file_types = FileTypes.new
 
-        expect { file_types.find_by_model!(ImageFile) }.to raise_error(FileType::NotFoundError)
+        expect {
+          file_types.find_by_model!(ImageFile)
+        }.to raise_error(FileType::NotFoundError)
       end
     end
 
     describe '#with_thumbnail_support' do
       it 'includes file types whose models have thumbnail_url instance method' do
+        config = Configuration.new
         file_type = FileType.new(model: ImageFile)
-        file_types = FileTypes.new([TestPageType.new(name: 'test', file_types: [file_type])])
+        config.file_types.register(file_type)
+        file_types = config.file_types
 
         result = file_types.with_thumbnail_support
 
@@ -87,8 +98,10 @@ module Pageflow
       end
 
       it 'does not include file types whose models do not have thumbnail_url instance method' do
+        config = Configuration.new
         file_type = FileType.new(model: AudioFile)
-        file_types = FileTypes.new([TestPageType.new(name: 'test', file_types: [file_type])])
+        config.file_types.register(file_type)
+        file_types = config.file_types
 
         result = file_types.with_thumbnail_support
 
@@ -98,9 +111,11 @@ module Pageflow
 
     describe '#with_css_background_image_support' do
       it 'includes file types with css_background_image_urls attribute set' do
+        config = Configuration.new
         file_type = FileType.new(model: ImageFile,
                                  css_background_image_urls: -> {})
-        file_types = FileTypes.new([TestPageType.new(name: 'test', file_types: [file_type])])
+        config.file_types.register(file_type)
+        file_types = config.file_types
 
         result = file_types.with_css_background_image_support
 
@@ -108,8 +123,10 @@ module Pageflow
       end
 
       it 'does not include file types without css_background_image_urls attribute set' do
+        config = Configuration.new
         file_type = FileType.new(model: ImageFile)
-        file_types = FileTypes.new([TestPageType.new(name: 'test', file_types: [file_type])])
+        config.file_types.register(file_type)
+        file_types = config.file_types
 
         result = file_types.with_css_background_image_support
 


### PR DESCRIPTION
For entry types without the concept of pages, file types are needed as
well. For this reason, file types cannot remain coupled to page types.

Page types can continue to define their own file types, however they
are now registered globally.

REDMINE-17249 REDMINE-17243