### PR TITLE
Fix scrolled entry json seed spec

### DIFF
--- a/spec/factories/published_entries.rb
+++ b/spec/factories/published_entries.rb
@@ -2,7 +2,7 @@ module Pageflow
   FactoryBot.define do
     factory :published_entry, class: PublishedEntry do
       transient do
-        type_name { nil }
+        type_name { 'paged' }
       end
 
       initialize_with do


### PR DESCRIPTION
Set `type_name` of `published_entry` factory to `paged`. Previous
`nil` value caused error when trying to construct entry type specic
config.

REDMINE-17257