### PR TITLE
Make useEntryStructure/useSectionStructure hooks private

### DIFF
--- a/entry_types/scrolled/package/documentation.yml
+++ b/entry_types/scrolled/package/documentation.yml
@@ -25,8 +25,6 @@ toc:
     children:
       - useFile
       - useI18n
-      - useEntryStructure
-      - useSectionStructure
       - useEntryMetadata
       - useFileRights
       - useLegalInfo


### PR DESCRIPTION
Remove from docs since those cannot be used outside of
`pageflow/frontend` and might change in the future.

REDMINE-17376