### PR TITLE
DataWrapper Chart URL Fix

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/dataWrapperChart/DataWrapperChart.js
+++ b/entry_types/scrolled/package/src/contentElements/dataWrapperChart/DataWrapperChart.js
@@ -9,11 +9,15 @@ import styles from './DataWrapperChart.module.css';
 export function DataWrapperChart({configuration}) {  
   const ref = useRef();
   const onScreen = useOnScreen(ref, '25% 0px 25% 0px');
-  
+  // remove url protocol, so that it is selected by the browser itself
+  var srcURL = '';
+  if (configuration.url && onScreen) {
+    srcURL = configuration.url.replace(/http(s|):/, '');
+  }
   return (
     <div ref={ref} className={styles.container}>
       <iframe 
-        src={onScreen ? configuration.url : ''}
+        src={srcURL}
         scrolling='auto'
         frameBorder='0'
         align='aus'


### PR DESCRIPTION
use chart urls without protocol in iframe src,
so that correct protocol gets selected based on the parent