### PR TITLE
Fix help link in editor page type drop down

### DIFF
--- a/packages/pageflow/src/editor/views/EditPageView.js
+++ b/packages/pageflow/src/editor/views/EditPageView.js
@@ -43,7 +43,7 @@ export const EditPageView = Marionette.Layout.extend({
 
       pictogramClass: 'type_pictogram',
 
-      helpLinkClicked: function(value) {
+      helpLinkClicked: value => {
         var pageType = this.options.api.pageTypes.findByName(value);
         app.trigger('toggle-help', pageType.seed.help_entry_translation_key);
       }


### PR DESCRIPTION
While replacing references to the global `pageflow.editor` with api
objects passed in via view options, it was overlooked that in the
event handler `this.options` does not refer to the options of the
`EditPageView`, but instead of the `ExtendedSelectInputView`.

Using an arrow function corrects the context of the callback.

REDMINE-17480