### PR TITLE
Improve support for Webpack setup in host appplication

### DIFF
--- a/bin/build-edge
+++ b/bin/build-edge
@@ -1,9 +1,18 @@
 #!/bin/bash
 
+add_and_commit() {
+  git add -f $@
+  git commit $@ -m "Build"
+}
+
 set -ex
 
 yarn install --frozen-lockfile
-./build-packages
+bin/build-packages
 
-git add -f app/assets/javascripts/pageflow/dist/{react-*,editor}.js
-git commit app/assets/javascripts/pageflow/dist/{react-*,editor}.js -m "Build"
+add_and_commit \
+    app/assets/javascripts/pageflow/dist/{react-*,editor,ui,frontend}.js \
+    packages/pageflow/{editor,ui}.js \
+    entry_types/paged/app/assets/javascripts/pageflow_paged/dist/editor.js \
+    entry_types/scrolled/package/{editor,frontend}.js \
+

--- a/doc/contributing/node_package_development.md
+++ b/doc/contributing/node_package_development.md
@@ -39,6 +39,36 @@ The Weback built for `pageflow-react` needs to be started separately:
     $ cd packages/pageflow-react
     $ yarn start
 
+### Using Local Packages in a Host Application
+
+To temporarily use a your local version of a package in a host
+application, first run `yarn link` in the package directory:
+
+    $ cd my-projects/pageflow/packages/pageflow
+    $ yarn link
+
+or
+
+    $ cd my-projects/entry_types/scrolled/package
+    $ yarn link
+
+In the host application run:
+
+    $ cd my-projects/pageflow-host-app
+    $ yarn link pageflow
+
+or
+
+    $ cd my-projects/pageflow-host-app
+    $ yarn link pageflow-scrolled
+
+Restart the development servers. Note that development watchers need
+to be running for the pageflow repository.
+
+You can return to using the version specified in the `package.json`
+file, by running `yarn unlink pageflow`/`yarn unlink
+pageflow-scrolled` and `yarn install --force`.
+
 ### Building for Release
 
 To output a production ready build, run from the repository run:

--- a/entry_types/scrolled/package/package.json
+++ b/entry_types/scrolled/package/package.json
@@ -7,10 +7,12 @@
   "author": "Codevise Solutions GmbH <info@codevise.de>",
   "license": "MIT",
   "dependencies": {
-    "pageflow": "15.1.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-tooltip": "^3.11.1"
+  },
+  "peerDependencies": {
+    "pageflow": "15.1.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "2.x",

--- a/packages/pageflow/config/webpack.js
+++ b/packages/pageflow/config/webpack.js
@@ -1,0 +1,15 @@
+module.exports = {
+  externals: {
+    'backbone': 'Backbone',
+    'backbone.babysitter': 'Backbone.ChildViewContainer',
+    'cocktail': 'Cocktail',
+    'jquery': 'jQuery',
+    'jquery-ui': 'jQuery',
+    'jquery.minicolors': 'jQuery',
+    'underscore': '_',
+    'backbone.marionette': 'Backbone.Marionette',
+    'i18n-js': 'I18n',
+    'iscroll': 'IScroll',
+    'wysihtml5': 'wysihtml5'
+  }
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -52,6 +52,7 @@ const plugins = [
   }),
   babel({
     exclude: 'node_modules/**',
+    extensions: ['js', 'jsx', 'svg'],
 
     // By default rollup-plugin-babel deduplicates runtime helpers
     // inserted by Babel. babel-preset-react-app uses


### PR DESCRIPTION
* Update `bin/build-edge` script to include all build outputs

* Turn pageflow into peer dependency of scrolled package

* Provide Webpack config fragment in pageflow package

* Improve handling of svg files in Rollup build

REDMINE-17274