### PR TITLE
Let entry types define editor controllers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,8 @@ Pageflow::Engine.routes.draw do
         resources :entry_publications, :only => [:create] do
           post :check, :on => :collection
         end
+
+        Pageflow.config(ignore_not_configured: true).entry_types.routes(self)
       end
 
       resources :entries, only: [] do

--- a/doc/creating_entry_types.md
+++ b/doc/creating_entry_types.md
@@ -100,6 +100,8 @@ end
 
 ## Customizing the Editor
 
+### Rendered Fragments
+
 To make the editor work for entries of a new entry type, we first need
 to provide some partials that will be used while rendering the
 editor. `EntryType` takes an `editor_fragment_renderer` option, which
@@ -145,6 +147,47 @@ This will render the following partials with a local `entry` variable:
 * `rainbow/editor/entries/_seed.json.jbuilder`
 
 The given controller determines the available view helpers.
+
+### REST Controllers
+
+Entry types can define new editor controllers, which can then be used
+by custom Backbone collections in the editor:
+
+```ruby
+module Rainbow
+  module Editor
+    class UnicornsController < ActionController::Base
+    end
+  end
+end
+```
+
+It is recommended to put all editor controllers into a `Editor`
+module. The easiest way is to use the routes defined by the entry type
+Rails engine:
+
+```ruby
+# rainbow/config/routes.rb
+scope module: 'editor' do
+  resources :unicorns
+end
+```
+
+The `scope` call is required to use controllers from the
+`Rainbow::Editor` module. Pass the engine as `editor_app` when
+registering the entry type:
+
+```ruby
+def entry_type
+  Pageflow::EntryType.new(name: 'rainbow',
+                          ...
+                          editor_app: Rainbow::Engine)
+end
+```
+
+The editor app will be mounted at
+`/editor/entries/:id/<entry_type_name>/`. So the example above would
+add the route `/editor/entries/:id/test/unicorns`.
 
 ## Adding to the Configuration
 

--- a/doc/creating_entry_types.md
+++ b/doc/creating_entry_types.md
@@ -239,6 +239,24 @@ module Rainbow
 end
 ```
 
+For controller actions that do not alter data, you can consider
+skipping edit lock verification:
+
+```ruby
+module Rainbow
+  module Editor
+    class UnicornsController < ActionController::Base
+      include Pageflow::EditorController
+
+      skip_before_action :verify_edit_lock, only: :show
+
+      def show
+      end
+    end
+  end
+end
+```
+
 ## Adding to the Configuration
 
 `EntryType` provides a `configuration` option, which accepts a class

--- a/doc/creating_entry_types.md
+++ b/doc/creating_entry_types.md
@@ -189,6 +189,56 @@ The editor app will be mounted at
 `/editor/entries/:id/<entry_type_name>/`. So the example above would
 add the route `/editor/entries/:id/test/unicorns`.
 
+Pageflow provides the `Pageflow::EditorController` module to take care
+of common editor controller concerns like:
+
+* Authenticating the user
+* Finding the entry from request params
+* Authorizing the usere
+* Ensuring the current user holds an edit lock for the entry
+
+```ruby
+module Rainbow
+  module Editor
+    class UnicornsController < ActionController::Base
+      include Pageflow::EditorController
+
+      def update
+        @entry # => Pageflow::DraftEntry
+      end
+    end
+  end
+end
+```
+
+In controller specs, you can use
+`Pageflow::EditorControllerTestHelper#authorize_for_editor_controller`
+to make sure the test request is authorized for the action:
+
+```ruby
+require 'spec_helper'
+require 'pageflow/editor_controller_test_helper'
+
+module Rainbow
+  RSpec.describe Editor::UnicornsController, type: :controller do
+    include Pageflow::EditorControllerTestHelper
+
+    routes { Rainbow::Engine.routes }
+
+    describe '#create' do
+      it 'succeeds' do
+        entry = create(:entry)
+
+        authorize_for_editor_controller(entry)
+        post(:create, params: {entry_id: entry.id}, format: 'json')
+
+        expect(response.status).to eq(204)
+      end
+    end
+  end
+end
+```
+
 ## Adding to the Configuration
 
 `EntryType` provides a `configuration` option, which accepts a class

