### PR TITLE
Revert "Update bourbon dependency minor version"

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -109,7 +109,7 @@ Gem::Specification.new do |s|
   # WYSIWYG editor
   s.add_dependency 'wysihtml-rails', '0.5.5'
 
-  s.add_dependency 'bourbon', '~> 3.1'
+  s.add_dependency 'bourbon', '~> 3.1.8'
 
   # Pretty URLs
   s.add_dependency 'friendly_id', '~> 5.2'


### PR DESCRIPTION
Reverts codevise/pageflow#1325

New [implementation of `hide-text` mixin](https://github.com/thoughtbot/bourbon/pull/285) breaks default navigation bar.

REDMINE-17410