### PR TITLE
Removed label dependency for before/after

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/BeforeAfter.js
+++ b/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/BeforeAfter.js
@@ -60,17 +60,11 @@ export function BeforeAfter({state,
   }
 
   if (current) {
-    // Size labels according to initial slider position. Unit is %,
-    // left and right spacing is 5%, so we subtract 10. 90 = 100 - 10.
-    const beforeLabelWidth = initial_slider_position - 10;
-    const afterLabelWidth = 90 - initial_slider_position;
     // Compute initial slider coordinate and pass it as a CSS
     // variable, so that before/after images can wiggle together with
     // the slider
     const containerWidth = current.getBoundingClientRect().width;
     const initialRectWidth = initialSliderPos * containerWidth;
-    current.style.setProperty('--before-label-max-width', beforeLabelWidth + '%');
-    current.style.setProperty('--after-label-max-width', afterLabelWidth + '%');
     current.style.setProperty('--initial-rect-width', initialRectWidth + 'px');
   }
 

--- a/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/BeforeAfter.module.css
+++ b/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/BeforeAfter.module.css
@@ -45,8 +45,6 @@
 /* With react-compare-image 2.0.4 (commit 7410d14), this selects the
    before label */
 .container div div:nth-child(4) div {
-  max-width: calc(var(--before-label-max-width, var(--default-label-max-width)) -
-                  var(--label-padding));
 }
 
 /* With react-compare-image 2.0.4 (commit 7410d14), this selects the
@@ -58,8 +56,6 @@
 /* With react-compare-image 2.0.4 (commit 7410d14), this selects the
    after label */
 .container div div:nth-child(5) div {
-  max-width: calc(var(--after-label-max-width, var(--default-label-max-width)) -
-                  var(--label-padding));
 }
 
 @keyframes BeforeImageLeftRightShake {


### PR DESCRIPTION
[REDMINE#17372](https://redmine.codevise.de/issues/17372)

(1/6)
- [X] Remove dependency between label width and slider initial position

> Removed max-width for label of before/after content element, which was causing the long labels to break in to different lines. Removed all the variables containing label width dependent on the slider position