### PR TITLE
Decouple editor layout

### DIFF
--- a/app/controllers/pageflow/editor/entries_controller.rb
+++ b/app/controllers/pageflow/editor/entries_controller.rb
@@ -1,6 +1,8 @@
 module Pageflow
   module Editor
     class EntriesController < Pageflow::ApplicationController
+      layout 'pageflow/editor'
+
       respond_to :json
 
       before_action :authenticate_user!

--- a/app/views/layouts/pageflow/editor.html.erb
+++ b/app/views/layouts/pageflow/editor.html.erb
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<%= content_tag(:html, lang: I18n.locale, dir: @page_text_direction) do %>
+<head>
+  <title><%= @page_title.presence || 'Pageflow' %></title>
+
+  <script>
+    window.PAGEFLOW_EDITOR = <%= @editor_scope ? 'true' : 'false' %>;
+  </script>
+
+  <%= javascript_include_tag 'pageflow/vendor', 'data-turbolinks-track' => true %>
+  <%= javascript_include_tag 'pageflow/application', 'data-turbolinks-track' => true %>
+
+  <%= csrf_meta_tags %>
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, minimum-scale=1, maximum-scale=1" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+
+  <%= yield :head %>
+
+  <%= stylesheet_link_tag 'pageflow/print_view', media: 'print', 'data-turbolinks-track' => true %>
+  <%= render 'layouts/pageflow/loading_spinner_inline_script' %>
+
+  <%= render 'layouts/pageflow/ie_include_tags' %>
+</head>
+
+<body class="load_all_images has_no_mobile_platform non_js">
+  <script>
+    jQuery('body').removeClass('load_all_images');
+    jQuery("body").removeClass('non_js').addClass('js');
+  </script>
+  <%= yield %>
+  <%= render 'layouts/pageflow/theme_probes' %>
+</body>
+<% end %>

--- a/app/views/layouts/pageflow/editor.html.erb
+++ b/app/views/layouts/pageflow/editor.html.erb
@@ -3,20 +3,12 @@
 <head>
   <title><%= @page_title.presence || 'Pageflow' %></title>
 
-  <script>
-    window.PAGEFLOW_EDITOR = <%= @editor_scope ? 'true' : 'false' %>;
-  </script>
-
-  <%= javascript_include_tag 'pageflow/vendor', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'pageflow/application', 'data-turbolinks-track' => true %>
-
   <%= csrf_meta_tags %>
+
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, minimum-scale=1, maximum-scale=1" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
 
   <%= yield :head %>
-
-  <%= render 'layouts/pageflow/ie_include_tags' %>
 </head>
 
 <body class="js">

--- a/app/views/layouts/pageflow/editor.html.erb
+++ b/app/views/layouts/pageflow/editor.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<%= content_tag(:html, lang: I18n.locale, dir: @page_text_direction) do %>
+<%= content_tag(:html, lang: I18n.locale) do %>
 <head>
   <title><%= @page_title.presence || 'Pageflow' %></title>
 
@@ -16,17 +16,10 @@
 
   <%= yield :head %>
 
-  <%= stylesheet_link_tag 'pageflow/print_view', media: 'print', 'data-turbolinks-track' => true %>
-  <%= render 'layouts/pageflow/loading_spinner_inline_script' %>
-
   <%= render 'layouts/pageflow/ie_include_tags' %>
 </head>
 
-<body class="load_all_images has_no_mobile_platform non_js">
-  <script>
-    jQuery('body').removeClass('load_all_images');
-    jQuery("body").removeClass('non_js').addClass('js');
-  </script>
+<body class="js">
   <%= yield %>
   <%= render 'layouts/pageflow/theme_probes' %>
 </body>

--- a/app/views/pageflow/editor/entries/show.html.erb
+++ b/app/views/pageflow/editor/entries/show.html.erb
@@ -1,10 +1,10 @@
 <% @editor_scope = true %>
 
 <% content_for(:head) do %>
-    <%= stylesheet_link_tag('pageflow/application_with_simulated_media_queries', media: 'all', 'data-turbolinks-track' => true) %>
-    <%= entry_theme_stylesheet_link_tag(@entry) %>
-    <%= entry_stylesheet_link_tag(@entry) %>
-    <%= editor_entry_type_fragment(@entry, :head) %>
+  <%= editor_entry_type_fragment(@entry, :head) %>
+
+  <%= entry_theme_stylesheet_link_tag(@entry) %>
+  <%= entry_stylesheet_link_tag(@entry) %>
 <% end %>
 
 <main class="ui-layout-center">

--- a/entry_types/paged/app/views/pageflow_paged/editor/entries/_head.html.erb
+++ b/entry_types/paged/app/views/pageflow_paged/editor/entries/_head.html.erb
@@ -1,2 +1,12 @@
-<%= stylesheet_link_tag 'pageflow_paged/editor', media: "all" %>
+<%= stylesheet_link_tag 'pageflow/application_with_simulated_media_queries', media: 'all' %>
+<%= stylesheet_link_tag 'pageflow_paged/editor', media: 'all' %>
+
+<script>
+  window.PAGEFLOW_EDITOR = true;
+</script>
+
+<%= javascript_include_tag 'pageflow/vendor' %>
+<%= javascript_include_tag 'pageflow/application' %>
 <%= javascript_include_tag 'pageflow_paged/editor' %>
+
+<%= render 'layouts/pageflow/ie_include_tags' %>

--- a/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
@@ -1,3 +1,7 @@
-<%= stylesheet_link_tag 'pageflow_paged/editor', media: "all" %>
+<%= stylesheet_link_tag 'pageflow_paged/editor', media: 'all' %>
+
+<%= javascript_include_tag 'pageflow/vendor' %>
+<%# Next line can be removed once remaining mentions of pageflow global in editor are removed %>
+<%= javascript_include_tag 'pageflow/application' %>
 <%= javascript_include_tag 'pageflow/editor/vendor' %>
 <%= javascript_pack_tag 'pageflow-scrolled-editor' %>


### PR DESCRIPTION
Before published entries and the editor used the same layout. This will let us work with a simplified layout for the editor, move the previous application layout to the entry type engine.

REDMINE-17269