--- a/entry_types/scrolled/app/controllers/pageflow_scrolled/editor/sections_controller.rb
+++ b/entry_types/scrolled/app/controllers/pageflow_scrolled/editor/sections_controller.rb
@@ -1,0 +1,10 @@
+module PageflowScrolled
+  module Editor
+    # @api private
+    class SectionsController < ActionController::Base
+      include Pageflow::EditorController
+
+      def create; end
+    end
+  end
+end

--- a/entry_types/scrolled/config/routes.rb
+++ b/entry_types/scrolled/config/routes.rb
@@ -1,0 +1,5 @@
+PageflowScrolled::Engine.routes.draw do
+  scope module: 'editor' do
+    resources :sections, only: :create
+  end
+end

--- a/entry_types/scrolled/lib/pageflow_scrolled.rb
+++ b/entry_types/scrolled/lib/pageflow_scrolled.rb
@@ -10,8 +10,9 @@ module PageflowScrolled
     def entry_type
       Pageflow::EntryType.new(name: 'scrolled',
                               frontend_app: PageflowScrolled::EntriesController.action(:show),
+                              configuration: Plugin::ScrolledConfiguration,
                               editor_fragment_renderer: editor_fragment_renderer,
-                              configuration: Plugin::ScrolledConfiguration)
+                              editor_app: PageflowScrolled::Engine)
     end
 
     private

--- a/entry_types/scrolled/spec/controllers/pageflow_scrolled/editor/sections_controller_spec.rb
+++ b/entry_types/scrolled/spec/controllers/pageflow_scrolled/editor/sections_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'pageflow/editor_controller_test_helper'
+
+module PageflowScrolled
+  RSpec.describe Editor::SectionsController, type: :controller do
+    include Pageflow::EditorControllerTestHelper
+
+    routes { PageflowScrolled::Engine.routes }
+
+    describe '#create' do
+      it 'requires authentication' do
+        entry = create(:entry)
+
+        post(:create, params: {entry_id: entry.id}, format: 'json')
+
+        expect(response.status).to eq(401)
+      end
+
+      it 'succeeds for authorized user' do
+        entry = create(:entry)
+
+        authorize_for_editor_controller(entry)
+        post(:create, params: {entry_id: entry.id}, format: 'json')
+
+        expect(response.status).to eq(204)
+      end
+    end
+  end
+end

--- a/lib/pageflow/editor_controller.rb
+++ b/lib/pageflow/editor_controller.rb
@@ -1,0 +1,40 @@
+module Pageflow
+  # Concern that can be included in entry type specific controllers
+  # that extend the REST interface used by the editor. Handles
+  # authentication, entry lookup, authorization and edit locking.
+  #
+  # @since edge
+  module EditorController
+    extend ActiveSupport::Concern
+
+    include EditLocking
+
+    included do
+      before_action :authenticate_user!
+
+      before_action do
+        begin
+          @entry = DraftEntry.find(params[:entry_id])
+        rescue ActiveRecord::RecordNotFound
+          head :not_found
+        end
+      end
+
+      before_action do
+        begin
+          Ability.new(current_user).authorize!(:update, @entry.to_model)
+        rescue CanCan::AccessDenied
+          head :forbidden
+        end
+      end
+
+      before_action do
+        verify_edit_lock!(@entry)
+      end
+
+      before_action do
+        head :bad_request if params[:entry_type] && @entry.entry_type.name != params[:entry_type]
+      end
+    end
+  end
+end

--- a/lib/pageflow/editor_controller.rb
+++ b/lib/pageflow/editor_controller.rb
@@ -28,13 +28,17 @@ module Pageflow
         end
       end
 
-      before_action do
-        verify_edit_lock!(@entry)
-      end
+      before_action :verify_edit_lock
 
       before_action do
         head :bad_request if params[:entry_type] && @entry.entry_type.name != params[:entry_type]
       end
+    end
+
+    private
+
+    def verify_edit_lock
+      verify_edit_lock!(@entry)
     end
   end
 end

