### PR TITLE
Defer creating filetypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Bug fix: Change revision#locale to always return string
   ([#1239](https://github.com/codevise/pageflow/pull/1239))
 
-#### Intenal
+#### Internal
 
 - Add entry type engines
   ([#1247](https://github.com/codevise/pageflow/pull/1247))

--- a/doc/creating_file_types.md
+++ b/doc/creating_file_types.md
@@ -75,7 +75,7 @@ whenever the page type is registered in a Pageflow application.
         end
 
         def self.package_file_type
-          FileType.new(model: Package)
+          FileType.new(model: 'Pageflow::Panorama::Package')
         end
       end
     end
@@ -113,7 +113,7 @@ JSON data passed to the editor. In order to do so, set the
     module Pageflow
       module
         def self.package_file_type
-          FileType.new(model: Package,
+          FileType.new(model: 'Pageflow::Panorama::Package',
                        editor_partial: 'pageflow/panorama/editor/packages/package')
         end
       end
@@ -375,7 +375,7 @@ specified when registering the file type:
         end
 
         def self.scraped_site_file_type
-          FileType.new(model: ScrapedSite,
+          FileType.new(model: 'Pageflow::Chart::ScrapedSite',
                        editor_partial: 'pageflow/chart/editor/scraped_sites/scraped_site',
                        custom_attributes: {
                          url: {
@@ -411,7 +411,7 @@ from:
          end
 
          def self.color_map_file_type
-           FileType.new(model: ColorMapFile,
+           FileType.new(model: 'Pageflow::LinkmapPage::ColorMapFile',
                         # ...
                         custom_attributes: {
                           source_image_file_id: {

--- a/doc/understanding_entry_export_and_import.md
+++ b/doc/understanding_entry_export_and_import.md
@@ -161,7 +161,7 @@ module Pageflow
     [...]
 
     def self.scraped_site_file_type
-      FileType.new(model: ScrapedSite,
+      FileType.new(model: 'Pageflow::Chart::ScrapedSite',
                    custom_attributes: %i[url use_custom_theme],
                    editor_partial: 'pageflow/chart/editor/scraped_sites/scraped_site')
     end

--- a/lib/pageflow/file_type.rb
+++ b/lib/pageflow/file_type.rb
@@ -58,12 +58,13 @@ module Pageflow
     #
     # @example
     #
-    #   Pageflow::FileType.new(model: Pageflow::Rainbow::File,
+    #   Pageflow::FileType.new(model: 'Pageflow::Rainbow::File',
     #                          editor_partial: 'pageflow/rainbow/editor/files/file')
     #
     # @param [Hash] options
     # @option options [ActiveRecord::Base, String] :model
-    #   Required. Model representing the file, or name of that model.
+    #   Required. Name of model representing the file. Model reference
+    #   still works, but is deprecated
     # @option options [String] :partial
     #   Optional. Path of a partial to include in json representations
     #   of the file both inside  the editor and published entries.

--- a/lib/pageflow/page_types.rb
+++ b/lib/pageflow/page_types.rb
@@ -59,9 +59,13 @@ module Pageflow
     end
 
     def register_file_types(config, page_type)
-      page_type.file_types.each do |file_type|
-        config.file_types.register(file_type)
-      end
+      # After a deprecation period against initializing FileType with
+      # a model reference instead of a model name string, we could
+      # rewrite this to register the page type's file types one by one
+      # right here instead of lazily in FileTypes#each.
+      config.file_types.register(
+        -> { page_type.file_types }
+      )
     end
   end
 end

--- a/spec/pageflow/configuration_spec.rb
+++ b/spec/pageflow/configuration_spec.rb
@@ -46,8 +46,12 @@ module Pageflow
 
     describe '#file_types' do
       it 'returns all registered FileTypes' do
-        file_type1 = FileType.new(model: ImageFile, collection_name: 'image_files', editor_partial: 'path')
-        file_type2 = FileType.new(model: VideoFile, collection_name: 'video_files', editor_partial: 'path')
+        file_type1 = FileType.new(model: 'Pageflow::ImageFile',
+                                  collection_name: 'image_files',
+                                  editor_partial: 'path')
+        file_type2 = FileType.new(model: 'Pageflow::VideoFile',
+                                  collection_name: 'video_files',
+                                  editor_partial: 'path')
         conf = Configuration.new
         conf.file_types.register(file_type1)
         conf.file_types.register(file_type2)

--- a/spec/pageflow/file_type_spec.rb
+++ b/spec/pageflow/file_type_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 module Pageflow
   describe FileType do
     describe '#model' do
-      it 'is set if model is passed' do
-        file_type = FileType.new(model: ImageFile)
+      it 'is set if model name is passed' do
+        file_type = FileType.new(model: 'Pageflow::ImageFile')
 
         expect(file_type.model).to eq(ImageFile)
       end
 
-      it 'is set if model name is passed' do
-        file_type = FileType.new(model: 'Pageflow::ImageFile')
+      it 'is set if model reference is passed (deprecated)' do
+        file_type = FileType.new(model: ImageFile)
 
         expect(file_type.model).to eq(ImageFile)
       end
@@ -18,13 +18,13 @@ module Pageflow
 
     describe '#collection_name' do
       it 'defaults to plural model name' do
-        file_type = FileType.new(model: ImageFile)
+        file_type = FileType.new(model: 'Pageflow::ImageFile')
 
         expect(file_type.collection_name).to eq('pageflow_image_files')
       end
 
       it 'can be overridden' do
-        file_type = FileType.new(model: ImageFile,
+        file_type = FileType.new(model: 'Pageflow::ImageFile',
                                  collection_name: 'image_files')
 
         expect(file_type.collection_name).to eq('image_files')
@@ -33,7 +33,7 @@ module Pageflow
 
     describe '#param_key' do
       it 'returns symbolized base class name' do
-        file_type = FileType.new(model: ImageFile)
+        file_type = FileType.new(model: 'Pageflow::ImageFile')
 
         expect(file_type.param_key).to eq(:image_file)
       end
@@ -41,7 +41,7 @@ module Pageflow
 
     describe '#short_name' do
       it 'returns symbolized base class name' do
-        file_type = FileType.new(model: ImageFile)
+        file_type = FileType.new(model: 'Pageflow::ImageFile')
 
         expect(file_type.param_key).to eq(:image_file)
       end
@@ -49,7 +49,7 @@ module Pageflow
 
     describe '#type_name' do
       it 'returns fully qualified name of ruby model' do
-        file_type = FileType.new(model: ImageFile)
+        file_type = FileType.new(model: 'Pageflow::ImageFile')
 
         expect(file_type.type_name).to eq('Pageflow::ImageFile')
       end
@@ -57,7 +57,7 @@ module Pageflow
 
     describe '#i18n_key' do
       it 'returns fully qualified underscored name of ruby model' do
-        file_type = FileType.new(model: ImageFile)
+        file_type = FileType.new(model: 'Pageflow::ImageFile')
 
         expect(file_type.i18n_key).to eq(:'pageflow/image_file')
       end
@@ -65,7 +65,7 @@ module Pageflow
 
     describe '#editor_partial' do
       it 'returns passed editor_partial' do
-        file_type = FileType.new(model: ImageFile,
+        file_type = FileType.new(model: 'Pageflow::ImageFile',
                                  editor_partial: 'pageflow/editor/image_files/image_file')
 
         expect(file_type.editor_partial).to eq('pageflow/editor/image_files/image_file')
@@ -74,7 +74,7 @@ module Pageflow
 
     describe '#custom_attributes' do
       it 'converts passed custom_attributes symbol array to hash' do
-        file_type = FileType.new(model: ImageFile,
+        file_type = FileType.new(model: 'Pageflow::ImageFile',
                                  custom_attributes: [:neural_network_analysis])
 
         expect(file_type.custom_attributes)

--- a/spec/pageflow/file_types_spec.rb
+++ b/spec/pageflow/file_types_spec.rb
@@ -5,13 +5,13 @@ module Pageflow
     describe 'as Enumerable' do
       it 'returns all registered FileTypes and nested FileTypes' do
         config = Configuration.new
-        nested_file_type = FileType.new(model: TextTrackFile,
+        nested_file_type = FileType.new(model: 'Pageflow::TextTrackFile',
                                         collection_name: 'text_track_files',
                                         editor_partial: 'path')
-        file_type1 = FileType.new(model: ImageFile,
+        file_type1 = FileType.new(model: 'Pageflow::ImageFile',
                                   collection_name: 'image_files',
                                   editor_partial: 'path')
-        file_type2 = FileType.new(model: VideoFile,
+        file_type2 = FileType.new(model: 'Pageflow::VideoFile',
                                   collection_name: 'video_files',
                                   editor_partial: 'path',
                                   nested_file_types: [nested_file_type])
@@ -22,12 +22,31 @@ module Pageflow
         expect(config.file_types.to_a).to eq([file_type1, file_type2, nested_file_type])
       end
 
-      it 'makes FileTypes unique by model' do
+      it 'allows lambda registration' do
         config = Configuration.new
-        file_type1 = FileType.new(model: ImageFile,
+        nested_file_type = FileType.new(model: 'Pageflow::TextTrackFile',
+                                        collection_name: 'text_track_files',
+                                        editor_partial: 'path')
+        file_type1 = FileType.new(model: 'Pageflow::ImageFile',
                                   collection_name: 'image_files',
                                   editor_partial: 'path')
-        file_type2 = FileType.new(model: VideoFile,
+        file_type2 = FileType.new(model: 'Pageflow::VideoFile',
+                                  collection_name: 'video_files',
+                                  editor_partial: 'path',
+                                  nested_file_types: [nested_file_type])
+
+        config.file_types.register(-> { file_type1 })
+        config.file_types.register(-> { [file_type2] })
+
+        expect(config.file_types.to_a).to eq([file_type1, file_type2, nested_file_type])
+      end
+
+      it 'makes FileTypes unique by model' do
+        config = Configuration.new
+        file_type1 = FileType.new(model: 'Pageflow::ImageFile',
+                                  collection_name: 'image_files',
+                                  editor_partial: 'path')
+        file_type2 = FileType.new(model: 'Pageflow::VideoFile',
                                   collection_name: 'video_files',
                                   editor_partial: 'path',
                                   nested_file_types: [file_type1])
@@ -42,7 +61,7 @@ module Pageflow
     describe '#find_by_collection_name!' do
       it 'finds FileType by collection_name' do
         config = Configuration.new
-        file_type = FileType.new(model: ImageFile,
+        file_type = FileType.new(model: 'Pageflow::ImageFile',
                                  collection_name: 'image_files',
                                  editor_partial: 'path')
         config.file_types.register(file_type)
@@ -65,7 +84,7 @@ module Pageflow
     describe '#find_by_model!' do
       it 'finds FileType by model' do
         config = Configuration.new
-        file_type = FileType.new(model: ImageFile,
+        file_type = FileType.new(model: 'Pageflow::ImageFile',
                                  collection_name: 'image_files',
                                  editor_partial: 'path')
         config.file_types.register(file_type)
@@ -88,7 +107,7 @@ module Pageflow
     describe '#with_thumbnail_support' do
       it 'includes file types whose models have thumbnail_url instance method' do
         config = Configuration.new
-        file_type = FileType.new(model: ImageFile)
+        file_type = FileType.new(model: 'Pageflow::ImageFile')
         config.file_types.register(file_type)
         file_types = config.file_types
 
@@ -99,7 +118,7 @@ module Pageflow
 
       it 'does not include file types whose models do not have thumbnail_url instance method' do
         config = Configuration.new
-        file_type = FileType.new(model: AudioFile)
+        file_type = FileType.new(model: 'Pageflow::AudioFile')
         config.file_types.register(file_type)
         file_types = config.file_types
 
@@ -112,7 +131,7 @@ module Pageflow
     describe '#with_css_background_image_support' do
       it 'includes file types with css_background_image_urls attribute set' do
         config = Configuration.new
-        file_type = FileType.new(model: ImageFile,
+        file_type = FileType.new(model: 'Pageflow::ImageFile',
                                  css_background_image_urls: -> {})
         config.file_types.register(file_type)
         file_types = config.file_types
@@ -124,7 +143,7 @@ module Pageflow
 
       it 'does not include file types without css_background_image_urls attribute set' do
         config = Configuration.new
-        file_type = FileType.new(model: ImageFile)
+        file_type = FileType.new(model: 'Pageflow::ImageFile')
         config.file_types.register(file_type)
         file_types = config.file_types
 

--- a/spec/pageflow/page_types_spec.rb
+++ b/spec/pageflow/page_types_spec.rb
@@ -92,7 +92,7 @@ module Pageflow
       it 'registers file types' do
         config = Configuration.new
         page_types = config.page_types
-        file_type = FileType.new(model: TestUploadableFile)
+        file_type = FileType.new(model: 'Pageflow::TestUploadableFile')
         page_types.register(TestPageType.new(name: 'test', file_types: [file_type]))
 
         page_types.setup(config)

--- a/spec/support/helpers/test_file_type.rb
+++ b/spec/support/helpers/test_file_type.rb
@@ -3,7 +3,7 @@ require 'pageflow/test_page_type'
 module Pageflow
   class TestFileType
     def self.register(config, options = {})
-      file_type = FileType.new(model: TestUploadableFile, **options)
+      file_type = FileType.new(model: 'Pageflow::TestUploadableFile', **options)
 
       page_type = TestPageType.new(name: :test,
                                    file_types: [file_type])


### PR DESCRIPTION
Previously, FileType objects could be initialized using a model reference. This is now deprecated and will be removed in a future version. Please use a string that contains the model name instead

REDMINE-17243