### PR TITLE
Ensure empty paragraphs have height

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/EditableText-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/EditableText-spec.js
@@ -101,4 +101,30 @@ describe('EditableText', () => {
 
     expect(getByRole('link')).toHaveTextContent('here')
   });
+
+  it('renders zero width no break space in empty leafs to prevent empty paragraphs from collapsing', () => {
+    const value = [{
+      type: 'paragraph',
+      children: [
+        {text: ''}
+      ]
+    }];
+
+    const {container} = render(<EditableText value={value} />);
+
+    expect(container.querySelector('p')).toHaveTextContent('\uFEFF', {normalizeWhitespace: false})
+  });
+
+  it('renders zero width no break space in blank leafs to prevent empty paragraphs from collapsing', () => {
+    const value = [{
+      type: 'paragraph',
+      children: [
+        {text: '  '}
+      ]
+    }];
+
+    const {container} = render(<EditableText value={value} />);
+
+    expect(container.querySelector('p')).toHaveTextContent('\uFEFF', {normalizeWhitespace: false})
+  });
 });

--- a/entry_types/scrolled/package/src/frontend/EditableText.js
+++ b/entry_types/scrolled/package/src/frontend/EditableText.js
@@ -14,10 +14,14 @@ export const EditableText = withInlineEditingAlternative('EditableText', functio
 function render(children = []) {
   return children.map((element, index) => {
     if (element.type) {
-      return renderElement({attributes: {key: index}, element, children: render(element.children)})
+      return renderElement({attributes: {key: index}, element, children: render(element.children)});
     }
     else {
-      return renderLeaf({attributes: {key: index}, leaf: element, children: element.text})
+      return renderLeaf({
+        attributes: {key: index},
+        leaf: element,
+        children: element.text.trim() === '' ? '\uFEFF' : element.text
+      });
     }
   });
 }


### PR DESCRIPTION
Simple way to span short sections with no other content than the
backdrop image.

REDMINE-17704