### PR TITLE
Hide Datawrapper chart in Percy snapshot

### DIFF
--- a/entry_types/scrolled/package/.storybook/preview-head.html
+++ b/entry_types/scrolled/package/.storybook/preview-head.html
@@ -5,4 +5,22 @@
   video::-webkit-media-controls-timeline {
     visibility: hidden;
   }
+
+  [data-percy=hide] {
+    position: relative;
+  }
+
+  [data-percy=hide]::after {
+    content: "Content hidden to prevent flaky Percy snapshots";
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    background: green;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+  }
 </style>

--- a/entry_types/scrolled/package/src/contentElements/dataWrapperChart/DataWrapperChart.js
+++ b/entry_types/scrolled/package/src/contentElements/dataWrapperChart/DataWrapperChart.js
@@ -15,8 +15,8 @@ export function DataWrapperChart({configuration}) {
     srcURL = configuration.url.replace(/http(s|):/, '');
   }
   return (
-    <div ref={ref} className={styles.container}>
-      <iframe 
+    <div ref={ref} className={styles.container} data-percy="hide">
+      <iframe
         src={srcURL}
         scrolling='auto'
         frameBorder='0'


### PR DESCRIPTION
Prevent flaky snapshots when chart does not load fast enough.

REDMINE-17388