### PR TITLE
Updated active admin to 2.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development do
 end
 
 # Required to make imports in Active Admin stylesheet work
-gem 'sassc-rails'
+gem 'sassc-rails', '~> 2.1'
 
 # Required for XML serialization in Active Admin
 gem 'activemodel-serializers-xml'
@@ -34,3 +34,7 @@ gem 'webpacker'
 
 # Make tests fail on JS errors
 gem 'capybara-chromedriver-logger', git: 'https://github.com/codevise/capybara-chromedriver-logger', branch: 'do-not-raise-on-filtered-errors', require: false
+
+# temporary fix, so that we dont have to upgrade ruby version
+gem 'inherited_resources', '~> 1.9.0'
+gem 'responders', '~> 2.4.1'

--- a/Gemfile
+++ b/Gemfile
@@ -20,9 +20,6 @@ group :development do
   gem 'listen'
 end
 
-# Required to make imports in Active Admin stylesheet work
-gem 'sassc-rails', '~> 2.1'
-
 # Required for XML serialization in Active Admin
 gem 'activemodel-serializers-xml'
 
@@ -34,7 +31,3 @@ gem 'webpacker'
 
 # Make tests fail on JS errors
 gem 'capybara-chromedriver-logger', git: 'https://github.com/codevise/capybara-chromedriver-logger', branch: 'do-not-raise-on-filtered-errors', require: false
-
-# temporary fix, so that we dont have to upgrade ruby version
-gem 'inherited_resources', '~> 1.9.0'
-gem 'responders', '~> 2.4.1'

