### PR TITLE
Read migrated attributes from configuration

### DIFF
--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -17,11 +17,9 @@ module Pageflow
              :type_name,
              :to => :entry)
 
-    delegate(:title, :summary, :credits, :manual_start,
+    delegate(:title, :summary, :credits,
              :widgets,
              :storylines, :main_storyline_chapters, :chapters, :pages,
-             :emphasize_chapter_beginning,
-             :emphasize_new_pages,
              :share_url, :share_image_id, :share_image_x, :share_image_y,
              :share_providers, :active_share_providers,
              :find_files, :find_file, :find_file_by_perma_id,
@@ -114,6 +112,18 @@ module Pageflow
 
     def overview_button
       OverviewButton.new(draft)
+    end
+
+    def manual_start
+      revision.configuration['manual_start']
+    end
+
+    def emphasize_chapter_beginning
+      revision.configuration['emphasize_chapter_beginning']
+    end
+
+    def emphasize_new_pages
+      revision.configuration['emphasize_new_pages']
     end
 
     def resolve_widgets(options = {})

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -20,9 +20,7 @@ module Pageflow
              :storylines, :main_storyline_chapters, :chapters, :pages,
              :find_files, :find_file, :find_file_by_perma_id,
              :image_files, :video_files, :audio_files,
-             :summary, :credits, :manual_start,
-             :emphasize_chapter_beginning,
-             :emphasize_new_pages,
+             :summary, :credits,
              :share_url, :share_image_id, :share_image_x, :share_image_y,
              :share_providers, :active_share_providers,
              :locale,
@@ -41,6 +39,18 @@ module Pageflow
 
     def title
       revision.title.presence || entry.title
+    end
+
+    def manual_start
+      revision.configuration['manual_start']
+    end
+
+    def emphasize_chapter_beginning
+      revision.configuration['emphasize_chapter_beginning']
+    end
+
+    def emphasize_new_pages
+      revision.configuration['emphasize_new_pages']
     end
 
     def stylesheet_model


### PR DESCRIPTION
The manual_start, emphasize_chapter_beginning and emphasize_chapter_beginning
attributes have been migrated to the revisions configuration.
Access via DraftEntry or PublishedEntry now delegates to the revisions configuration.
There is a modified getter for configuration in revision which accesses
legacy column values on read.

REDMINE-17498