### PR TITLE
Fix section index and references to adjacent chapters

### DIFF
--- a/entry_types/scrolled/package/spec/entryState/structure-spec.js
+++ b/entry_types/scrolled/package/spec/entryState/structure-spec.js
@@ -95,6 +95,11 @@ describe('useEntryStructure', () => {
       summary: 'An introductory chapter',
       sections: [
         {
+          permaId: 101,
+          previousSection: undefined,
+          nextSection: {permaId: 102},
+          sectionIndex: 0,
+
           transition: 'scroll',
           foreground: [
             {
@@ -118,6 +123,11 @@ describe('useEntryStructure', () => {
       summary: 'A great chapter',
       sections: [
         {
+          permaId: 102,
+          previousSection: {permaId: 101},
+          nextSection: undefined,
+          sectionIndex: 1,
+
           transition: 'fade',
           foreground: [
             {

--- a/entry_types/scrolled/package/src/frontend/Chapter.js
+++ b/entry_types/scrolled/package/src/frontend/Chapter.js
@@ -19,23 +19,18 @@ function renderSections(sections,
                         setCurrentSectionIndex,
                         scrollTargetSectionIndex,
                         setScrollTargetSectionIndex) {
-  function onActivate(index) {
-    setCurrentSectionIndex(index);
+  function onActivate(sectionIndex) {
+    setCurrentSectionIndex(sectionIndex);
     setScrollTargetSectionIndex(null);
   }
 
-  return sections.map((section, index) => {
-    const previousSection = sections[index - 1];
-    const nextSection = sections[index + 1];
-
+  return sections.map((section) => {
     return (
-      <Section key={index}
-               state={index > currentSectionIndex ? 'below' : index < currentSectionIndex ? 'above' : 'active'}
-               isScrollTarget={index === scrollTargetSectionIndex}
-               onActivate={() => onActivate(index)}
-               {...section}
-               previousSection={previousSection}
-               nextSection={nextSection}/>
+      <Section key={section.permaId}
+               state={section.sectionIndex > currentSectionIndex ? 'below' : section.sectionIndex < currentSectionIndex ? 'above' : 'active'}
+               isScrollTarget={section.sectionIndex === scrollTargetSectionIndex}
+               onActivate={() => onActivate(section.sectionIndex)}
+               {...section} />
     )
   });
 }


### PR DESCRIPTION
In #1298, the `Chapter` component was extracted from the `Entry`
component. Before, the `Entry`, while iterating sections, used the
index of that iteration to tell each Section whether it's the current
section and pass references to its adjacent sections.

This logic was moved into `Chapter`. The index of a section inside a
chapter cannot be used, though, to track the active scene of the
entry. Moreover, only references to adjacent sections inside that
chapter were passed.

Restore and move this logic into the `useEntryStructure` hook.

REDMINE-17300