### PR TITLE
Prevent including pageflow/ui in pageflow/editor

### DIFF
--- a/packages/pageflow/jest.config.js
+++ b/packages/pageflow/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
   modulePaths: ["<rootDir>/src"],
   moduleNameMapper: {
     "^\\$support(.*)$": "<rootDir>/spec/support$1",
-    "^\\$pageflow(.*)$": "<rootDir>/src$1",
+    "^\\pageflow/(.*)$": "<rootDir>/src/$1",
     "^\\$state$": "<rootDir>/spec/support/state.js",
 
     ...moduleNameMapper

--- a/packages/pageflow/spec/editor/api-spec.js
+++ b/packages/pageflow/spec/editor/api-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {EditorApi} from '$pageflow/editor';
+import {EditorApi} from 'pageflow/editor';
 import {state} from '$state';
 
 import sinon from 'sinon';

--- a/packages/pageflow/spec/editor/api/FileTypes-spec.js
+++ b/packages/pageflow/spec/editor/api/FileTypes-spec.js
@@ -1,9 +1,9 @@
 import _ from 'underscore';
 
-import {TextInputView, TextTableCellView} from '$pageflow/ui';
+import {TextInputView, TextTableCellView} from 'pageflow/ui';
 
-import {ImageFile, TextTrackFile, VideoFile} from '$pageflow/editor';
-import {FileTypes} from '$pageflow/editor/api/FileTypes';
+import {ImageFile, TextTrackFile, VideoFile} from 'pageflow/editor';
+import {FileTypes} from 'pageflow/editor/api/FileTypes';
 
 describe('FileTypes', () => {
   describe('#register/#setup', () => {

--- a/packages/pageflow/spec/editor/api/PageTypes-spec.js
+++ b/packages/pageflow/spec/editor/api/PageTypes-spec.js
@@ -1,5 +1,5 @@
-import {Page} from '$pageflow/editor';
-import {PageTypes} from '$pageflow/editor/api/PageTypes';
+import {Page} from 'pageflow/editor';
+import {PageTypes} from 'pageflow/editor/api/PageTypes';
 
 
 describe('PageTypes', () => {

--- a/packages/pageflow/spec/editor/api/WidgetTypes-spec.js
+++ b/packages/pageflow/spec/editor/api/WidgetTypes-spec.js
@@ -1,4 +1,4 @@
-import {WidgetTypes} from '$pageflow/editor/api/WidgetTypes';
+import {WidgetTypes} from 'pageflow/editor/api/WidgetTypes';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/editor/api/failuresApi-spec.js
+++ b/packages/pageflow/spec/editor/api/failuresApi-spec.js
@@ -1,7 +1,7 @@
 import Backbone from 'backbone';
 
-import {EditorApi} from '$pageflow/editor';
-import {Failure} from '$pageflow/editor/api/Failure';
+import {EditorApi} from 'pageflow/editor';
+import {Failure} from 'pageflow/editor/api/Failure';
 
 describe('Failures API', () => {
   describe('#add', () => {

--- a/packages/pageflow/spec/editor/collections/FilesCollection-spec.js
+++ b/packages/pageflow/spec/editor/collections/FilesCollection-spec.js
@@ -1,4 +1,4 @@
-import {FilesCollection} from '$pageflow/editor';
+import {FilesCollection} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/collections/NestedFilesCollection-spec.js
+++ b/packages/pageflow/spec/editor/collections/NestedFilesCollection-spec.js
@@ -1,4 +1,4 @@
-import {NestedFilesCollection} from '$pageflow/editor';
+import {NestedFilesCollection} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/collections/SubsetCollection-spec.js
+++ b/packages/pageflow/spec/editor/collections/SubsetCollection-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {SubsetCollection} from '$pageflow/editor';
+import {SubsetCollection} from 'pageflow/editor';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/editor/collections/chapterPagesCollection-spec.js
+++ b/packages/pageflow/spec/editor/collections/chapterPagesCollection-spec.js
@@ -1,4 +1,4 @@
-import {Chapter, PagesCollection, Page} from '$pageflow/editor';
+import {Chapter, PagesCollection, Page} from 'pageflow/editor';
 
 describe('ChapterPagesCollection', () => {
   it('filters pages by chapter', () => {

--- a/packages/pageflow/spec/editor/collections/fileTypesCollection-spec.js
+++ b/packages/pageflow/spec/editor/collections/fileTypesCollection-spec.js
@@ -1,5 +1,5 @@
-import {ImageFile, UnmatchedUploadError, VideoFile} from '$pageflow/editor';
-import {FileTypes} from '$pageflow/editor/api/FileTypes';
+import {ImageFile, UnmatchedUploadError, VideoFile} from 'pageflow/editor';
+import {FileTypes} from 'pageflow/editor/api/FileTypes';
 
 describe('FileTypesCollection', () => {
   describe('#findByUpload', () => {

--- a/packages/pageflow/spec/editor/collections/mixins/orderedCollection-spec.js
+++ b/packages/pageflow/spec/editor/collections/mixins/orderedCollection-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {orderedCollection} from '$pageflow/editor';
+import {orderedCollection} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/models/Entry-spec.js
+++ b/packages/pageflow/spec/editor/models/Entry-spec.js
@@ -1,7 +1,7 @@
 import Backbone from 'backbone';
 import _ from 'underscore';
 
-import {FilesCollection, ImageFile, ThemesCollection} from '$pageflow/editor';
+import {FilesCollection, ImageFile, ThemesCollection} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/models/FileImport-spec.js
+++ b/packages/pageflow/spec/editor/models/FileImport-spec.js
@@ -4,7 +4,7 @@ import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 import * as support from '$support';
 
-import {app, FileImport, editor, authenticationProvider} from '$pageflow/editor';
+import {app, FileImport, editor, authenticationProvider} from 'pageflow/editor';
 
 describe('FileImport', () => {
   let testContext;

--- a/packages/pageflow/spec/editor/models/FileStage-spec.js
+++ b/packages/pageflow/spec/editor/models/FileStage-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {FileStage} from '$pageflow/editor';
+import {FileStage} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/models/FileUploader-spec.js
+++ b/packages/pageflow/spec/editor/models/FileUploader-spec.js
@@ -1,4 +1,4 @@
-import {EditorApi, FileUploader, FilesCollection, ImageFile, InvalidNestedTypeError, NestedTypeError, TextTrackFile} from '$pageflow/editor';
+import {EditorApi, FileUploader, FilesCollection, ImageFile, InvalidNestedTypeError, NestedTypeError, TextTrackFile} from 'pageflow/editor';
 
 import * as support from '$support';
 import sinon from 'sinon';

--- a/packages/pageflow/spec/editor/models/OtherEntry-spec.js
+++ b/packages/pageflow/spec/editor/models/OtherEntry-spec.js
@@ -1,4 +1,4 @@
-import {OtherEntry} from '$pageflow/editor';
+import {OtherEntry} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/models/Page-spec.js
+++ b/packages/pageflow/spec/editor/models/Page-spec.js
@@ -1,4 +1,4 @@
-import {FilesCollection, Page, editor} from '$pageflow/editor';
+import {FilesCollection, Page, editor} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/models/PreviewEntryData-spec.js
+++ b/packages/pageflow/spec/editor/models/PreviewEntryData-spec.js
@@ -1,4 +1,4 @@
-import {ChaptersCollection, Chapter, FilesCollection, PagesCollection, Page, PreviewEntryData, StorylinesCollection, Storyline, ThemesCollection} from '$pageflow/editor';
+import {ChaptersCollection, Chapter, FilesCollection, PagesCollection, Page, PreviewEntryData, StorylinesCollection, Storyline, ThemesCollection} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/models/ReusableFile-spec.js
+++ b/packages/pageflow/spec/editor/models/ReusableFile-spec.js
@@ -1,7 +1,7 @@
 import Backbone from 'backbone';
 
-import {FileTypesCollection, ReusableFile, SubsetCollection} from '$pageflow/editor';
-import {FileType} from '$pageflow/editor/api/FileType';
+import {FileTypesCollection, ReusableFile, SubsetCollection} from 'pageflow/editor';
+import {FileType} from 'pageflow/editor/api/FileType';
 
 import * as support from '$support';
 import sinon from 'sinon';

--- a/packages/pageflow/spec/editor/models/StorylineOrdering-spec.js
+++ b/packages/pageflow/spec/editor/models/StorylineOrdering-spec.js
@@ -1,4 +1,4 @@
-import {ChaptersCollection, PagesCollection, StorylineOrdering, StorylinesCollection} from '$pageflow/editor';
+import {ChaptersCollection, PagesCollection, StorylineOrdering, StorylinesCollection} from 'pageflow/editor';
 
 describe('pageflow.StorylineOrdering', () => {
   describe('#sort', () => {

--- a/packages/pageflow/spec/editor/models/StorylineTransitiveChildPages-spec.js
+++ b/packages/pageflow/spec/editor/models/StorylineTransitiveChildPages-spec.js
@@ -1,4 +1,4 @@
-import {ChaptersCollection, PagesCollection, StorylineTransitiveChildPages, StorylinesCollection} from '$pageflow/editor';
+import {ChaptersCollection, PagesCollection, StorylineTransitiveChildPages, StorylinesCollection} from 'pageflow/editor';
 
 describe('pageflow.StorylineTransitiveChildPages', () => {
   describe('#contain', () => {

--- a/packages/pageflow/spec/editor/models/TextTrackFile-spec.js
+++ b/packages/pageflow/spec/editor/models/TextTrackFile-spec.js
@@ -1,4 +1,4 @@
-import {TextTrackFile} from '$pageflow/editor';
+import {TextTrackFile} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/models/UploadableFile-spec.js
+++ b/packages/pageflow/spec/editor/models/UploadableFile-spec.js
@@ -1,4 +1,4 @@
-import {UploadableFile} from '$pageflow/editor';
+import {UploadableFile} from 'pageflow/editor';
 
 describe('UploadableFile', () => {
   describe('#processingStages', () => {

--- a/packages/pageflow/spec/editor/models/Widget-spec.js
+++ b/packages/pageflow/spec/editor/models/Widget-spec.js
@@ -1,4 +1,4 @@
-import {Widget} from '$pageflow/editor';
+import {Widget} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/models/mixins/encodedFile-spec.js
+++ b/packages/pageflow/spec/editor/models/mixins/encodedFile-spec.js
@@ -1,4 +1,4 @@
-import {VideoFile} from '$pageflow/editor';
+import {VideoFile} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/models/mixins/filesCountWatcher-spec.js
+++ b/packages/pageflow/spec/editor/models/mixins/filesCountWatcher-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {FilesCollection, ReusableFile, filesCountWatcher} from '$pageflow/editor';
+import {FilesCollection, ReusableFile, filesCountWatcher} from 'pageflow/editor';
 
 describe('filesCountWatcher', () => {
   var Model = Backbone.Model.extend({

--- a/packages/pageflow/spec/editor/models/mixins/stageProvider-spec.js
+++ b/packages/pageflow/spec/editor/models/mixins/stageProvider-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {stageProvider} from '$pageflow/editor';
+import {stageProvider} from 'pageflow/editor';
 
 describe('stageProvider', () => {
   var Model = Backbone.Model.extend({

--- a/packages/pageflow/spec/editor/models/mixins/transientReferences-spec.js
+++ b/packages/pageflow/spec/editor/models/mixins/transientReferences-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {FilesCollection, ImageFile, transientReferences} from '$pageflow/editor';
+import {FilesCollection, ImageFile, transientReferences} from 'pageflow/editor';
 
 import * as support from '$support';
 import sinon from 'sinon';

--- a/packages/pageflow/spec/editor/utils/formDataUtils-spec.js
+++ b/packages/pageflow/spec/editor/utils/formDataUtils-spec.js
@@ -1,7 +1,7 @@
 import Backbone from 'backbone';
 import _ from 'underscore';
 
-import {formDataUtils} from '$pageflow/editor';
+import {formDataUtils} from 'pageflow/editor';
 
 describe('formDataUtils', () => {
   describe('fromObject', () => {

--- a/packages/pageflow/spec/editor/views/ChangeThemeDialogView-spec.js
+++ b/packages/pageflow/spec/editor/views/ChangeThemeDialogView-spec.js
@@ -1,4 +1,4 @@
-import {ChangeThemeDialogView, ThemesCollection} from '$pageflow/editor';
+import {ChangeThemeDialogView, ThemesCollection} from 'pageflow/editor';
 
 import sinon from 'sinon';
 import {ThemeItem} from '$support/dominos/editor';

--- a/packages/pageflow/spec/editor/views/ConfigurationEditorTabView-spec.js
+++ b/packages/pageflow/spec/editor/views/ConfigurationEditorTabView-spec.js
@@ -1,4 +1,4 @@
-import {ConfigurationEditorTabView} from '$pageflow/ui';
+import {ConfigurationEditorTabView} from 'pageflow/ui';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/editor/views/DropDownButtonView-spec.js
+++ b/packages/pageflow/spec/editor/views/DropDownButtonView-spec.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import Backbone from 'backbone';
 
-import {DropDownButtonView} from '$pageflow/editor';
+import {DropDownButtonView} from 'pageflow/editor';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/editor/views/EditEntryView-spec.js
+++ b/packages/pageflow/spec/editor/views/EditEntryView-spec.js
@@ -1,6 +1,6 @@
 import Marionette from 'backbone.marionette';
 
-import {EditEntryView, editor} from '$pageflow/editor';
+import {EditEntryView, editor} from 'pageflow/editor';
 
 import {factories} from '$support';
 

--- a/packages/pageflow/spec/editor/views/EditFileView-spec.js
+++ b/packages/pageflow/spec/editor/views/EditFileView-spec.js
@@ -1,8 +1,8 @@
 import Backbone from 'backbone';
 
-import {TextInputView} from '$pageflow/ui';
+import {TextInputView} from 'pageflow/ui';
 
-import {EditFileView} from '$pageflow/editor';
+import {EditFileView} from 'pageflow/editor';
 
 import * as support from '$support';
 import sinon from 'sinon';

--- a/packages/pageflow/spec/editor/views/EditMetaDataView-spec.js
+++ b/packages/pageflow/spec/editor/views/EditMetaDataView-spec.js
@@ -1,7 +1,7 @@
 import Marionette from 'backbone.marionette';
 
-import {EditMetaDataView, editor} from '$pageflow/editor';
-import {CheckBoxInputView} from '$pageflow/ui';
+import {EditMetaDataView, editor} from 'pageflow/editor';
+import {CheckBoxInputView} from 'pageflow/ui';
 
 import {factories} from '$support';
 

--- a/packages/pageflow/spec/editor/views/EditPageLinkView-spec.js
+++ b/packages/pageflow/spec/editor/views/EditPageLinkView-spec.js
@@ -1,6 +1,6 @@
-import {ConfigurationEditorView, TextInputView} from '$pageflow/ui';
+import {ConfigurationEditorView, TextInputView} from 'pageflow/ui';
 
-import {EditPageLinkView, PageLink, Page} from '$pageflow/editor';
+import {EditPageLinkView, PageLink, Page} from 'pageflow/editor';
 
 import * as support from '$support';
 import {ConfigurationEditor} from '$support/dominos/ui';

--- a/packages/pageflow/spec/editor/views/EditPageView-spec.js
+++ b/packages/pageflow/spec/editor/views/EditPageView-spec.js
@@ -1,6 +1,6 @@
-import {ConfigurationEditorView, TextInputView} from '$pageflow/ui';
+import {ConfigurationEditorView, TextInputView} from 'pageflow/ui';
 
-import {EditPageView, Page} from '$pageflow/editor';
+import {EditPageView, Page} from 'pageflow/editor';
 
 import * as support from '$support';
 import {ConfigurationEditor} from '$support/dominos/ui';

--- a/packages/pageflow/spec/editor/views/EditWidgetView-spec.js
+++ b/packages/pageflow/spec/editor/views/EditWidgetView-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {Widget, EditWidgetView} from '$pageflow/editor';
+import {Widget, EditWidgetView} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/views/FileItemView-spec.js
+++ b/packages/pageflow/spec/editor/views/FileItemView-spec.js
@@ -1,4 +1,4 @@
-import {FileItemView, FileMetaDataItemValueView} from '$pageflow/editor';
+import {FileItemView, FileMetaDataItemValueView} from 'pageflow/editor';
 
 import * as support from '$support';
 import {FileMetaDataTable} from '$support/dominos/editor';

--- a/packages/pageflow/spec/editor/views/FileMetaDataItemView-spec.js
+++ b/packages/pageflow/spec/editor/views/FileMetaDataItemView-spec.js
@@ -1,4 +1,4 @@
-import {FileMetaDataItemView} from '$pageflow/editor';
+import {FileMetaDataItemView} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/views/FileSettingsDialogView-spec.js
+++ b/packages/pageflow/spec/editor/views/FileSettingsDialogView-spec.js
@@ -1,6 +1,6 @@
-import {TextInputView} from '$pageflow/ui';
+import {TextInputView} from 'pageflow/ui';
 
-import {FileSettingsDialogView} from '$pageflow/editor';
+import {FileSettingsDialogView} from 'pageflow/editor';
 
 import * as support from '$support';
 import {Tabs} from '$support/dominos/ui';

--- a/packages/pageflow/spec/editor/views/ModelThumbnailView-spec.js
+++ b/packages/pageflow/spec/editor/views/ModelThumbnailView-spec.js
@@ -1,4 +1,4 @@
-import {ModelThumbnailView} from '$pageflow/editor';
+import {ModelThumbnailView} from 'pageflow/editor';
 
 import * as support from '$support';
 import {FileThumbnail, StaticThumbnail} from '$support/dominos/editor';

--- a/packages/pageflow/spec/editor/views/NestedFilesView-spec.js
+++ b/packages/pageflow/spec/editor/views/NestedFilesView-spec.js
@@ -1,8 +1,8 @@
 import Backbone from 'backbone';
 
-import {TextTableCellView} from '$pageflow/ui';
+import {TextTableCellView} from 'pageflow/ui';
 
-import {NestedFilesView} from '$pageflow/editor';
+import {NestedFilesView} from 'pageflow/editor';
 
 import * as support from '$support';
 import {Table} from '$support/dominos/ui';

--- a/packages/pageflow/spec/editor/views/TextTracksFileMetaDataItemValueView-spec.js
+++ b/packages/pageflow/spec/editor/views/TextTracksFileMetaDataItemValueView-spec.js
@@ -1,4 +1,4 @@
-import {TextTracksFileMetaDataItemValueView} from '$pageflow/editor';
+import {TextTracksFileMetaDataItemValueView} from 'pageflow/editor';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/editor/views/UploadableFilesView-spec.js
+++ b/packages/pageflow/spec/editor/views/UploadableFilesView-spec.js
@@ -1,8 +1,8 @@
 import Backbone from 'backbone';
 
-import {TextTableCellView} from '$pageflow/ui';
+import {TextTableCellView} from 'pageflow/ui';
 
-import {UploadableFilesView} from '$pageflow/editor';
+import {UploadableFilesView} from 'pageflow/editor';
 
 import * as support from '$support';
 import {Table} from '$support/dominos/ui';

--- a/packages/pageflow/spec/editor/views/WidgetItemView-spec.js
+++ b/packages/pageflow/spec/editor/views/WidgetItemView-spec.js
@@ -1,4 +1,4 @@
-import {Widget,WidgetItemView} from '$pageflow/editor';
+import {Widget,WidgetItemView} from 'pageflow/editor';
 
 import * as support from '$support';
 import {SelectInput} from '$support/dominos/ui';

--- a/packages/pageflow/spec/editor/views/inputs/FileInputView-spec.js
+++ b/packages/pageflow/spec/editor/views/inputs/FileInputView-spec.js
@@ -1,4 +1,4 @@
-import {Configuration, FileInputView} from '$pageflow/editor';
+import {Configuration, FileInputView} from 'pageflow/editor';
 
 import * as support from '$support';
 import {DropDownButton} from '$support/dominos/editor';

--- a/packages/pageflow/spec/editor/views/inputs/FileProcessingStateDisplay-spec.js
+++ b/packages/pageflow/spec/editor/views/inputs/FileProcessingStateDisplay-spec.js
@@ -1,4 +1,4 @@
-import {Configuration, FileProcessingStateDisplayView} from '$pageflow/editor';
+import {Configuration, FileProcessingStateDisplayView} from 'pageflow/editor';
 
 import * as support from '$support';
 import {FileStageItem} from '$support/dominos/editor';

--- a/packages/pageflow/spec/editor/views/inputs/ReferenceInputView-spec.js
+++ b/packages/pageflow/spec/editor/views/inputs/ReferenceInputView-spec.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import Backbone from 'backbone';
 
-import {ReferenceInputView} from '$pageflow/editor';
+import {ReferenceInputView} from 'pageflow/editor';
 
 import {ReferenceInput} from '$support/dominos/editor';
 

--- a/packages/pageflow/spec/editor/views/inputs/ThemeInputView-spec.js
+++ b/packages/pageflow/spec/editor/views/inputs/ThemeInputView-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {ThemesCollection, app, ThemeInputView} from '$pageflow/editor';
+import {ThemesCollection, app, ThemeInputView} from 'pageflow/editor';
 
 import {ReferenceInput, ThemeItem} from '$support/dominos/editor';
 

--- a/packages/pageflow/spec/frontend/audio/multi_player_spec.js
+++ b/packages/pageflow/spec/frontend/audio/multi_player_spec.js
@@ -1,6 +1,6 @@
 import jQuery from 'jquery';
 
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/frontend/audio/player_pool_spec.js
+++ b/packages/pageflow/spec/frontend/audio/player_pool_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/frontend/audio_spec.js
+++ b/packages/pageflow/spec/frontend/audio_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/frontend/browser/agent_spec.js
+++ b/packages/pageflow/spec/frontend/browser/agent_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 describe('pageflow.browser.Agent', function() {
   var Agent = pageflow.browser.Agent;

--- a/packages/pageflow/spec/frontend/chapter_filter_spec.js
+++ b/packages/pageflow/spec/frontend/chapter_filter_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 describe('pageflow.ChapterFilter', function() {
   var p = pageflow;

--- a/packages/pageflow/spec/frontend/delayed_start_spec.js
+++ b/packages/pageflow/spec/frontend/delayed_start_spec.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/frontend/entry_data_spec.js
+++ b/packages/pageflow/spec/frontend/entry_data_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 describe('pageflow.EntryData', function() {
   var p = pageflow;

--- a/packages/pageflow/spec/frontend/features_spec.js
+++ b/packages/pageflow/spec/frontend/features_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/frontend/highlighted_page_spec.js
+++ b/packages/pageflow/spec/frontend/highlighted_page_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 describe('pageflow.HighlightedPage', function() {
   var p = pageflow;

--- a/packages/pageflow/spec/frontend/media_player/async_play_spec.js
+++ b/packages/pageflow/spec/frontend/media_player/async_play_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/frontend/media_player/handle_failed_play_spec.js
+++ b/packages/pageflow/spec/frontend/media_player/handle_failed_play_spec.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import Backbone from 'backbone';
 
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/frontend/media_player/hooks_spec.js
+++ b/packages/pageflow/spec/frontend/media_player/hooks_spec.js
@@ -3,7 +3,7 @@ import Backbone from 'backbone';
 
 import _ from 'underscore';
 
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/frontend/media_player/volume_binding_spec.js
+++ b/packages/pageflow/spec/frontend/media_player/volume_binding_spec.js
@@ -1,7 +1,7 @@
 import jQuery from 'jquery';
 import Backbone from 'backbone';
 
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import sinon from 'sinon';
 

--- a/packages/pageflow/spec/frontend/media_player/volume_fading_spec.js
+++ b/packages/pageflow/spec/frontend/media_player/volume_fading_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import '$support/fakeBrowserFeatures';
 import sinon from 'sinon';

--- a/packages/pageflow/spec/frontend/page_transitions_spec.js
+++ b/packages/pageflow/spec/frontend/page_transitions_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 describe('pageflow.PageTransitions', function() {
   var PageTransitions = pageflow.PageTransitions;

--- a/packages/pageflow/spec/frontend/seed_entry_data_spec.js
+++ b/packages/pageflow/spec/frontend/seed_entry_data_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 describe('pageflow.SeedEntryData', function() {
   var p = pageflow;

--- a/packages/pageflow/spec/frontend/slideshow/adjacent_preloader_spec.js
+++ b/packages/pageflow/spec/frontend/slideshow/adjacent_preloader_spec.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import * as support from '$support';
 import sinon from 'sinon';

--- a/packages/pageflow/spec/frontend/slideshow/atmo_spec.js
+++ b/packages/pageflow/spec/frontend/slideshow/atmo_spec.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import '$support/fakeBrowserFeatures';
 import * as support from '$support';

--- a/packages/pageflow/spec/frontend/slideshow/successor_preparer_spec.js
+++ b/packages/pageflow/spec/frontend/slideshow/successor_preparer_spec.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import * as support from '$support';
 import sinon from 'sinon';

--- a/packages/pageflow/spec/frontend/visited_spec.js
+++ b/packages/pageflow/spec/frontend/visited_spec.js
@@ -1,4 +1,4 @@
-import '$pageflow/frontend';
+import 'pageflow/frontend';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/support/dominos/Base.js
+++ b/packages/pageflow/spec/support/dominos/Base.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 export const Base = Object.extend({
   initialize: function($el) {

--- a/packages/pageflow/spec/support/factories.js
+++ b/packages/pageflow/spec/support/factories.js
@@ -1,9 +1,9 @@
 import Backbone from 'backbone';
 import _ from 'underscore';
 
-import {EditorApi, Entry, FilesCollection, ImageFile, SubsetCollection, TextTrackFile, Theme, VideoFile} from '$pageflow/editor';
-import {WidgetTypes} from '$pageflow/editor/api/WidgetTypes';
-import {FileTypes} from '$pageflow/editor/api/FileTypes';
+import {EditorApi, Entry, FilesCollection, ImageFile, SubsetCollection, TextTrackFile, Theme, VideoFile} from 'pageflow/editor';
+import {WidgetTypes} from 'pageflow/editor/api/WidgetTypes';
+import {FileTypes} from 'pageflow/editor/api/FileTypes';
 
 export const factories = {
   entry: function entry(attributes, options) {

--- a/packages/pageflow/spec/ui/utils/cssModulesUtils-spec.js
+++ b/packages/pageflow/spec/ui/utils/cssModulesUtils-spec.js
@@ -1,4 +1,4 @@
-import {cssModulesUtils} from '$pageflow/ui';
+import {cssModulesUtils} from 'pageflow/ui';
 
 describe('uiFromCssModule', () => {
   it('it turns class name mapping into ui mapping', () => {

--- a/packages/pageflow/spec/ui/utils/i18nUtils/attributeTranslation-spec.js
+++ b/packages/pageflow/spec/ui/utils/i18nUtils/attributeTranslation-spec.js
@@ -1,4 +1,4 @@
-import {i18nUtils} from '$pageflow/ui';
+import {i18nUtils} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/utils/i18nUtils/attributeTranslationKeys-spec.js
+++ b/packages/pageflow/spec/ui/utils/i18nUtils/attributeTranslationKeys-spec.js
@@ -1,4 +1,4 @@
-import {i18nUtils} from '$pageflow/ui';
+import {i18nUtils} from 'pageflow/ui';
 
 describe('pageflow.i18nUtils.attributeTranslationKeys', () => {
   var attributeTranslationKeys = i18nUtils.attributeTranslationKeys;

--- a/packages/pageflow/spec/ui/utils/i18nUtils/findKeyWithTranslation-spec.js
+++ b/packages/pageflow/spec/ui/utils/i18nUtils/findKeyWithTranslation-spec.js
@@ -1,4 +1,4 @@
-import {i18nUtils} from '$pageflow/ui';
+import {i18nUtils} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/utils/i18nUtils/findTranslation-spec.js
+++ b/packages/pageflow/spec/ui/utils/i18nUtils/findTranslation-spec.js
@@ -1,4 +1,4 @@
-import {i18nUtils} from '$pageflow/ui';
+import {i18nUtils} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/utils/i18nUtils/translationKeysWithSuffix-spec.js
+++ b/packages/pageflow/spec/ui/utils/i18nUtils/translationKeysWithSuffix-spec.js
@@ -1,4 +1,4 @@
-import {i18nUtils} from '$pageflow/ui';
+import {i18nUtils} from 'pageflow/ui';
 
 describe('pageflow.i18nUtils.translationKeysWithSuffix', () => {
   it('returns array with additional suffixed key for each item', () => {

--- a/packages/pageflow/spec/ui/views/CollectionView-spec.js
+++ b/packages/pageflow/spec/ui/views/CollectionView-spec.js
@@ -1,7 +1,7 @@
 import Backbone from 'backbone';
 import Marionette from 'backbone.marionette';
 
-import {CollectionView} from '$pageflow/ui';
+import {CollectionView} from 'pageflow/ui';
 
 describe('pageflow.CollectionView', () => {
   describe('with blankSlateViewConstructor option', () => {

--- a/packages/pageflow/spec/ui/views/ConfigurationEditorView-spec.js
+++ b/packages/pageflow/spec/ui/views/ConfigurationEditorView-spec.js
@@ -1,4 +1,4 @@
-import {ConfigurationEditorView} from '$pageflow/ui';
+import {ConfigurationEditorView} from 'pageflow/ui';
 
 import * as support from '$support';
 import {Tabs} from '$support/dominos/ui'

--- a/packages/pageflow/spec/ui/views/TableView-spec.js
+++ b/packages/pageflow/spec/ui/views/TableView-spec.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import Backbone from 'backbone';
 
-import {TableCellView, TableView, TextTableCellView} from '$pageflow/ui';
+import {TableCellView, TableView, TextTableCellView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/views/TabsView-spec.js
+++ b/packages/pageflow/spec/ui/views/TabsView-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {TabsView} from '$pageflow/ui';
+import {TabsView} from 'pageflow/ui';
 
 import * as support from '$support';
 import {Tabs} from '$support/dominos/ui'

--- a/packages/pageflow/spec/ui/views/inputs/CheckBoxGroupInputView-spec.js
+++ b/packages/pageflow/spec/ui/views/inputs/CheckBoxGroupInputView-spec.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import Backbone from 'backbone';
 
-import {CheckBoxGroupInputView} from '$pageflow/ui';
+import {CheckBoxGroupInputView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/views/inputs/ColorInputView-spec.js
+++ b/packages/pageflow/spec/ui/views/inputs/ColorInputView-spec.js
@@ -1,7 +1,7 @@
 import Backbone from 'backbone';
 import sinon from 'sinon';
 
-import {ColorInputView} from '$pageflow/ui';
+import {ColorInputView} from 'pageflow/ui';
 
 import * as support from '$support';
 import {ColorInput} from '$support/dominos/ui'

--- a/packages/pageflow/spec/ui/views/inputs/JsonInputView-spec.js
+++ b/packages/pageflow/spec/ui/views/inputs/JsonInputView-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {JsonInputView} from '$pageflow/ui';
+import {JsonInputView} from 'pageflow/ui';
 
 describe('pageflow.JsonInputView', () => {
   it('displays attribute value as pretty printed JSON', () => {

--- a/packages/pageflow/spec/ui/views/inputs/SelectInputView-spec.js
+++ b/packages/pageflow/spec/ui/views/inputs/SelectInputView-spec.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import Backbone from 'backbone';
 
-import {SelectInputView} from '$pageflow/ui';
+import {SelectInputView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/views/inputs/TextAreaInputView-spec.js
+++ b/packages/pageflow/spec/ui/views/inputs/TextAreaInputView-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {TextAreaInputView} from '$pageflow/ui';
+import {TextAreaInputView} from 'pageflow/ui';
 
 describe('pageflow.TextAreaInputView', () => {
   it('supports disabled option', () => {

--- a/packages/pageflow/spec/ui/views/inputs/TextInputView-spec.js
+++ b/packages/pageflow/spec/ui/views/inputs/TextInputView-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {TextInputView} from '$pageflow/ui';
+import {TextInputView} from 'pageflow/ui';
 
 describe('pageflow.TextInputView', () => {
   it('supports disabled option', () => {

--- a/packages/pageflow/spec/ui/views/mixins/inputView-spec.js
+++ b/packages/pageflow/spec/ui/views/mixins/inputView-spec.js
@@ -2,7 +2,7 @@ import Backbone from 'backbone';
 import Cocktail from 'cocktail';
 import Marionette from 'backbone.marionette';
 
-import {inputView} from '$pageflow/ui';
+import {inputView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/views/tableCells/DeleteRowTableCellView-spec.js
+++ b/packages/pageflow/spec/ui/views/tableCells/DeleteRowTableCellView-spec.js
@@ -1,7 +1,7 @@
 import Backbone from 'backbone';
 import sinon from 'sinon';
 
-import {DeleteRowTableCellView} from '$pageflow/ui';
+import {DeleteRowTableCellView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/views/tableCells/EnumTableCellView.js
+++ b/packages/pageflow/spec/ui/views/tableCells/EnumTableCellView.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {EnumTableCellView} from '$pageflow/ui';
+import {EnumTableCellView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/views/tableCells/IconTableCellView-spec.js
+++ b/packages/pageflow/spec/ui/views/tableCells/IconTableCellView-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {IconTableCellView} from '$pageflow/ui';
+import {IconTableCellView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/views/tableCells/PresenceTableCellView-spec.js
+++ b/packages/pageflow/spec/ui/views/tableCells/PresenceTableCellView-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {PresenceTableCellView} from '$pageflow/ui';
+import {PresenceTableCellView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/views/tableCells/TableCellView-spec.js
+++ b/packages/pageflow/spec/ui/views/tableCells/TableCellView-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {TableCellView} from '$pageflow/ui';
+import {TableCellView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/views/tableCells/TableHeaderCellView-spec.js
+++ b/packages/pageflow/spec/ui/views/tableCells/TableHeaderCellView-spec.js
@@ -1,4 +1,4 @@
-import {TableHeaderCellView} from '$pageflow/ui';
+import {TableHeaderCellView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/spec/ui/views/tableCells/TextTableCellView-spec.js
+++ b/packages/pageflow/spec/ui/views/tableCells/TextTableCellView-spec.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {TextTableCellView} from '$pageflow/ui';
+import {TextTableCellView} from 'pageflow/ui';
 
 import * as support from '$support';
 

--- a/packages/pageflow/src/editor/api/CommonPageConfigurationTabs.js
+++ b/packages/pageflow/src/editor/api/CommonPageConfigurationTabs.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 export const CommonPageConfigurationTabs = Object.extend({
   initialize: function() {

--- a/packages/pageflow/src/editor/api/Failure.js
+++ b/packages/pageflow/src/editor/api/Failure.js
@@ -1,4 +1,4 @@
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 /**
  * Failure and subclasses are used in the failures api.

--- a/packages/pageflow/src/editor/api/Failures.js
+++ b/packages/pageflow/src/editor/api/Failures.js
@@ -1,7 +1,7 @@
 import Backbone from 'backbone';
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 import {SavingFailure} from './Failure';
 

--- a/packages/pageflow/src/editor/api/FileImporters.js
+++ b/packages/pageflow/src/editor/api/FileImporters.js
@@ -1,4 +1,4 @@
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 export const FileImporters = Object.extend({
   initialize: function() {

--- a/packages/pageflow/src/editor/api/FileType.js
+++ b/packages/pageflow/src/editor/api/FileType.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 import {EditFileView} from '../views/EditFileView';
 import {TextFileMetaDataItemValueView} from '../views/TextFileMetaDataItemValueView';

--- a/packages/pageflow/src/editor/api/FileTypes.js
+++ b/packages/pageflow/src/editor/api/FileTypes.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 import {FileTypesCollection} from '../collections/FileTypesCollection';
 import {FileType} from './FileType';

--- a/packages/pageflow/src/editor/api/PageType.js
+++ b/packages/pageflow/src/editor/api/PageType.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import {ConfigurationEditorView, Object} from '$pageflow/ui';
+import {ConfigurationEditorView, Object} from 'pageflow/ui';
 
 import {PageLinkConfigurationEditorView} from '../views/PageLinkConfigurationEditorView';
 

--- a/packages/pageflow/src/editor/api/PageTypes.js
+++ b/packages/pageflow/src/editor/api/PageTypes.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 import {PageType} from './PageType';
 

--- a/packages/pageflow/src/editor/api/WidgetType.js
+++ b/packages/pageflow/src/editor/api/WidgetType.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 export const WidgetType = Object.extend({
   initialize: function(serverSideConfig, clientSideConfig) {

--- a/packages/pageflow/src/editor/api/WidgetTypes.js
+++ b/packages/pageflow/src/editor/api/WidgetTypes.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 import {WidgetType} from './WidgetType';
 

--- a/packages/pageflow/src/editor/api/errors.js
+++ b/packages/pageflow/src/editor/api/errors.js
@@ -2,7 +2,7 @@ import Cocktail from 'cocktail';
 import I18n from 'i18n-js';
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 export const UploadError = Object.extend({
   setMessage: function(options) {

--- a/packages/pageflow/src/editor/api/index.js
+++ b/packages/pageflow/src/editor/api/index.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 import {CommonPageConfigurationTabs} from './CommonPageConfigurationTabs';
 import {FailuresAPI} from './Failures';

--- a/packages/pageflow/src/editor/collections/FileTypesCollection.js
+++ b/packages/pageflow/src/editor/collections/FileTypesCollection.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 import {UnmatchedUploadError} from '../api/errors';
 

--- a/packages/pageflow/src/editor/index.js
+++ b/packages/pageflow/src/editor/index.js
@@ -2,7 +2,7 @@ import './sync';
 
 export * from './api';
 
-export * from '$pageflow/ui';
+export * from 'pageflow/ui';
 
 export * from './state';
 export * from './app';

--- a/packages/pageflow/src/editor/initializers/setupFileTypes.js
+++ b/packages/pageflow/src/editor/initializers/setupFileTypes.js
@@ -1,6 +1,6 @@
 import I18n from 'i18n-js';
 
-import {IconTableCellView, SelectInputView, TextInputView, TextTableCellView} from '$pageflow/ui';
+import {IconTableCellView, SelectInputView, TextInputView, TextTableCellView} from 'pageflow/ui';
 
 import {AudioFile} from '../models/AudioFile';
 import {ImageFile} from '../models/ImageFile';

--- a/packages/pageflow/src/editor/models/FileUploader.js
+++ b/packages/pageflow/src/editor/models/FileUploader.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 import {InvalidNestedTypeError, NestedTypeError} from '../api/errors';
 import {editor as editorApi} from '../base';

--- a/packages/pageflow/src/editor/models/Scaffold.js
+++ b/packages/pageflow/src/editor/models/Scaffold.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 export const Scaffold = Object.extend({
   initialize: function(parent, options) {

--- a/packages/pageflow/src/editor/models/authenticationProvider.js
+++ b/packages/pageflow/src/editor/models/authenticationProvider.js
@@ -1,4 +1,4 @@
-import {Object} from '$pageflow/ui';
+import {Object} from 'pageflow/ui';
 
 var AuthenticationProvider =  Object.extend({
   authenticate: function (parent, provider) {

--- a/packages/pageflow/src/editor/views/ChangeThemeDialogView.js
+++ b/packages/pageflow/src/editor/views/ChangeThemeDialogView.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import Backbone from 'backbone';
 import Marionette from 'backbone.marionette';
 
-import {CollectionView} from '$pageflow/ui';
+import {CollectionView} from 'pageflow/ui';
 
 import {app} from '../app';
 

--- a/packages/pageflow/src/editor/views/ConfirmEncodingView.js
+++ b/packages/pageflow/src/editor/views/ConfirmEncodingView.js
@@ -1,6 +1,6 @@
 import Marionette from 'backbone.marionette';
 
-import {CollectionView} from '$pageflow/ui';
+import {CollectionView} from 'pageflow/ui';
 
 import {BackButtonDecoratorView} from './BackButtonDecoratorView';
 import {ConfirmableFileItemView} from './ConfirmableFileItemView';

--- a/packages/pageflow/src/editor/views/DropDownButtonItemListView.js
+++ b/packages/pageflow/src/editor/views/DropDownButtonItemListView.js
@@ -1,4 +1,4 @@
-import {CollectionView} from '$pageflow/ui';
+import {CollectionView} from 'pageflow/ui';
 
 import {DropDownButtonItemView} from './DropDownButtonItemView';
 

--- a/packages/pageflow/src/editor/views/EditChapterView.js
+++ b/packages/pageflow/src/editor/views/EditChapterView.js
@@ -1,7 +1,7 @@
 import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 
-import {CheckBoxInputView, ConfigurationEditorView, TextInputView} from '$pageflow/ui';
+import {CheckBoxInputView, ConfigurationEditorView, TextInputView} from 'pageflow/ui';
 
 import {failureIndicatingView} from './mixins/failureIndicatingView';
 

--- a/packages/pageflow/src/editor/views/EditEntryView.js
+++ b/packages/pageflow/src/editor/views/EditEntryView.js
@@ -3,7 +3,7 @@ import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {tooltipContainer} from '$pageflow/ui';
+import {tooltipContainer} from 'pageflow/ui';
 
 import {editor} from '../base';
 

--- a/packages/pageflow/src/editor/views/EditFileView.js
+++ b/packages/pageflow/src/editor/views/EditFileView.js
@@ -1,7 +1,7 @@
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {ConfigurationEditorTabView, TextInputView, UrlDisplayView} from '$pageflow/ui';
+import {ConfigurationEditorTabView, TextInputView, UrlDisplayView} from 'pageflow/ui';
 
 import {state} from '$state';
 

--- a/packages/pageflow/src/editor/views/EditMetaDataView.js
+++ b/packages/pageflow/src/editor/views/EditMetaDataView.js
@@ -2,7 +2,7 @@ import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {CheckBoxGroupInputView, CheckBoxInputView, ConfigurationEditorView, SelectInputView, TextAreaInputView, TextInputView} from '$pageflow/ui';
+import {CheckBoxGroupInputView, CheckBoxInputView, ConfigurationEditorView, SelectInputView, TextAreaInputView, TextInputView} from 'pageflow/ui';
 
 import {editor} from '../base';
 

--- a/packages/pageflow/src/editor/views/EditPageView.js
+++ b/packages/pageflow/src/editor/views/EditPageView.js
@@ -2,7 +2,7 @@ import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 import 'jquery-ui';
 
-import {ExtendedSelectInputView} from '$pageflow/ui';
+import {ExtendedSelectInputView} from 'pageflow/ui';
 
 import {app} from '../app';
 import {editor} from '../base';

--- a/packages/pageflow/src/editor/views/EditStorylineView.js
+++ b/packages/pageflow/src/editor/views/EditStorylineView.js
@@ -1,7 +1,7 @@
 import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 
-import {CheckBoxInputView, ConfigurationEditorView, SelectInputView, TextInputView, tooltipContainer} from '$pageflow/ui';
+import {CheckBoxInputView, ConfigurationEditorView, SelectInputView, TextInputView, tooltipContainer} from 'pageflow/ui';
 
 import {PageLinkInputView} from './inputs/PageLinkInputView';
 import {failureIndicatingView} from './mixins/failureIndicatingView';

--- a/packages/pageflow/src/editor/views/EditWidgetsView.js
+++ b/packages/pageflow/src/editor/views/EditWidgetsView.js
@@ -1,6 +1,6 @@
 import Marionette from 'backbone.marionette';
 
-import {CollectionView} from '$pageflow/ui';
+import {CollectionView} from 'pageflow/ui';
 
 import {WidgetItemView} from './WidgetItemView';
 

--- a/packages/pageflow/src/editor/views/FileItemView.js
+++ b/packages/pageflow/src/editor/views/FileItemView.js
@@ -1,7 +1,7 @@
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {CollectionView} from '$pageflow/ui';
+import {CollectionView} from 'pageflow/ui';
 
 import {editor} from '../base';
 

--- a/packages/pageflow/src/editor/views/FileMetaDataItemView.js
+++ b/packages/pageflow/src/editor/views/FileMetaDataItemView.js
@@ -1,7 +1,7 @@
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {i18nUtils} from '$pageflow/ui';
+import {i18nUtils} from 'pageflow/ui';
 
 import template from '../templates/fileMetaDataItem.jst';
 

--- a/packages/pageflow/src/editor/views/FileSettingsDialogView.js
+++ b/packages/pageflow/src/editor/views/FileSettingsDialogView.js
@@ -1,7 +1,7 @@
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {TabsView} from '$pageflow/ui';
+import {TabsView} from 'pageflow/ui';
 
 import {app} from '../app';
 

--- a/packages/pageflow/src/editor/views/FilesExplorerView.js
+++ b/packages/pageflow/src/editor/views/FilesExplorerView.js
@@ -2,7 +2,7 @@ import Backbone from 'backbone';
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {CollectionView, TabsView} from '$pageflow/ui';
+import {CollectionView, TabsView} from 'pageflow/ui';
 
 import {app} from '../app';
 import {editor} from '../base';

--- a/packages/pageflow/src/editor/views/FilesView.js
+++ b/packages/pageflow/src/editor/views/FilesView.js
@@ -3,7 +3,7 @@ import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {TabsView} from '$pageflow/ui';
+import {TabsView} from 'pageflow/ui';
 
 import {app} from '../app';
 import {editor} from '../base';

--- a/packages/pageflow/src/editor/views/FilteredFilesView.js
+++ b/packages/pageflow/src/editor/views/FilteredFilesView.js
@@ -1,7 +1,7 @@
 import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 
-import {CollectionView, i18nUtils} from '$pageflow/ui';
+import {CollectionView, i18nUtils} from 'pageflow/ui';
 
 import {editor} from '../base';
 

--- a/packages/pageflow/src/editor/views/ListView.js
+++ b/packages/pageflow/src/editor/views/ListView.js
@@ -1,7 +1,7 @@
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {CollectionView, SortableCollectionView} from '$pageflow/ui';
+import {CollectionView, SortableCollectionView} from 'pageflow/ui';
 
 import {ListItemView} from './ListItemView';
 

--- a/packages/pageflow/src/editor/views/NestedFilesView.js
+++ b/packages/pageflow/src/editor/views/NestedFilesView.js
@@ -1,7 +1,7 @@
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {DeleteRowTableCellView, TableView} from '$pageflow/ui';
+import {DeleteRowTableCellView, TableView} from 'pageflow/ui';
 
 import template from '../templates/nestedFiles.jst';
 

--- a/packages/pageflow/src/editor/views/OtherEntriesCollectionView.js
+++ b/packages/pageflow/src/editor/views/OtherEntriesCollectionView.js
@@ -1,6 +1,6 @@
 import Marionette from 'backbone.marionette';
 
-import {CollectionView} from '$pageflow/ui';
+import {CollectionView} from 'pageflow/ui';
 
 import {OtherEntriesCollection} from '../collections/OtherEntriesCollection';
 

--- a/packages/pageflow/src/editor/views/PageLinkConfigurationEditorView.js
+++ b/packages/pageflow/src/editor/views/PageLinkConfigurationEditorView.js
@@ -1,4 +1,4 @@
-import {ConfigurationEditorView} from '$pageflow/ui';
+import {ConfigurationEditorView} from 'pageflow/ui';
 
 export const PageLinkConfigurationEditorView = ConfigurationEditorView.extend({
   configure: function() {

--- a/packages/pageflow/src/editor/views/PageLinksView.js
+++ b/packages/pageflow/src/editor/views/PageLinksView.js
@@ -1,6 +1,6 @@
 import Marionette from 'backbone.marionette';
 
-import {CollectionView, SortableCollectionView} from '$pageflow/ui';
+import {CollectionView, SortableCollectionView} from 'pageflow/ui';
 
 import {editor} from '../base';
 

--- a/packages/pageflow/src/editor/views/UploadableFilesView.js
+++ b/packages/pageflow/src/editor/views/UploadableFilesView.js
@@ -2,7 +2,7 @@ import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {PresenceTableCellView, TableView, TextTableCellView} from '$pageflow/ui';
+import {PresenceTableCellView, TableView, TextTableCellView} from 'pageflow/ui';
 
 import template from '../templates/uploadableFiles.jst';
 

--- a/packages/pageflow/src/editor/views/WidgetItemView.js
+++ b/packages/pageflow/src/editor/views/WidgetItemView.js
@@ -1,7 +1,7 @@
 import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 
-import {SelectInputView} from '$pageflow/ui';
+import {SelectInputView} from 'pageflow/ui';
 
 import {editor} from '../base';
 

--- a/packages/pageflow/src/editor/views/configurationEditors/audio.js
+++ b/packages/pageflow/src/editor/views/configurationEditors/audio.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import {CheckBoxInputView, ColorInputView, ConfigurationEditorView, SelectInputView, TextAreaInputView, TextInputView} from '$pageflow/ui';
+import {CheckBoxInputView, ColorInputView, ConfigurationEditorView, SelectInputView, TextAreaInputView, TextInputView} from 'pageflow/ui';
 
 import {FileInputView} from '../inputs/FileInputView';
 

--- a/packages/pageflow/src/editor/views/configurationEditors/backgroundImage.js
+++ b/packages/pageflow/src/editor/views/configurationEditors/backgroundImage.js
@@ -1,4 +1,4 @@
-import {ConfigurationEditorView} from '$pageflow/ui';
+import {ConfigurationEditorView} from 'pageflow/ui';
 
 import {FileInputView} from '../inputs/FileInputView';
 

--- a/packages/pageflow/src/editor/views/configurationEditors/groups/background.js
+++ b/packages/pageflow/src/editor/views/configurationEditors/groups/background.js
@@ -1,4 +1,4 @@
-import {ConfigurationEditorTabView, SelectInputView} from '$pageflow/ui';
+import {ConfigurationEditorTabView, SelectInputView} from 'pageflow/ui';
 
 import {FileInputView} from '../../inputs/FileInputView';
 

--- a/packages/pageflow/src/editor/views/configurationEditors/groups/general.js
+++ b/packages/pageflow/src/editor/views/configurationEditors/groups/general.js
@@ -1,4 +1,4 @@
-import {CheckBoxInputView, ConfigurationEditorTabView, SelectInputView, SliderInputView, TextAreaInputView, TextInputView} from '$pageflow/ui';
+import {CheckBoxInputView, ConfigurationEditorTabView, SelectInputView, SliderInputView, TextAreaInputView, TextInputView} from 'pageflow/ui';
 
 import {Page} from '../../../models/Page';
 

--- a/packages/pageflow/src/editor/views/configurationEditors/groups/options.js
+++ b/packages/pageflow/src/editor/views/configurationEditors/groups/options.js
@@ -1,4 +1,4 @@
-import {CheckBoxInputView, ConfigurationEditorTabView, SelectInputView, TextAreaInputView} from '$pageflow/ui';
+import {CheckBoxInputView, ConfigurationEditorTabView, SelectInputView, TextAreaInputView} from 'pageflow/ui';
 
 import {Page} from '../../../models/Page';
 

--- a/packages/pageflow/src/editor/views/configurationEditors/groups/pageLink.js
+++ b/packages/pageflow/src/editor/views/configurationEditors/groups/pageLink.js
@@ -1,4 +1,4 @@
-import {ConfigurationEditorTabView, TextInputView} from '$pageflow/ui';
+import {ConfigurationEditorTabView, TextInputView} from 'pageflow/ui';
 
 import {PageLinkInputView} from '../../inputs/PageLinkInputView';
 

--- a/packages/pageflow/src/editor/views/configurationEditors/groups/pageTransitions.js
+++ b/packages/pageflow/src/editor/views/configurationEditors/groups/pageTransitions.js
@@ -1,7 +1,7 @@
 import I18n from 'i18n-js';
 import _ from 'underscore';
 
-import {ConfigurationEditorTabView, SelectInputView} from '$pageflow/ui';
+import {ConfigurationEditorTabView, SelectInputView} from 'pageflow/ui';
 
 ConfigurationEditorTabView.groups.define('page_transitions', function(options) {
   var inputOptions = {

--- a/packages/pageflow/src/editor/views/configurationEditors/video.js
+++ b/packages/pageflow/src/editor/views/configurationEditors/video.js
@@ -1,4 +1,4 @@
-import {CheckBoxInputView, ConfigurationEditorView, TextAreaInputView, TextInputView} from '$pageflow/ui';
+import {CheckBoxInputView, ConfigurationEditorView, TextAreaInputView, TextInputView} from 'pageflow/ui';
 
 import {FileInputView} from '../inputs/FileInputView';
 

--- a/packages/pageflow/src/editor/views/inputs/FileInputView.js
+++ b/packages/pageflow/src/editor/views/inputs/FileInputView.js
@@ -3,7 +3,7 @@ import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
-import {inputView} from '$pageflow/ui';
+import {inputView} from 'pageflow/ui';
 
 import {editor} from '../../base';
 

--- a/packages/pageflow/src/editor/views/inputs/FileProcessingStateDisplayView.js
+++ b/packages/pageflow/src/editor/views/inputs/FileProcessingStateDisplayView.js
@@ -1,6 +1,6 @@
 import Marionette from 'backbone.marionette';
 
-import {CollectionView, inputView} from '$pageflow/ui';
+import {CollectionView, inputView} from 'pageflow/ui';
 
 import {editor} from '../../base';
 

--- a/packages/pageflow/src/editor/views/inputs/ReferenceInputView.js
+++ b/packages/pageflow/src/editor/views/inputs/ReferenceInputView.js
@@ -1,7 +1,7 @@
 import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 
-import {inputView} from '$pageflow/ui';
+import {inputView} from 'pageflow/ui';
 
 import {ModelThumbnailView} from '../ModelThumbnailView';
 

--- a/packages/pageflow/src/editor/views/widgetTypes/classicLoadingSpinner.js
+++ b/packages/pageflow/src/editor/views/widgetTypes/classicLoadingSpinner.js
@@ -1,6 +1,6 @@
 import I18n from 'i18n-js';
 
-import {ConfigurationEditorView} from '$pageflow/ui';
+import {ConfigurationEditorView} from 'pageflow/ui';
 
 import {editor} from '../../base';
 

--- a/packages/pageflow/src/editor/views/widgetTypes/cookieNoticeBar.js
+++ b/packages/pageflow/src/editor/views/widgetTypes/cookieNoticeBar.js
@@ -1,6 +1,6 @@
 import I18n from 'i18n-js';
 
-import {ConfigurationEditorView} from '$pageflow/ui';
+import {ConfigurationEditorView} from 'pageflow/ui';
 
 import {editor} from '../../base';
 

--- a/packages/pageflow/src/editor/views/widgetTypes/mediaLoadingSpinner.js
+++ b/packages/pageflow/src/editor/views/widgetTypes/mediaLoadingSpinner.js
@@ -1,6 +1,6 @@
 import I18n from 'i18n-js';
 
-import {CheckBoxInputView, ConfigurationEditorView, SliderInputView} from '$pageflow/ui';
+import {CheckBoxInputView, ConfigurationEditorView, SliderInputView} from 'pageflow/ui';
 
 import {editor} from '../../base';
 

--- a/packages/pageflow/src/editor/views/widgetTypes/phoneHorizontalSlideshowMode.js
+++ b/packages/pageflow/src/editor/views/widgetTypes/phoneHorizontalSlideshowMode.js
@@ -1,6 +1,6 @@
 import I18n from 'i18n-js';
 
-import {ConfigurationEditorView} from '$pageflow/ui';
+import {ConfigurationEditorView} from 'pageflow/ui';
 
 import {editor} from '../../base';
 

--- a/packages/pageflow/src/editor/views/widgetTypes/titleLoadingSpinner.js
+++ b/packages/pageflow/src/editor/views/widgetTypes/titleLoadingSpinner.js
@@ -1,6 +1,6 @@
 import I18n from 'i18n-js';
 
-import {CheckBoxInputView, ConfigurationEditorView, SliderInputView, TextInputView} from '$pageflow/ui';
+import {CheckBoxInputView, ConfigurationEditorView, SliderInputView, TextInputView} from 'pageflow/ui';
 
 import {editor} from '../../base';
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,6 +45,9 @@ const externalEditorGlobalsAndCoreJs = function(id) {
 const externalPageflowEditorGlobalsAndCoreJs = function(id) {
   return id.match(/^pageflow\//) || externalEditorGlobalsAndCoreJs(id);
 };
+const externalPageflowUIEditorGlobalsAndCoreJs = function(id) {
+  return id.match(/^pageflow\/ui/) || externalEditorGlobalsAndCoreJs(id);
+};
 
 const plugins = [
   postcss({
@@ -71,7 +74,6 @@ const plugins = [
 const pageflowPackagePlugins = [
   alias({
     entries: {
-      '$pageflow': __dirname + '/' +  pageflowPackageRoot + '/src',
       '$state': __dirname + '/' + pageflowPackageRoot + '/src/editor/state.js',
     }
   }),
@@ -96,7 +98,7 @@ export default [
       file: pageflowPackageRoot + '/editor.js',
       format: 'esm'
     },
-    external: externalEditorGlobalsAndCoreJs,
+    external: externalPageflowUIEditorGlobalsAndCoreJs,
     plugins: pageflowPackagePlugins
   },
 


### PR DESCRIPTION
Some of the files have side effects (like adding mixins to base
objects). When the entry type specific editor js files then import
things from `pageflow/ui` this is not detected as the same thing as
what is already included in `pageflow/editor`, evaluating the side
effects a second time.

Import from `pageflow/ui` in `pageflow/src/editor` files and mark
`pageflow/ui` as external dependency. This causes the import
statements to remain in the `pageflow/editor` build output. This also
gets rid of the `$pageflow` alias which was used to reference files in
`pageflow/src/ui` from `pageflow/src/editor`.

We still need to tell Jest how to handle imports if the form
`pageflow/...`, since it works against sources not build outputs.

REDMINE-17328