### PR TITLE
Update bourbon dependency minor version

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -109,7 +109,7 @@ Gem::Specification.new do |s|
   # WYSIWYG editor
   s.add_dependency 'wysihtml-rails', '0.5.5'
 
-  s.add_dependency 'bourbon', '~> 3.1.8'
+  s.add_dependency 'bourbon', '~> 3.1'
 
   # Pretty URLs
   s.add_dependency 'friendly_id', '~> 5.2'


### PR DESCRIPTION
When starting my local development server just now I came across the hundreds of warnings again:
`DEPRECATION WARNING: Passing 100%, a non-string value, to unquote() will be an error in future versions of Sass.`
I remembered this had to do with the version of `bourbon` we're using, which we couldn't update because of some dependency to `sass` by `activeadmin`.
Now that we updated `sass` in the course of our `activeadmin` update in https://github.com/codevise/pageflow/commit/cb2beef69a7715adfda050136b2d82b5b0a0ed82#diff-063b9e22ec07e7f812323b34dd15f644R24 , we could finally update `bourbon` to a newer minor version which gets rid of the deprecation warnings mentioned above.

REDMINE-17410