### PR TITLE
Render placeholder for content element of missing type

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/ContentElement-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/ContentElement-spec.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import '@testing-library/jest-dom/extend-expect'
+import {render} from '@testing-library/react'
+
+import {ContentElement} from 'frontend/ContentElement';
+
+describe('ContentElement', () => {
+  it('renders placeholder if content element type is unknown', () => {
+    const {container} = render(<ContentElement type="fantasy" />);
+
+    expect(container).toHaveTextContent('Element of unknown type "fantasy"');
+  });
+});

--- a/entry_types/scrolled/package/src/frontend/ContentElement.js
+++ b/entry_types/scrolled/package/src/frontend/ContentElement.js
@@ -3,15 +3,22 @@ import React from 'react';
 import {api} from './api';
 import {withInlineEditingDecorator} from './inlineEditing';
 
+import styles from './ContentElement.module.css';
+
 export const ContentElement = withInlineEditingDecorator(
   'ContentElementDecorator',
   function ContentElement(props) {
     const Component = api.contentElementTypes.getComponent(props.type);
 
-    return (
-      <Component sectionProps={props.sectionProps}
-                 configuration={props.itemProps}
-                 contentElementId={props.id} />
-    );
+    if (Component) {
+      return (
+        <Component sectionProps={props.sectionProps}
+                   configuration={props.itemProps}
+                   contentElementId={props.id} />
+      );
+    }
+    else {
+      return <div className={styles.missing}>Element of unknown type "{props.type}"</div>
+    }
   }
 );

--- a/entry_types/scrolled/package/src/frontend/ContentElement.module.css
+++ b/entry_types/scrolled/package/src/frontend/ContentElement.module.css
@@ -1,0 +1,7 @@
+.missing {
+  color: #000;
+  background-color: #fff;
+  border-left: solid 5px #f44336;
+  padding: 0.5em;
+  margin: 1em 0;
+}

--- a/entry_types/scrolled/package/src/frontend/api/ContentElementTypeRegistry.js
+++ b/entry_types/scrolled/package/src/frontend/api/ContentElementTypeRegistry.js
@@ -31,10 +31,6 @@ export class ContentElementTypeRegistry {
   }
 
   getComponent(typeName) {
-    if (!this.types[typeName]) {
-      throw new Error(`Unknown content element type name "${typeName}"`);
-    }
-
-    return this.types[typeName].component;
+    return this.types[typeName] && this.types[typeName].component;
   }
 }


### PR DESCRIPTION
Prevent the whole preview from not rendering just because one content
element has an unknown type.