--- a/lib/pageflow/entry_type.rb
+++ b/lib/pageflow/entry_type.rb
@@ -4,21 +4,28 @@ module Pageflow
   # @since 15.1
   class EntryType
     # @api private
-    attr_reader :name, :frontend_app, :editor_fragment_renderer, :configuration
+    attr_reader :name, :frontend_app, :editor_fragment_renderer, :configuration, :editor_app
 
     # @param name [String] A unique name.
     #
     # @param frontend_app [#call] A rack app that renders the entry
     #   when not in the editor (i.e. preview and published entries).
     #
-    # @param editor_fragment_renderer
+    # @param editor_fragment_renderer [PartialEditorFragmentRenderer]
+    #   Inject content into editor HTML and JSON seed templates.
     #
-    # @param configuration [EntryTypeConfiguration]
-    def initialize(name:, frontend_app:, editor_fragment_renderer:, configuration:)
+    # @param configuration [Class] Class including
+    #   {Pageflow::Configuration::EntryTypeConfiguration}.
+    #
+    # @param editor_app [#call] A rack app that extends the REST
+    #   interface used by editor Backbone collections. Mounted at
+    #   `/editor/entries/:id/<entry_type_name>/`
+    def initialize(name:, frontend_app:, editor_fragment_renderer:, configuration:, editor_app: nil)
       @name = name
       @frontend_app = frontend_app
       @editor_fragment_renderer = editor_fragment_renderer
       @configuration = configuration
+      @editor_app = editor_app
     end
   end
 end

--- a/lib/pageflow/entry_types.rb
+++ b/lib/pageflow/entry_types.rb
@@ -3,6 +3,8 @@ module Pageflow
   #
   # @since 15.1
   class EntryTypes
+    include Enumerable
+
     # @api private
     def initialize
       @entry_types_by_name = {}
@@ -19,6 +21,26 @@ module Pageflow
     def find_by_name!(name)
       @entry_types_by_name.fetch(name) do
         raise "Unknown entry type with name #{name}."
+      end
+    end
+
+    # @api private
+    def each(&block)
+      @entry_types_by_name.values.each(&block)
+    end
+
+    # @api private
+    def routes(router)
+      each do |entry_type|
+        next unless entry_type.editor_app
+
+        router.instance_eval do
+          nested do
+            scope '/:entry_type', constraints: {entry_type: entry_type.name} do
+              mount entry_type.editor_app, at: '/'
+            end
+          end
+        end
       end
     end
   end

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -149,6 +149,9 @@ Gem::Specification.new do |s|
   # Matchers like "to have(3).items"
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.1'
 
+  # Use assigns in controller specs
+  s.add_development_dependency 'rails-controller-testing', '~> 1.0'
+
   # Browser like integration testing
   s.add_development_dependency 'capybara', '~> 3.9'
 

