### PR TITLE
Delay label fadeout on mousedown/touchstart

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/BeforeAfter.module.css
+++ b/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/BeforeAfter.module.css
@@ -32,6 +32,7 @@
 /* With react-compare-image 2.0.4 (commit 7410d14), this selects the
    before label */
 .container div div:nth-child(4) div {
+  transition: opacity 0.1s ease-out 0.3s !important;
 }
 
 /* With react-compare-image 2.0.4 (commit 7410d14), this selects the
@@ -43,6 +44,7 @@
 /* With react-compare-image 2.0.4 (commit 7410d14), this selects the
    after label */
 .container div div:nth-child(5) div {
+  transition: opacity 0.1s ease-out 0.3s !important;
 }
 
 @keyframes BeforeImageLeftRightShake {


### PR DESCRIPTION
[REDMINE#17372](https://redmine.codevise.de/issues/17372)

(2/6)
- [X] Delay label fadeout on mousedown/touchstart

> Increased the fade out transition time of before/after labels so there must be a delay in fade-out on mousedown/touchstart.
Since it was an inline property coming from `react-compare-image`, so override the value by using `!important`. 