### PR TITLE
Add stories for section transitions

### DIFF
--- a/entry_types/scrolled/package/spec/support/stories.js
+++ b/entry_types/scrolled/package/spec/support/stories.js
@@ -217,7 +217,7 @@ function exampleStoryGroup({name, typeName, examples, parameters}) {
   }
 }
 
-function normalizeAndMergeFixture(options) {
+export function normalizeAndMergeFixture(options) {
   const seed = normalizeSeed(options);
 
   return {

--- a/entry_types/scrolled/package/src/frontend/__stories__/transitions-stories.js
+++ b/entry_types/scrolled/package/src/frontend/__stories__/transitions-stories.js
@@ -1,0 +1,108 @@
+import React from 'react';
+
+import {Entry, EntryStateProvider} from 'pageflow-scrolled/frontend';
+
+import {normalizeAndMergeFixture, filePermaId} from 'pageflow-scrolled/spec/support/stories';
+import {storiesOf} from '@storybook/react';
+
+const lorem = 'At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr. Sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet.';
+
+const stories = storiesOf('Frontend/Section Transitions', module);
+
+const transitions = ['fade', 'fadeBg', 'scroll', 'scrollOver', 'reveal', 'beforeAfter'];
+
+transitions.forEach(transition1 =>
+  transitions.forEach(transition2 =>
+    stories.add(
+      `${transition1}/${transition2}`,
+      () =>
+        <EntryStateProvider seed={exampleSeed(transition1, transition2)}>
+          <Entry />
+        </EntryStateProvider>,
+      {
+        percy: {skip: true}
+      }
+    )
+  )
+);
+
+function exampleSeed(transition1, transition2) {
+  return normalizeAndMergeFixture({
+    sections: [
+      {
+        id: 1,
+        configuration: {
+          transition: 'fade',
+          backdrop: {
+            image: filePermaId('imageFiles', 'turtle')
+          },
+          fullHeight: true
+        }
+      },
+      {
+        id: 2,
+        configuration: {
+          transition: transition1,
+          backdrop: {
+            image: filePermaId('imageFiles', 'churchBefore')
+          },
+          fullHeight: true
+        }
+      },
+      {
+        id: 3,
+        configuration: {
+          transition: transition2,
+          backdrop: {
+            image: filePermaId('imageFiles', 'churchAfter')
+          },
+          fullHeight: true
+        }
+      },
+    ],
+    contentElements: [
+      {
+        sectionId: 1,
+        typeName: 'heading',
+        configuration: {
+          children: `Transition ${transition1}/${transition2}`
+        }
+      },
+      {
+        sectionId: 1,
+        typeName: 'textBlock',
+        configuration: {
+          children: lorem
+        }
+      },
+      {
+        sectionId: 2,
+        typeName: 'heading',
+        configuration: {
+          children: `Transition ${transition1}`
+        }
+      },
+      {
+        sectionId: 2,
+        typeName: 'textBlock',
+        configuration: {
+          children: lorem
+        }
+      },
+      {
+        sectionId: 3,
+        typeName: 'heading',
+        configuration: {
+          children: `Transition ${transition2}`
+        }
+      },
+      {
+        sectionId: 3,
+        typeName: 'textBlock',
+        configuration: {
+          children: lorem
+        }
+      }
+    ]
+  })
+}


### PR DESCRIPTION
Make cross browser testing easier. Since CSS of a section depends on
entering and exiting transition, add one story for each combination of
enter/exit transitions.

Exclude from Percy build since visual diff is not meaningful.

REDMINE-17369