--- a/spec/pageflow/editor_controller_spec.rb
+++ b/spec/pageflow/editor_controller_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+require 'pageflow/editor_controller_test_helper'
+
+module Pageflow
+  describe EditorController, type: :controller do
+    include EditorControllerTestHelper
+
+    controller(ActionController::Base) do
+      include EditorController
+
+      def create; end
+    end
+
+    it 'requires authentication' do
+      entry = create(:entry)
+
+      post(:create,
+           params: {entry_id: entry},
+           format: 'json')
+
+      expect(response.status).to eq(401)
+    end
+
+    it 'responds with not found for invalid entry id' do
+      user = create(:user)
+
+      sign_in(user, scope: :user)
+      post(:create,
+           params: {entry_id: 'not-there'},
+           format: 'json')
+
+      expect(response.status).to eq(404)
+    end
+
+    it 'responds with forbidden for entry previewer' do
+      user = create(:user)
+      account = create(:account, with_previewer: user)
+      entry = create(:entry, account: account)
+
+      sign_in(user, scope: :user)
+      post(:create,
+           params: {entry_id: entry},
+           format: 'json')
+
+      expect(response.status).to eq(403)
+    end
+
+    it 'responds with conflict for entry editor without edit lock' do
+      user = create(:user)
+      account = create(:account, with_editor: user)
+      entry = create(:entry, account: account)
+
+      sign_in(user, scope: :user)
+      post(:create,
+           params: {entry_id: entry},
+           format: 'json')
+
+      expect(response.status).to eq(409)
+    end
+
+    it 'is allowed for entry editor with edit lock' do
+      user = create(:user)
+      account = create(:account, with_editor: user)
+      entry = create(:entry, account: account)
+
+      sign_in(user, scope: :user)
+      acquire_edit_lock(user, entry)
+      post(:create,
+           params: {entry_id: entry},
+           format: 'json')
+
+      expect(response.status).to eq(204)
+    end
+
+    it 'assigns draft entry to @entry' do
+      entry = create(:entry)
+
+      authorize_for_editor_controller(entry)
+      post(:create,
+           params: {entry_id: entry},
+           format: 'json')
+
+      expect(assigns(:entry)).to be_a(DraftEntry)
+    end
+
+    it 'fails if entry type does not match entry_type param' do
+      pageflow_configure do |config|
+        TestEntryType.register(config, name: 'default')
+        TestEntryType.register(config, name: 'other')
+      end
+
+      entry = create(:entry, type_name: 'other')
+
+      authorize_for_editor_controller(entry)
+      post(:create,
+           params: {entry_type: 'default', entry_id: entry},
+           format: 'json')
+
+      expect(response.status).to eq(400)
+    end
+
+    it 'succeeds if entry type matches entry_type param' do
+      pageflow_configure do |config|
+        TestEntryType.register(config, name: 'default')
+      end
+
+      entry = create(:entry, type_name: 'default')
+
+      authorize_for_editor_controller(entry)
+      post(:create,
+           params: {entry_type: 'default', entry_id: entry},
+           format: 'json')
+
+      expect(response.status).to eq(204)
+    end
+  end
+end

--- a/spec/pageflow/editor_controller_spec.rb
+++ b/spec/pageflow/editor_controller_spec.rb
@@ -8,6 +8,10 @@ module Pageflow
     controller(ActionController::Base) do
       include EditorController
 
+      skip_before_action :verify_edit_lock, only: :index
+
+      def index; end
+
       def create; end
     end
 
@@ -56,6 +60,19 @@ module Pageflow
            format: 'json')
 
       expect(response.status).to eq(409)
+    end
+
+    it 'allows skipping the verify_edit_lock before action' do
+      user = create(:user)
+      account = create(:account, with_editor: user)
+      entry = create(:entry, account: account)
+
+      sign_in(user, scope: :user)
+      post(:index,
+           params: {entry_id: entry},
+           format: 'json')
+
+      expect(response.status).to eq(204)
     end
 
     it 'is allowed for entry editor with edit lock' do

--- a/spec/pageflow/entry_types_spec.rb
+++ b/spec/pageflow/entry_types_spec.rb
@@ -2,6 +2,16 @@ require 'spec_helper'
 
 module Pageflow
   describe EntryTypes do
+    it 'is enumarable' do
+      entry_types = EntryTypes.new
+      entry_type = TestEntryType.new(name: 'test')
+
+      entry_types.register(entry_type)
+      result = entry_types.map(&:name)
+
+      expect(result).to eq(['test'])
+    end
+
     describe '#find_by_name!' do
       it 'returns entry type with given name' do
         entry_types = EntryTypes.new

