### PR TITLE
Make pageflow-scrolled Capybara specs less flaky

### DIFF
--- a/entry_types/scrolled/package/spec/collections-spec.js
+++ b/entry_types/scrolled/package/spec/collections-spec.js
@@ -62,6 +62,26 @@ describe('watch', () => {
     expect(items.map(i => i.text)).toEqual(['News', 'Report']);
   });
 
+  it('supports mapping to constants', () => {
+    const {result} = renderHook(() => useCollections());
+    const posts = new Backbone.Collection([
+      {title: 'News'},
+    ]);
+
+    act(() => {
+      const [, dispatch] = result.current;
+      watchCollection(posts, {
+        name: 'posts',
+        attributes: [{id: () => 1}, 'title'],
+        dispatch
+      });
+    });
+    const [state,] = result.current;
+    const items = getItems(state, 'posts');
+
+    expect(items.map(i => i.title)).toEqual(['News']);
+  });
+
   it('supports watching multiple collections', () => {
     const {result} = renderHook(() => useCollections());
     const posts = new Backbone.Collection([
@@ -215,7 +235,7 @@ describe('watch', () => {
 
   it('supports including configuration attributes', () => {
     const {result} = renderHook(() => useCollections());
-    const model = new Backbone.Model();
+    const model = new Backbone.Model({id: 1});
     model.configuration = new Backbone.Model({title: 'Title from configuration'});
     const posts = new Backbone.Collection([model])
 
@@ -359,7 +379,7 @@ describe('watch', () => {
 
   it('updates useCollections state when included configuration changes', () => {
     const {result} = renderHook(() => useCollections());
-    const model = new Backbone.Model();
+    const model = new Backbone.Model({id: 1});
     model.configuration = new Backbone.Model({title: 'Old title'});
     const posts = new Backbone.Collection([model])
 
@@ -383,7 +403,7 @@ describe('watch', () => {
 
   it('updates useCollections state when attribute with mapped name changes', () => {
     const {result} = renderHook(() => useCollections());
-    const posts = new Backbone.Collection([{title: 'Old title'}]);
+    const posts = new Backbone.Collection([{id: 1, title: 'Old title'}]);
 
     act(() => {
       const [, dispatch] = result.current;

--- a/entry_types/scrolled/package/spec/entryState/legalInfo-spec.js
+++ b/entry_types/scrolled/package/spec/entryState/legalInfo-spec.js
@@ -172,6 +172,7 @@ describe('useFileRights', () => {
             filesAttributes: {
               image_files: [
                 {
+                  perma_id: 1,
                   rights: 'author'
                 }
               ]

--- a/entry_types/scrolled/package/spec/entryState/metadata-spec.js
+++ b/entry_types/scrolled/package/spec/entryState/metadata-spec.js
@@ -6,7 +6,6 @@ import {renderHookInEntry, normalizeSeed} from 'support';
 
 describe('useEntryMetadata', () => {
   const expectedEntryMetadata = {
-    id: 1,
     shareProviders: {
       facebook: true,
       twitter: false
@@ -21,7 +20,6 @@ describe('useEntryMetadata', () => {
       {
         seed: {
           entry: {
-            id: 1,
             permaId: 1,
             shareProviders: {
               facebook: true,
@@ -46,7 +44,6 @@ describe('useEntryMetadata', () => {
           watchCollections(
             factories.entry(ScrolledEntry, {
               metadata: {
-                id: 1,
                 share_providers: {
                   facebook: true,
                   twitter: false

--- a/entry_types/scrolled/package/spec/support/normalizeSeed.js
+++ b/entry_types/scrolled/package/spec/support/normalizeSeed.js
@@ -134,8 +134,8 @@ function normalizeLegalInfo(legalInfo) {
 
 function normalizeCollection(collection = [], defaults = {}) {
   return collection.map((item, index) => ({
-    id: index,
-    permaId: index,
+    id: index + 1,
+    permaId: index + 1,
     ...defaults,
     ...item
   }));

--- a/entry_types/scrolled/package/src/collections.js
+++ b/entry_types/scrolled/package/src/collections.js
@@ -91,6 +91,7 @@ export function watchCollection(collection,
     attributeNames: attributes,
     includeConfiguration
   };
+  let tearingDown = false;
 
   const watchedAttributeNames = getWatchedAttributeNames(attributes);
 
@@ -141,14 +142,18 @@ export function watchCollection(collection,
     }), handle);
   }
 
-  collection.on('remove', model => dispatch({
-    type: REMOVE,
-    payload: {
-      collectionName: name,
-      order: collection.pluck(keyAttribute),
-      key: model.attributes[keyAttribute]
+  collection.on('remove', model => {
+    if (!tearingDown) {
+      dispatch({
+        type: REMOVE,
+        payload: {
+          collectionName: name,
+          order: collection.pluck(keyAttribute),
+          key: model.attributes[keyAttribute]
+        }
+      })
     }
-  }), handle);
+  }, handle);
 
   collection.on('sort', model => dispatch({
     type: SORT,
@@ -161,6 +166,7 @@ export function watchCollection(collection,
   }), handle);
 
   return function() {
+    tearingDown = true;
     collection.off(null, null, handle);
   };
 }

--- a/entry_types/scrolled/package/src/collections.js
+++ b/entry_types/scrolled/package/src/collections.js
@@ -73,6 +73,8 @@ function reducer(state, action) {
 }
 
 function init(items, keyAttribute = 'id') {
+  items = items.filter(item => item[keyAttribute]);
+
   return {
     order: items.map(item => item[keyAttribute]),
     items: items.reduce((result, item) => {
@@ -183,7 +185,12 @@ function getAttributes(model, {attributeNames, includeConfiguration}) {
       const key = Object.keys(attributeName)[0];
       const value = attributeName[key];
 
-      result[key] = model.get(value);
+      if (typeof value == 'function') {
+        result[key] = value();
+      }
+      else {
+        result[key] = model.get(value);
+      }
     }
     else {
       result[attributeName] = model.get(attributeName);

--- a/entry_types/scrolled/package/src/editor/views/SectionItemView.js
+++ b/entry_types/scrolled/package/src/editor/views/SectionItemView.js
@@ -44,6 +44,10 @@ export const SectionItemView = Marionette.ItemView.extend({
     }
   },
 
+  modelEvents: {
+    'change:id': 'renderThumbnail'
+  },
+
   initialize() {
     this.listenTo(this.options.entry, 'change:currentSectionIndex', () => {
       const active =
@@ -62,6 +66,17 @@ export const SectionItemView = Marionette.ItemView.extend({
 
   onRender() {
     this.timeout = setTimeout(() => {
+      this.renderThumbnail();
+    }, 100);
+  },
+
+  onClose() {
+    clearTimeout(this.timeout);
+    ReactDOM.unmountComponentAtNode(this.ui.thumbnail[0]);
+  },
+
+  renderThumbnail() {
+    if (!this.model.isNew()) {
       ReactDOM.render(React.createElement(SectionThumbnail,
                                           {
                                             sectionPermaId: this.model.get('permaId'),
@@ -70,11 +85,6 @@ export const SectionItemView = Marionette.ItemView.extend({
                                               watchCollections(this.options.entry, {dispatch})
                                           }),
                       this.ui.thumbnail[0]);
-    }, 100);
-  },
-
-  onClose() {
-    clearTimeout(this.timeout);
-    ReactDOM.unmountComponentAtNode(this.ui.thumbnail[0]);
+    }
   }
 });

--- a/entry_types/scrolled/package/src/editor/views/SectionItemView.module.css
+++ b/entry_types/scrolled/package/src/editor/views/SectionItemView.module.css
@@ -19,7 +19,12 @@
   position: relative;
 }
 
-.thumbnail {}
+.thumbnail {
+  border: solid 1px #888;
+  padding-top: 50%;
+  position: relative;
+  text-align: initial;
+}
 
 .clickMask {
   position: absolute;

--- a/entry_types/scrolled/package/src/entryState/watchCollections.js
+++ b/entry_types/scrolled/package/src/entryState/watchCollections.js
@@ -6,7 +6,13 @@ export function watchCollections(entry, {dispatch}) {
 
   teardownFns.push(watchCollection(new Backbone.Collection([entry.metadata]), {
     name: 'entries',
-    attributes: ['id', {shareProviders: 'share_providers'}, {shareUrl: 'share_url'}, 'credits'],
+    attributes: [
+      {permaId: () => entry.id}, // Make sure key attribute is present
+      {shareProviders: 'share_providers'},
+      {shareUrl: 'share_url'},
+      'credits'
+    ],
+    keyAttribute: 'permaId',
     dispatch
   }));
   teardownFns.push(watchCollection(chapters, {

--- a/entry_types/scrolled/package/src/frontend/SectionThumbnail.js
+++ b/entry_types/scrolled/package/src/frontend/SectionThumbnail.js
@@ -25,12 +25,10 @@ function Inner({sectionPermaId, subscribe}) {
 
   if (section) {
     return (
-      <div className={styles.root}>
-        <div className={styles.crop}>
-          <div className={styles.scale}>
-            <div className={entryStyles.Entry}>
-              <Section state="active" {...section} transition="preview" />
-            </div>
+      <div className={styles.crop}>
+        <div className={styles.scale}>
+          <div className={entryStyles.Entry}>
+            <Section state="active" {...section} transition="preview" />
           </div>
         </div>
       </div>

--- a/entry_types/scrolled/package/src/frontend/SectionThumbnail.module.css
+++ b/entry_types/scrolled/package/src/frontend/SectionThumbnail.module.css
@@ -1,9 +1,3 @@
-.root {
-  padding-top: 50%;
-  position: relative;
-  border: solid 1px #888;
-}
-
 .crop {
   position: absolute;
   top: 0;

--- a/entry_types/scrolled/spec/spec_helper.rb
+++ b/entry_types/scrolled/spec/spec_helper.rb
@@ -17,6 +17,9 @@ require 'pageflow/support/config/paperclip'
 require 'pageflow/support/config/webmock'
 require 'pageflow_scrolled'
 
+# see REDMINE-17430
+Webdrivers::Chromedriver.required_version = '79.0.3945.36'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'

--- a/packages/pageflow/src/testHelpers/factories.js
+++ b/packages/pageflow/src/testHelpers/factories.js
@@ -50,7 +50,11 @@ export const factories = {
     ensureFileTypes(options);
     ensureFilesCollections(options);
 
-    const entry = new model(attributes, _.extend({
+    const entry = new model({
+      id: 1,
+      ...attributes
+    },
+    _.extend({
       storylines: new Backbone.Collection(),
       chapters: new Backbone.Collection(),
     }, options));


### PR DESCRIPTION
* Downgrade to `chromedriver` 79 to workaround bug that causes timeout when switching between iframes.
* Fix React warnings about state updates on unmounted components and missing keys.

REDMINE-17430