### PR TITLE
Improve navigation

### DIFF
--- a/entry_types/scrolled/config/locales/new/de.yml
+++ b/entry_types/scrolled/config/locales/new/de.yml
@@ -1,6 +1,8 @@
 de:
   pageflow_scrolled:
     public:
+      navigation:
+        chapter: Kapitel
       sound_disclaimer:
         help_text: Dieser Artikel wirkt am besten mit eingeschaltetem Ton.<br/> Klicken Sie einmal in dieses Feld, um den Ton für die gesamte Geschichte zu aktivieren.
     inline_editing:

--- a/entry_types/scrolled/config/locales/new/en.yml
+++ b/entry_types/scrolled/config/locales/new/en.yml
@@ -1,6 +1,8 @@
 en:
   pageflow_scrolled:
     public:
+      navigation:
+        chapter: Chapter
       sound_disclaimer:
         help_text: This article works best with the sound turned on. <br/> Click once in this field to activate the sound for the entire story.
     inline_editing:

--- a/entry_types/scrolled/package/src/frontend/navigation/AppHeader.js
+++ b/entry_types/scrolled/package/src/frontend/navigation/AppHeader.js
@@ -97,9 +97,10 @@ export function AppHeader(props) {
           </ul>
         </nav>
 
-        <LegalInfoMenu />
-
-        <SharingMenu />
+        <div className={classNames(styles.contextIcons)}>
+          <SharingMenu />
+          <LegalInfoMenu />
+        </div>
       </div>
 
       <div className={styles.progressBar} onMouseEnter={handleProgressBarMouseEnter}>

--- a/entry_types/scrolled/package/src/frontend/navigation/AppHeader.js
+++ b/entry_types/scrolled/package/src/frontend/navigation/AppHeader.js
@@ -65,7 +65,9 @@ export function AppHeader(props) {
   };
 
   function renderChapterLinks(chapters) {
-    return chapters.map((chapter, index) => {
+    return chapters.filter(function (chapterConfiguration) {
+      return chapterConfiguration.title && chapterConfiguration.summary;
+    }).map((chapter, index) => {
       const chapterIndex = index + 1;
       const chapterLinkId = `chapterLink${chapterIndex}`
       return (

--- a/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
@@ -34,6 +34,21 @@
   position: absolute;
 }
 
+.contextIcons {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  width: 80px;
+  height: 50px;
+  padding: 0px 12px;
+}
+
+.contextIcon {
+  float: right;
+  width: 40px;
+  height: 50px;
+}
+
 .wdrLogo {
   top: 12px;
   left: 15px;
@@ -114,8 +129,8 @@
     display: table;
     content: " ";
     border-top: 1px solid rgb(100, 100, 100);
-    width: 30%;
-    margin: 0 35%;
+    width: 14%;
+    margin: 0 43%;
     transition: width .15s, margin .15s;
   }
 
@@ -126,9 +141,8 @@
     margin: 0 10%;
   }
 
-  .chapterLink,
-  .chapterLink:hover {
-    padding: 10px 0px;
+  .chapterListItem p {
+    margin-top: 0;
   }
 
   .progressBar {

--- a/entry_types/scrolled/package/src/frontend/navigation/ChapterLink.js
+++ b/entry_types/scrolled/package/src/frontend/navigation/ChapterLink.js
@@ -12,6 +12,8 @@ export function ChapterLink(props) {
          data-tip data-for={props.chapterLinkId} >
         {props.title}
       </a>
+      <p className={styles.summary}
+         dangerouslySetInnerHTML={{__html: props.summary}} />
       <ChapterLinkTooltip chapterIndex={props.chapterIndex}
                           chapterLinkId={props.chapterLinkId}
                           {...props} />

--- a/entry_types/scrolled/package/src/frontend/navigation/ChapterLink.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/ChapterLink.module.css
@@ -7,7 +7,7 @@
   font-family: inherit;
   font-weight: 700;
   font-size: 1rem;
-  height: 48px;
+  height: 50px;
 }
 
 .chapterLink:hover,
@@ -15,10 +15,13 @@
   color: #e10028;
 }
 
+.summary {
+  display: none;
+}
+
 /* mobile view */
 @media (max-width: 780px) {
-  .chapterLink,
-  .chapterLink:hover {
-    padding: 10px 0px;
+  .summary {
+    display: block;
   }
 }

--- a/entry_types/scrolled/package/src/frontend/navigation/ChapterLinkTooltip.js
+++ b/entry_types/scrolled/package/src/frontend/navigation/ChapterLinkTooltip.js
@@ -3,8 +3,11 @@ import classNames from 'classnames';
 import headerStyles from "./AppHeader.module.css";
 import styles from "./ChapterLinkTooltip.module.css";
 import ReactTooltip from "react-tooltip";
+import {useI18n} from '../i18n';
 
 export function ChapterLinkTooltip(props) {
+  const {t} = useI18n();
+
   return(
     <ReactTooltip id={props.chapterLinkId}
                   type='light'
@@ -13,7 +16,9 @@ export function ChapterLinkTooltip(props) {
                   className={classNames(headerStyles.navigationTooltip,
                                         styles.chapterLinkTooltip)}>
       <div>
-        <h3 className={styles.tooltipHeadline}>Kapitel {props.chapterIndex}</h3>
+        <h3 className={styles.tooltipHeadline}>
+          {t('pageflow_scrolled.public.navigation.chapter')} {props.chapterIndex}
+        </h3>
         <p dangerouslySetInnerHTML={{__html: props.summary}} />
       </div>
     </ReactTooltip>

--- a/entry_types/scrolled/package/src/frontend/navigation/LegalInfoMenu.js
+++ b/entry_types/scrolled/package/src/frontend/navigation/LegalInfoMenu.js
@@ -9,7 +9,7 @@ import ReactTooltip from "react-tooltip";
 export function LegalInfoMenu(props) {
   return (
     <div>
-      <a className={classNames(headerStyles.menuIcon, styles.infoIcon)}
+      <a className={classNames(headerStyles.contextIcon, styles.infoIcon)}
          data-tip data-for={'legalInfoTooltip'}
          onMouseEnter={() => { ReactTooltip.hide()}}>
         <InfoIcon/>

--- a/entry_types/scrolled/package/src/frontend/navigation/LegalInfoMenu.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/LegalInfoMenu.module.css
@@ -1,6 +1,6 @@
-.infoIcon {
-  top: 12px;
-  right: 55px;
+.infoIcon svg {
   width: 26px;
+  height: 26px;
+  margin: 12px 0px;
 }
 

--- a/entry_types/scrolled/package/src/frontend/navigation/LegalInfoTooltip.js
+++ b/entry_types/scrolled/package/src/frontend/navigation/LegalInfoTooltip.js
@@ -19,7 +19,7 @@ export function LegalInfoTooltip() {
                   event={'click'}
                   globalEventOff={'click'}
                   clickable={true}
-                  offset={{bottom: 5, right: -97}}
+                  offset={{right: -97}}
                   className={classNames(headerStyles.navigationTooltip,
                                         styles.legalInfoTooltip)}>
       <div onMouseLeave={() => { ReactTooltip.hide() }}>

--- a/entry_types/scrolled/package/src/frontend/navigation/LegalInfoTooltip.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/LegalInfoTooltip.module.css
@@ -2,8 +2,6 @@
   width: 200px;
   max-width: 200px;
   text-align: left;
-  margin-top: 12px !important;
-  margin-bottom: 12px !important;
 }
 
 .legalInfoTooltip:after {

--- a/entry_types/scrolled/package/src/frontend/navigation/SharingMenu.js
+++ b/entry_types/scrolled/package/src/frontend/navigation/SharingMenu.js
@@ -5,17 +5,24 @@ import styles from "./SharingMenu.module.css";
 import ShareIcon from "../assets/images/navigation/icons/share_icon.svg";
 import {SharingTooltip} from "./SharingTooltip";
 import ReactTooltip from "react-tooltip";
+import {useShareProviders} from "../../entryState";
 
 export function SharingMenu() {
-  return (
-    <div>
-      <a className={classNames(headerStyles.contextIcon, styles.shareIcon)}
-         data-tip data-for={'sharingTooltip'}
-         onMouseEnter={() => { ReactTooltip.hide()}}>
-        <ShareIcon/>
-      </a>
-      <SharingTooltip />
-    </div>
-  )
+  const shareProviders = useShareProviders();
+
+  if(shareProviders.length > 0) {
+    return (
+      <div>
+        <a className={classNames(headerStyles.contextIcon, styles.shareIcon)}
+           data-tip data-for={'sharingTooltip'}
+           onMouseEnter={() => { ReactTooltip.hide()}}>
+          <ShareIcon/>
+        </a>
+        <SharingTooltip />
+      </div>
+    )
+  } else {
+    return (null);
+  }
 }
 

--- a/entry_types/scrolled/package/src/frontend/navigation/SharingMenu.js
+++ b/entry_types/scrolled/package/src/frontend/navigation/SharingMenu.js
@@ -9,7 +9,7 @@ import ReactTooltip from "react-tooltip";
 export function SharingMenu() {
   return (
     <div>
-      <a className={classNames(headerStyles.menuIcon, styles.shareIcon)}
+      <a className={classNames(headerStyles.contextIcon, styles.shareIcon)}
          data-tip data-for={'sharingTooltip'}
          onMouseEnter={() => { ReactTooltip.hide()}}>
         <ShareIcon/>

--- a/entry_types/scrolled/package/src/frontend/navigation/SharingMenu.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/SharingMenu.module.css
@@ -1,5 +1,5 @@
-.shareIcon {
-  top: 5px;
-  right: 10px;
+.shareIcon svg {
   width: 40px;
+  height: 40px;
+  margin: 5px 0px;
 }

--- a/entry_types/scrolled/package/src/frontend/navigation/SharingTooltip.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/SharingTooltip.module.css
@@ -16,7 +16,7 @@
 }
 
 .shareLinkContainer {
-  float: left;
+  display: inline-block;
   width: 80px;
   height: 60px;
   cursor: pointer;


### PR DESCRIPTION
Add summary to mobile navigation.
Restructure nav icons to account for empty set of share providers.
Translate hard-coded chapter tooltip title.
Only show chapters with title and summary in navigation.

REDMINE-17425