### PR TITLE
Include scrolled content element js files in gem

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
   s.files = Dir['{,entry_types/*/}' \
                 '{admins,app,config,db,lib,vendor,spec/factories,spec/fixtures}/**/*',
                 'packages/pageflow/{config/**/*,editor.js,ui.js,testHelpers.js,package.json}',
-                'entry_types/scrolled/package/{frontend.js,editor.js,package.json}',
+                'entry_types/scrolled/package/{contentElements-frontend.js,' \
+                'contentElements-editor.js,frontend.js,editor.js,package.json}',
                 'MIT-LICENSE', 'Rakefile', 'README.md', 'CHANGELOG.md']
 
   s.require_paths = ['lib', 'entry_types/paged/lib', 'entry_types/scrolled/lib']


### PR DESCRIPTION
These outputs have recently be added to the package and were
forgotten in the gemspec.

REDMINE-17382