### PR TITLE
Render raw html in text block content items

### DIFF
--- a/entry_types/scrolled/package/src/frontend/TextBlock.js
+++ b/entry_types/scrolled/package/src/frontend/TextBlock.js
@@ -5,6 +5,8 @@ import styles from './TextBlock.module.css';
 
 export default function TextBlock(props) {
   return (
-    <div className={classNames(styles.TextBlock, {[styles.dummy]: props.dummy})} style={props.style}>{props.children}</div>
+    <div className={classNames(styles.TextBlock, {[styles.dummy]: props.dummy})}
+         style={props.style}
+         dangerouslySetInnerHTML={{__html: props.children}} />
   );
 }


### PR DESCRIPTION
Turned from React fragments into HTML strings during migration from
`example.js` to DB seeds.

REDMINE-17260