### PR TITLE
Prevent Percy from reporting different video loading progress

### DIFF
--- a/entry_types/scrolled/package/.storybook/preview-head.html
+++ b/entry_types/scrolled/package/.storybook/preview-head.html
@@ -1,1 +1,8 @@
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700&display=swap" rel="stylesheet">
+
+<style>
+  /* Do not report different loading progress as visual change */
+  video::-webkit-media-controls-timeline {
+    visibility: hidden;
+  }
+</style>

--- a/entry_types/scrolled/package/src/contentElements/inlineVideo/InlineVideo.module.css
+++ b/entry_types/scrolled/package/src/contentElements/inlineVideo/InlineVideo.module.css
@@ -10,3 +10,7 @@
   bottom: 0;
   right: 0;
 }
+
+/* Timeline in native video controls is hidden in Storybook to prevent
+   Percy from detecting different loading progress as visual
+   change. See .storybook/preview-head.html file. */


### PR DESCRIPTION
Hide the progress bar in storybook to prevent noisy change
Percy alerts for inline videos.