### PR TITLE
Publish pageflow-scrolled storybook via Travis

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,15 +49,6 @@ jobs:
         theme: pageflow-documentation-js-theme
         themePackage: codevise/pageflow-documentation-js-theme#master
 
-    - name: Build pageflow-scrolled Storybook
-      run: |
-        (cd entry_types/scrolled/package && yarn install && yarn build-storybook)
-        mkdir out/scrolled/storybook
-        ref="${{ github.ref }}"
-        ref=${ref/'refs/heads/'/}
-        ref=${ref/'refs/tags/'/}
-        mv entry_types/scrolled/package/.storybook/out out/scrolled/storybook/$ref
-
     - name: Deploy
       run: |
         wget https://raw.githubusercontent.com/peaceiris/actions-gh-pages/v2/entrypoint.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,16 +91,16 @@ jobs:
         - (cd entry_types/paged/packages/pageflow-paged; yarn test)
         - (cd entry_types/scrolled/package; yarn test)
 
-    - name: Percy - pageflow-scrolled
+    - name: Percy/Storybook - pageflow-scrolled
       <<: *ruby_job
       before_script:
         - |
-          export ON_UPSTREAM_MASTER=$([[ "$TRAVIS_PULL_REQUEST" == "false" && \
-                                         "$TRAVIS_REPO_SLUG" == "codevise/pageflow" && \
-                                         "$TRAVIS_BRANCH" == "master" ]] && echo "true" || echo "false")
+          export ON_UPSTREAM=$([[ "$TRAVIS_PULL_REQUEST" == "false" && \
+                                  "$TRAVIS_REPO_SLUG" == "codevise/pageflow" ]] &&
+                               echo "true" || echo "false")
 
-          if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$ON_UPSTREAM_MASTER" == "false" ]]; then
-            echo "Stopping job: Neither upstream master nor PR."
+          if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$ON_UPSTREAM" == "false" ]]; then
+            echo "Stopping job: Neither upstream nor PR."
             travis_terminate 0
           fi
 
@@ -116,8 +116,10 @@ jobs:
         - (cd entry_types/scrolled; bundle exec rake pageflow_scrolled:dummy)
       script:
         - |
-          export PAGEFLOW_PAPERCLIP_S3_ROOT=master
-          export PAGEFLOW_SCROLLED_DB_SEED_SKIP_FILES=$([[ $ON_UPSTREAM_MASTER == "true" ]] && echo "false" || echo "true")
+          export PAGEFLOW_PAPERCLIP_S3_ROOT=$([[ $ON_UPSTREAM == "true" ]] &&
+                                              echo "$TRAVIS_BRANCH" || echo "master")
+          export PAGEFLOW_SCROLLED_DB_SEED_SKIP_FILES=$([[ $ON_UPSTREAM == "true" ]] &&
+                                                        echo "false" || echo "true")
           export S3_BUCKET=de-codevise-pageflow-storybook-seed
           export S3_ACCESS_KEY=$STORYBOOK_SEED_S3_ACCESS_KEY
           export S3_SECRET_KEY=$STORYBOOK_SEED_S3_SECRET_KEY
@@ -128,3 +130,24 @@ jobs:
           export PT=b55731926f7bcb9344a0b3ff662613954a4137d3c21c1be748e9929823f19b08
         - (cd entry_types/scrolled; bundle exec rake pageflow_scrolled:storybook:seed:setup[package/.storybook/seed.json])
         - (cd entry_types/scrolled/package; yarn run snapshot)
+        - |
+          # Publish storybook to GitHub pages.
+
+          [[ $ON_UPSTREAM == "true" ]] || travis_terminate 0
+          cp -r entry_types/scrolled/package/.storybook/out $HOME/dist
+
+          git config --global user.email "travis@travis-ci.org"
+          git config --global user.name "Travis"
+
+          git clone --quiet https://${CODEVISE_BOT_PERSONAL_TOKEN}@github.com/codevise/pageflow-scrolled-storybook.git gh-pages > /dev/null
+          cd gh-pages
+
+          # Create directory for branch or tag. Remove old files if
+          # there already was a published storybook for this branch.
+          rm -rf $TRAVIS_BRANCH
+          mkdir $TRAVIS_BRANCH
+          cp -r $HOME/dist/* $TRAVIS_BRANCH
+
+          git add -f .
+          git commit -m "Travis build $TRAVIS_BUILD_NUMBER"
+          git push -fq origin master > /dev/null


### PR DESCRIPTION
The storybook generated via GitHub actions (#1392) is missing the seed data
file. Publish as part of Percy storybook job instead.

Use `$TRAVIS_BRANCH` as `$PAGEFLOW_PAPERCLIP_S3_ROOT` to make sure
storybook builds for version tags use their own set of files on
S3. Pull requests still use files based on the most recent `master`
build.

Run Percy job and publishing for all upstream branches and tags (not
just `master`) to keep a history of published storybooks.

We cannot use Travis gh-pages deploy strategy since it removes all
previously published files on deploy. We want to keep old versions,
though.

REDMINE-17369