### PR TITLE
Add needed command to node package development docs

### DIFF
--- a/doc/contributing/node_package_development.md
+++ b/doc/contributing/node_package_development.md
@@ -47,7 +47,7 @@ application, first run `yarn link` in the package directory:
     $ cd my-projects/pageflow/packages/pageflow
     $ yarn link
 
-or
+and
 
     $ cd my-projects/entry_types/scrolled/package
     $ yarn link
@@ -57,13 +57,14 @@ In the host application run:
     $ cd my-projects/pageflow-host-app
     $ yarn link pageflow
 
-or
+and
 
     $ cd my-projects/pageflow-host-app
     $ yarn link pageflow-scrolled
 
 Restart the development servers. Note that development watchers need
-to be running for the pageflow repository.
+to be running for the pageflow repository. Run `yarn install` in the
+host application.
 
 You can return to using the version specified in the `package.json`
 file, by running `yarn unlink pageflow`/`yarn unlink


### PR DESCRIPTION
When linking a local pageflow gem from a host application (for the
first time?), we need to run `yarn install` in the host application to
pick up the linked packages in a way that doesn't let the app crash.

Also, this replaces two 'or' by 'and', because 'or' confused me as to
which order would be valid.

REDMINE-17257