### PR TITLE
Fix disabling home button input in account form based on theme

### DIFF
--- a/app/assets/javascripts/pageflow/admin/accounts.js
+++ b/app/assets/javascripts/pageflow/admin/accounts.js
@@ -1,6 +1,6 @@
 jQuery(function($) {
   $('.admin_accounts').filter('.new, .edit').find('form.pageflow_account').each(function() {
-    var themeSelect = $('#account_default_theming_attributes_theme_name', this);
+    var themeSelect = $('#account_paged_entry_template_attributes_theme_name', this);
     var themeOptions = JSON.parse($('script#theme_options', this).text());
     var homeButtonCheckBox = $('#account_paged_entry_template_attributes_configuration_home_button_enabled', this);
 


### PR DESCRIPTION
"Enable home button by default" check box needs to be disabled when
selected theme does not support home button. Theme select id changed
while extracting entry templates. Update selector.

REDMINE-17545