### PR TITLE
Set PAGEFLOW_EDITOR global in scrolled editor

### DIFF
--- a/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
@@ -1,7 +1,12 @@
 <%= stylesheet_link_tag 'pageflow_paged/editor', media: 'all' %>
 
 <%= javascript_include_tag 'pageflow/vendor' %>
-<%# Next line can be removed once remaining mentions of pageflow global in editor are removed %>
+
+<%# Can be removed once remaining mentions of pageflow global in editor are removed %>
+<script>
+  window.PAGEFLOW_EDITOR = true;
+</script>
 <%= javascript_include_tag 'pageflow/application' %>
+
 <%= javascript_include_tag 'pageflow/editor/vendor' %>
 <%= javascript_pack_tag 'pageflow-scrolled-editor' %>


### PR DESCRIPTION
Follow up for #1284. As long as we still load the paged js in the
editor, this global has to be set.

REDMINE-17269