### PR TITLE
Remove obsolete member_label usage

### DIFF
--- a/admins/pageflow/accounts.rb
+++ b/admins/pageflow/accounts.rb
@@ -71,6 +71,7 @@ module Pageflow
     end
 
     controller do
+      helper Pageflow::Admin::AccountsHelper
       helper Pageflow::Admin::FeaturesHelper
       helper Pageflow::Admin::FormHelper
       helper Pageflow::Admin::LocalesHelper

--- a/app/helpers/pageflow/admin/accounts_helper.rb
+++ b/app/helpers/pageflow/admin/accounts_helper.rb
@@ -1,0 +1,11 @@
+module Pageflow
+  module Admin
+    module AccountsHelper
+      def share_providers_input_collection
+        Pageflow.config.available_share_providers.map do |provider|
+          [provider.to_s.camelize, provider]
+        end
+      end
+    end
+  end
+end

--- a/app/views/admin/accounts/_form.html.erb
+++ b/app/views/admin/accounts/_form.html.erb
@@ -36,8 +36,7 @@
         placeholder: Pageflow.config.default_keywords_meta_tag %>
       <%= theming.input :share_providers,
                         as: :check_boxes,
-                        collection: Pageflow.config.available_share_providers,
-                        member_label: Proc.new { |s| s.to_s.camelize } %>
+                        collection: share_providers_input_collection %>
 
     <% end %>
 


### PR DESCRIPTION
Formtastic 3.1 deprecated the member label option. This commit removes
the deprecation notice from the test log by addressing it.

See [1].

REDMINE-17257, REDMINE-17277

[1] https://github.com/justinfrench/formtastic/blob/master/DEPRECATIONS#L14