### PR TITLE
Make scrolled API respond with no content for PUT/DELETE

### DIFF
--- a/entry_types/scrolled/app/controllers/pageflow_scrolled/editor/chapters_controller.rb
+++ b/entry_types/scrolled/app/controllers/pageflow_scrolled/editor/chapters_controller.rb
@@ -16,7 +16,7 @@ module PageflowScrolled
         chapter = Chapter.all_for_revision(@entry.draft).find(params[:id])
         chapter.update_attributes(chapter_params)
 
-        render partial: 'pageflow_scrolled/chapters/chapter', locals: {chapter: chapter}
+        head :no_content
       rescue ActiveRecord::RecordNotFound
         head :not_found
       end
@@ -25,7 +25,7 @@ module PageflowScrolled
         chapter = Chapter.all_for_revision(@entry.draft).find(params[:id])
         chapter.destroy
 
-        render partial: 'pageflow_scrolled/chapters/chapter', locals: {chapter: chapter}
+        head :no_content
       rescue ActiveRecord::RecordNotFound
         head :not_found
       end

--- a/entry_types/scrolled/app/controllers/pageflow_scrolled/editor/content_elements_controller.rb
+++ b/entry_types/scrolled/app/controllers/pageflow_scrolled/editor/content_elements_controller.rb
@@ -29,8 +29,7 @@ module PageflowScrolled
         content_element = ContentElement.all_for_revision(@entry.draft).find(params[:id])
         content_element.update_attributes(content_element_params)
 
-        render partial: 'pageflow_scrolled/content_elements/content_element',
-               locals: {content_element: content_element}
+        head :no_content
       rescue ActiveRecord::RecordNotFound
         head :not_found
       end
@@ -39,8 +38,7 @@ module PageflowScrolled
         content_element = ContentElement.all_for_revision(@entry.draft).find(params[:id])
         content_element.destroy
 
-        render partial: 'pageflow_scrolled/content_elements/content_element',
-               locals: {content_element: content_element}
+        head :no_content
       rescue ActiveRecord::RecordNotFound
         head :not_found
       end

--- a/entry_types/scrolled/app/controllers/pageflow_scrolled/editor/sections_controller.rb
+++ b/entry_types/scrolled/app/controllers/pageflow_scrolled/editor/sections_controller.rb
@@ -17,7 +17,7 @@ module PageflowScrolled
         section = Section.all_for_revision(@entry.draft).find(params[:id])
         section.update_attributes(section_params)
 
-        render partial: 'pageflow_scrolled/sections/section', locals: {section: section}
+        head :no_content
       rescue ActiveRecord::RecordNotFound
         head :not_found
       end
@@ -26,7 +26,7 @@ module PageflowScrolled
         section = Section.all_for_revision(@entry.draft).find(params[:id])
         section.destroy
 
-        render partial: 'pageflow_scrolled/sections/section', locals: {section: section}
+        head :no_content
       rescue ActiveRecord::RecordNotFound
         head :not_found
       end

--- a/entry_types/scrolled/spec/controllers/pageflow_scrolled/editor/chapters_controller_spec.rb
+++ b/entry_types/scrolled/spec/controllers/pageflow_scrolled/editor/chapters_controller_spec.rb
@@ -76,6 +76,7 @@ module PageflowScrolled
               }, format: 'json')
 
         expect(chapter.reload.configuration).to eq('title' => 'A chapter title')
+        expect(response.status).to eq(204)
       end
 
       it 'does not allow updating a chapter from a different entry' do
@@ -95,17 +96,6 @@ module PageflowScrolled
               }, format: 'json')
 
         expect(response.status).to eq(404)
-      end
-
-      it 'renders attributes as camel case' do
-        entry = create(:entry)
-        chapter = create(:scrolled_chapter, revision: entry.draft)
-
-        authorize_for_editor_controller(entry)
-        patch(:update,
-              params: {entry_id: entry, id: chapter, chapter: attributes_for(:scrolled_chapter)},
-              format: 'json')
-        expect(json_response(path: [:permaId])).to be_present
       end
     end
 
@@ -190,6 +180,7 @@ module PageflowScrolled
                }, format: 'json')
 
         expect(storyline).to have(0).chapters
+        expect(response.status).to eq(204)
       end
 
       it 'does not allow deleting a chapter from a different entry' do