--- a/spec/requests/pageflow/editor/custom_routes_spec.rb
+++ b/spec/requests/pageflow/editor/custom_routes_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+module Pageflow
+  describe '/editor/entries/:id/<entry_type>', type: :request do
+    it 'delegates to editor app' do
+      pageflow_configure do |config|
+        route_set = ActionDispatch::Routing::RouteSet.new.tap do |routes|
+          routes.draw do
+            get('/custom_route', to: ->(_env) { ['200', {}, ['custom']] })
+          end
+        end
+
+        TestEntryType.register(config,
+                               name: 'test',
+                               editor_app: route_set)
+      end
+      Rails.application.reload_routes!
+
+      entry = create(:entry)
+
+      get("/editor/entries/#{entry.id}/test/custom_route")
+
+      expect(response.status).to eq(200)
+    end
+
+    it 'sets entry_type param' do
+      editor_app = lambda do |env|
+        entry_type = ActionDispatch::Request.new(env).params['entry_type']
+        ['200', {}, ["Entry type #{entry_type}"]]
+      end
+
+      pageflow_configure do |config|
+        TestEntryType.register(config,
+                               name: 'test',
+                               editor_app: editor_app)
+      end
+      Rails.application.reload_routes!
+
+      entry = create(:entry)
+
+      get("/editor/entries/#{entry.id}/test/custom_route")
+
+      expect(response.body).to eq('Entry type test')
+    end
+
+    it 'lets different entry types define the same editor routes' do
+      pageflow_configure do |config|
+        route_set1 = ActionDispatch::Routing::RouteSet.new.tap do |routes|
+          routes.draw do
+            get('/custom_route', to: ->(_env) { ['200', {}, ['custom1']] })
+          end
+        end
+
+        route_set2 = ActionDispatch::Routing::RouteSet.new.tap do |routes|
+          routes.draw do
+            get('/custom_route', to: ->(_env) { ['200', {}, ['custom2']] })
+          end
+        end
+
+        TestEntryType.register(config,
+                               name: 'test1',
+                               editor_app: route_set1)
+        TestEntryType.register(config,
+                               name: 'test2',
+                               editor_app: route_set2)
+      end
+      Rails.application.reload_routes!
+
+      entry = create(:entry)
+
+      get("/editor/entries/#{entry.id}/test2/custom_route")
+
+      expect(response.body).to eq('custom2')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'coveralls'
 Coveralls.wear!
 
+require 'rails-controller-testing'
 require 'rspec/rails'
 require 'rspec/collection_matchers'
 require 'domino'

--- a/spec/support/helpers/edit_lock_test_helpers.rb
+++ b/spec/support/helpers/edit_lock_test_helpers.rb
@@ -1,10 +1,5 @@
-module EditLockTestHelpers
-  def acquire_edit_lock(user, entry)
-    edit_lock = create(:edit_lock, :user => user, :entry => entry)
-    request.headers['X-Edit-Lock'] = edit_lock.id
-  end
-end
+require 'pageflow/edit_lock_test_helper'
 
 RSpec.configure do |config|
-  config.include EditLockTestHelpers, :type => :controller
+  config.include Pageflow::EditLockTestHelpers, type: :controller
 end

--- a/spec/support/pageflow/edit_lock_test_helper.rb
+++ b/spec/support/pageflow/edit_lock_test_helper.rb
@@ -1,0 +1,8 @@
+module Pageflow
+  module EditLockTestHelpers
+    def acquire_edit_lock(user, entry)
+      edit_lock = FactoryBot.create(:edit_lock, user: user, entry: entry)
+      request.headers['X-Edit-Lock'] = edit_lock.id
+    end
+  end
+end

--- a/spec/support/pageflow/editor_controller_test_helper.rb
+++ b/spec/support/pageflow/editor_controller_test_helper.rb
@@ -1,0 +1,24 @@
+require 'pageflow/edit_lock_test_helper'
+
+module Pageflow
+  # Helpers to test controllers that include
+  # {Pageflow::EditorController}.
+  #
+  # @since edge
+  module EditorControllerTestHelper
+    extend ActiveSupport::Concern
+
+    include EditLockTestHelpers
+    include Devise::Test::ControllerHelpers
+
+    # Sign in with user that has permission to edit the entry and
+    # acquire an edit lock.
+    def authorize_for_editor_controller(entry)
+      user = FactoryBot.create(:user)
+      FactoryBot.create(:membership, user: user, entity: entry, role: :editor)
+
+      sign_in(user, scope: :user)
+      acquire_edit_lock(user, entry)
+    end
+  end
+end


### PR DESCRIPTION
Add `editor_app` option to `EntryType` to allow adding entry type
specific routes below `/editor/entries/:id/<entry_type_name>/`. This
can be used for entry type specific editor REST controllers.

Allow including `Pageflow::EditorController` in entry type specific
editor controllers to handle common concerns like authentication and
authorization.

Provide a controller test helper that creates and signs a user, gives
them edit permission and acquires an edit lock.

Add example editor controller to scrolled engine.

REDMINE-17265