--- a/app/assets/stylesheets/pageflow/admin/embedded_index_table.scss
+++ b/app/assets/stylesheets/pageflow/admin/embedded_index_table.scss
@@ -1,6 +1,6 @@
 .embedded_index_table {
   .sortable a {
-    background: url("/assets/active_admin/orderable.png") no-repeat 100% 2px;
+    background: url($orderable-icon-url) no-repeat 100% 2px;
     padding-right: 13px;
   }
 

--- a/app/assets/stylesheets/pageflow/admin/embedded_index_table.scss
+++ b/app/assets/stylesheets/pageflow/admin/embedded_index_table.scss
@@ -1,3 +1,7 @@
+//since activeadmin 2.5.0 depends on ruby 2.4
+//this is a temporary fix to use activeadmin < 2.5 for supporting ruby 2.3
+$orderable-icon-url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAABGCAYAAAAAVo4aAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAH5JREFUeNpi3LhlOwMU1AExGxDXwARYoHQLEFdD2cxAXAliMKFJgEAFEHfBJEHGMKLhMpgkTsAEdch/NNwCk2xCdiEQtML4LEgCf6EubUX3Cgh0oNvJ+P//f7wOGpUclRwYSZb41CyidNbB8giNM+9oXhmVHHm5bJjUSAABBgDKKiwMMUxPwgAAAABJRU5ErkJggg==" !default;
+
 .embedded_index_table {
   .sortable a {
     background: url($orderable-icon-url) no-repeat 100% 2px;

--- a/lib/generators/pageflow/active_admin_initializer/active_admin_initializer_generator.rb
+++ b/lib/generators/pageflow/active_admin_initializer/active_admin_initializer_generator.rb
@@ -7,7 +7,7 @@ module Pageflow
 
       def configure_active_admin_load_path
         prepend_to_file 'config/initializers/active_admin.rb' do
-          "ActiveAdmin.application.load_paths.unshift(Pageflow.active_admin_load_path)\n\n"
+          "ActiveAdmin.application.load_paths += [Pageflow.active_admin_load_path]\n\n"
         end
       end
 

--- a/lib/generators/pageflow/assets/assets_generator.rb
+++ b/lib/generators/pageflow/assets/assets_generator.rb
@@ -16,8 +16,8 @@ module Pageflow
 
         template 'components.js', 'app/assets/javascripts/components.js'
 
-        append_to_file 'app/assets/javascripts/active_admin.js.coffee' do
-          "#= require pageflow/admin\n"
+        append_to_file 'app/assets/javascripts/active_admin.js' do
+          "//= require pageflow/admin\n"
         end
 
         append_to_file 'app/assets/stylesheets/active_admin.scss' do

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 5.2.0'
 
   # Framework for admin interface
-  s.add_dependency 'activeadmin', '~> 1.3.0'
+  s.add_dependency 'activeadmin', '~> 2.5.0'
 
   # Searchable select boxes for filters and forms
   s.add_dependency 'activeadmin-searchable_select', '~> 1.0'
@@ -141,7 +141,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'redis-namespace', '~> 1.5'
 
   # Faster scss compilation
-  s.add_development_dependency 'sassc-rails', '~> 1.0'
+  s.add_development_dependency 'sassc-rails', '~> 2.1'
 
   # Testing framework
   s.add_development_dependency 'rspec-rails', '~> 3.4'

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 5.2.0'
 
   # Framework for admin interface
-  s.add_dependency 'activeadmin', '~> 2.5.0'
+  s.add_dependency 'activeadmin', ['>= 1.3.0', '< 3']
 
   # Searchable select boxes for filters and forms
   s.add_dependency 'activeadmin-searchable_select', '~> 1.0'

--- a/spec/generators/pageflow/active_admin_initializer/active_admin_initializer_spec.rb
+++ b/spec/generators/pageflow/active_admin_initializer/active_admin_initializer_spec.rb
@@ -17,7 +17,7 @@ module Pageflow
         run_generator
         initializer = file('config/initializers/active_admin.rb')
         expect(initializer)
-          .to contain("ActiveAdmin.application.load_paths.unshift(Pageflow.active_admin_load_path)\n\n")
+          .to contain("ActiveAdmin.application.load_paths += [Pageflow.active_admin_load_path]\n\n")
       end
     end
   end

--- a/spec/generators/pageflow/assets/assets_generator_spec.rb
+++ b/spec/generators/pageflow/assets/assets_generator_spec.rb
@@ -12,7 +12,7 @@ module Pageflow
         FileUtils.mkdir_p "#{destination_root}/app/assets/stylesheets"
         FileUtils.mkdir_p "#{destination_root}/config"
 
-        FileUtils.touch "#{destination_root}/app/assets/javascripts/active_admin.js.coffee"
+        FileUtils.touch "#{destination_root}/app/assets/javascripts/active_admin.js"
         FileUtils.touch "#{destination_root}/app/assets/stylesheets/active_admin.scss"
         FileUtils.touch "#{destination_root}/config/application.rb"
       end
@@ -31,8 +31,8 @@ module Pageflow
 
       it 'requires pageflow in active_admin JavaScript' do
         run_generator
-        asset = file('app/assets/javascripts/active_admin.js.coffee')
-        expect(asset).to contain("#= require pageflow/admin\n")
+        asset = file('app/assets/javascripts/active_admin.js')
+        expect(asset).to contain("//= require pageflow/admin\n")
       end
 
       it 'requires pageflow in active_admin SCSS' do

--- a/spec/support/pageflow-support.gemspec
+++ b/spec/support/pageflow-support.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'redis', '~> 3.0'
   s.add_runtime_dependency 'redis-namespace', '~> 1.5'
 
-  s.add_runtime_dependency 'sassc-rails', '~> 1.0'
+  s.add_runtime_dependency 'sassc-rails', '~> 2.1'
 end


### PR DESCRIPTION
REDMINE-17241

- All coffee scripts are removed and should not be added again. if it is required then coffee-rails gem should be included.
- Active admin load_paths are added using the setter `+=` instead of `unshift` method as a workaround to activeadmin initialisation order [issue](https://github.com/activeadmin/activeadmin/issues/5995)
