### PR TITLE
Do not force host application to install Webpacker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,10 +23,16 @@ group :development do
 end
 
 # Required to make imports in Active Admin stylesheet work
-gem 'sassc-rails', '~> 1.0'
+gem 'sassc-rails'
 
 # Required for XML serialization in Active Admin
 gem 'activemodel-serializers-xml'
+
+# Make webpacker available in specs. Host applications that want to
+# use webpacker need to add it to their Gemfile themselves. Requiring
+# webpacker in an engine file (like we normally do) would force all
+# host application to install webpacker.
+gem 'webpacker'
 
 # Make tests fail on JS errors
 gem 'capybara-chromedriver-logger', git: 'https://github.com/codevise/capybara-chromedriver-logger', branch: 'do-not-raise-on-filtered-errors', require: false

--- a/entry_types/scrolled/lib/pageflow_scrolled/engine.rb
+++ b/entry_types/scrolled/lib/pageflow_scrolled/engine.rb
@@ -1,5 +1,3 @@
-require 'webpacker'
-
 module PageflowScrolled
   # Rails integration
   class Engine < ::Rails::Engine


### PR DESCRIPTION
Soon as Webpacker is required, it starts complaining if the host
application does not have files like `config/webpacker.yaml`. Since,
for now, Webpacker is only required when using the scrolled entry
type, we let Bundler require it by adding an entry to the `Gemfile`.

This makes sure it is required at the right moment to define its Rails
helpers etc.

We leave the `gemspec` entry to make sure host application use a
compatible version if they decide to use Webpacker.

Remove version string from `sassc-rails` Gemfile entry to remove
warning about duplicate entries.