### PR TITLE
Do not prefix partial paths with pageflow_paged

### DIFF
--- a/entry_types/paged/app/controllers/concerns/pageflow_paged/without_controller_namespace_partial_path_prefix.rb
+++ b/entry_types/paged/app/controllers/concerns/pageflow_paged/without_controller_namespace_partial_path_prefix.rb
@@ -1,0 +1,21 @@
+module PageflowPaged
+  # @api private
+  module WithoutControllerNamespacePartialPathPrefix
+    extend ActiveSupport::Concern
+
+    included do
+      around_action :without_controller_namespace_partial_path_prefix
+    end
+
+    private
+
+    def without_controller_namespace_partial_path_prefix
+      old_value = ActionView::Base.prefix_partial_path_with_controller_namespace
+      ActionView::Base.prefix_partial_path_with_controller_namespace = false
+
+      yield
+    ensure
+      ActionView::Base.prefix_partial_path_with_controller_namespace = old_value
+    end
+  end
+end

--- a/entry_types/paged/app/controllers/pageflow_paged/entries_controller.rb
+++ b/entry_types/paged/app/controllers/pageflow_paged/entries_controller.rb
@@ -2,6 +2,7 @@ module PageflowPaged
   # @api private
   class EntriesController < PageflowPaged::ApplicationController
     include Pageflow::EntriesControllerEnvHelper
+    include WithoutControllerNamespacePartialPathPrefix
 
     helper Pageflow::MetaTagsHelper
     helper Pageflow::StructuredDataHelper

--- a/entry_types/paged/spec/support/helpers/stub_template_controller_test_helper.rb
+++ b/entry_types/paged/spec/support/helpers/stub_template_controller_test_helper.rb
@@ -1,0 +1,9 @@
+module StubTemplateControllerTestHelper
+  def stub_template(hash)
+    controller.append_view_path(ActionView::FixtureResolver.new(hash))
+  end
+end
+
+RSpec.configure do |config|
+  config.include(StubTemplateControllerTestHelper, type: :controller)
+end


### PR DESCRIPTION
Plugins like `pageflow-external-links` depend on having `render site`
where site is a `Pageflow::ExternalLinks::Site` render
`pageflow/external_links/sites/_site.html.erb`. By default Rails looks
for `pageflow_paged/pageflow/external_links/sites/_site.html.erb` when
rendering in the context of
`PageflowPaged::EntriesController`. Temporarily set
`prefix_partial_path_with_controller_namespace` [1] to `false` in an
`around_action` to disable this behavior.

[1] https://edgeguides.rubyonrails.org/configuring.html#configuring-action-view

REDMINE-17319