@@ -206,15 +197,6 @@ module PageflowScrolled
                }, format: 'json')
 
         expect(response.status).to eq(404)
-      end
-
-      it 'renders attributes as camel case' do
-        entry = create(:entry)
-        chapter = create(:scrolled_chapter, revision: entry.draft)
-
-        authorize_for_editor_controller(entry)
-        delete(:destroy, params: {entry_id: entry, id: chapter}, format: 'json')
-        expect(json_response(path: [:permaId])).to be_present
       end
     end
   end

--- a/entry_types/scrolled/spec/controllers/pageflow_scrolled/editor/content_elements_controller_spec.rb
+++ b/entry_types/scrolled/spec/controllers/pageflow_scrolled/editor/content_elements_controller_spec.rb
@@ -373,6 +373,7 @@ module PageflowScrolled
               }, format: 'json')
 
         expect(content_element.reload.configuration).to eq('children' => 'some content')
+        expect(response.status).to eq(204)
       end
 
       it 'does not allow updating a content element from a different entry' do
@@ -392,20 +393,6 @@ module PageflowScrolled
               }, format: 'json')
 
         expect(response.status).to eq(404)
-      end
-
-      it 'renders attributes as camel case' do
-        entry = create(:entry)
-        content_element = create(:content_element, :text_block, revision: entry.draft)
-
-        authorize_for_editor_controller(entry)
-        patch(:update,
-              params: {
-                entry_id: entry,
-                id: content_element,
-                content_element: attributes_for(:content_element, :text_block)
-              }, format: 'json')
-        expect(json_response(path: [:permaId])).to be_present
       end
     end
 
@@ -460,6 +447,7 @@ module PageflowScrolled
                }, format: 'json')
 
         expect(section).to have(0).content_elements
+        expect(response.status).to eq(204)
       end
 
       it 'does not allow deleting a content element from a different entry' do
@@ -475,17 +463,6 @@ module PageflowScrolled
                }, format: 'json')
 
         expect(response.status).to eq(404)
-      end
-
-      it 'renders attributes as camel case' do
-        entry = create(:entry)
-        content_element = create(:content_element, :text_block, revision: entry.draft)
-
-        authorize_for_editor_controller(entry)
-        delete(:destroy,
-               params: {entry_id: entry, id: content_element},
-               format: 'json')
-        expect(json_response(path: [:permaId])).to be_present
       end
     end
   end

--- a/entry_types/scrolled/spec/controllers/pageflow_scrolled/editor/sections_controller_spec.rb
+++ b/entry_types/scrolled/spec/controllers/pageflow_scrolled/editor/sections_controller_spec.rb
@@ -85,6 +85,7 @@ module PageflowScrolled
               }, format: 'json')
 
         expect(section.reload.configuration).to eq('title' => 'A title')
+        expect(response.status).to eq(204)
       end
 
       it 'does not allow updating a section from a different entry' do
@@ -104,20 +105,6 @@ module PageflowScrolled
               }, format: 'json')
 
         expect(response.status).to eq(404)
-      end
-
-      it 'renders attributes as camel case' do
-        entry = create(:entry)
-        section = create(:section, revision: entry.draft)
-
-        authorize_for_editor_controller(entry)
-        patch(:update,
-              params: {
-                entry_id: entry,
-                id: section,
-                section: attributes_for(:section)
-              }, format: 'json')
-        expect(json_response(path: [:permaId])).to be_present
       end
     end
 
@@ -190,6 +177,7 @@ module PageflowScrolled
                }, format: 'json')
 
         expect(chapter).to have(0).sections
+        expect(response.status).to eq(204)
       end
 
       it 'does not allow deleting a section from a different entry' do
@@ -206,17 +194,6 @@ module PageflowScrolled
                }, format: 'json')
 
         expect(response.status).to eq(404)
-      end
-
-      it 'renders attributes as camel case' do
-        entry = create(:entry)
-        section = create(:section, revision: entry.draft)
-
-        authorize_for_editor_controller(entry)
-        delete(:destroy,
-               params: {entry_id: entry, id: section},
-               format: 'json')
-        expect(json_response(path: [:permaId])).to be_present
       end
     end
   end


### PR DESCRIPTION
Otherwise Backbone passes the response to `set` again, causing an
unneeded entry state update and rerender.

REDMINE-17336