### PR TITLE
Give height to element in case of no images

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/InlineBeforeAfter.module.css
+++ b/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/InlineBeforeAfter.module.css
@@ -1,4 +1,5 @@
 .root {
   position: relative;
   margin: 0 auto;
+  min-height: 30px;
 }


### PR DESCRIPTION
[REDMINE#17372](https://redmine.codevise.de/issues/17372)

(3/6)
- [X] Give height to element if there are no images

> Give minimum `min-height` to the `inline_before_after_root` element so if there are no images the element can be easily selected which before was difficult.