### PR TITLE
Preview thumbnails for section transitions

### DIFF
--- a/entry_types/scrolled/package/spec/editor/views/EditSectionTransitionView-spec.js
+++ b/entry_types/scrolled/package/spec/editor/views/EditSectionTransitionView-spec.js
@@ -1,6 +1,6 @@
 import {EditSectionTransitionView} from 'editor/views/EditSectionTransitionView';
 import {ScrolledEntry} from 'editor/models/ScrolledEntry';
-import {SelectInput, TransitionsInput} from 'pageflow/testHelpers';
+import {RadioButtonGroupInput} from 'pageflow/testHelpers';
 import {normalizeSeed, factories} from 'support';
 
 describe('EditSectionTransitionView', () => {
@@ -19,7 +19,7 @@ describe('EditSectionTransitionView', () => {
     });
 
     view.render();
-    const transitionsSelectInput = TransitionsInput.findByPropertyName('transition', {inView: view});
+    const transitionsSelectInput = RadioButtonGroupInput.findByPropertyName('transition', {inView: view});
 
     expect(transitionsSelectInput.enabledValues()).toContain('fade');
     expect(transitionsSelectInput.enabledValues()).toContain('fadeBg');
@@ -38,9 +38,9 @@ describe('EditSectionTransitionView', () => {
       model: entry.sections.get(2),
       entry
     });
-    
+
     view.render();
-    const transitionsSelectInput = TransitionsInput.findByPropertyName('transition', {inView: view});
+    const transitionsSelectInput = RadioButtonGroupInput.findByPropertyName('transition', {inView: view});
 
     expect(transitionsSelectInput.enabledValues()).toContain('scroll');
     expect(transitionsSelectInput.enabledValues()).not.toContain('fade');

--- a/entry_types/scrolled/package/spec/editor/views/EditSectionTransitionView-spec.js
+++ b/entry_types/scrolled/package/spec/editor/views/EditSectionTransitionView-spec.js
@@ -1,6 +1,6 @@
 import {EditSectionTransitionView} from 'editor/views/EditSectionTransitionView';
 import {ScrolledEntry} from 'editor/models/ScrolledEntry';
-import {SelectInput} from 'pageflow/testHelpers';
+import {SelectInput, TransitionsInput} from 'pageflow/testHelpers';
 import {normalizeSeed, factories} from 'support';
 
 describe('EditSectionTransitionView', () => {
@@ -19,7 +19,7 @@ describe('EditSectionTransitionView', () => {
     });
 
     view.render();
-    const transitionsSelectInput = SelectInput.findByPropertyName('transition', {inView: view});
+    const transitionsSelectInput = TransitionsInput.findByPropertyName('transition', {inView: view});
 
     expect(transitionsSelectInput.enabledValues()).toContain('fade');
     expect(transitionsSelectInput.enabledValues()).toContain('fadeBg');
@@ -38,9 +38,9 @@ describe('EditSectionTransitionView', () => {
       model: entry.sections.get(2),
       entry
     });
-
+    
     view.render();
-    const transitionsSelectInput = SelectInput.findByPropertyName('transition', {inView: view});
+    const transitionsSelectInput = TransitionsInput.findByPropertyName('transition', {inView: view});
 
     expect(transitionsSelectInput.enabledValues()).toContain('scroll');
     expect(transitionsSelectInput.enabledValues()).not.toContain('fade');

--- a/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.js
+++ b/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.js
@@ -1,14 +1,11 @@
-
 import $ from 'jquery';
 import I18n from 'i18n-js';
 import Marionette from 'backbone.marionette';
 import _ from 'underscore';
-//import {app, cssModulesUtils} from 'pageflow/editor';
 
 import {inputView} from 'pageflow/ui';
 
 import styles from './EditSectionTransitionEffectView.module.css';
-
 
 export const EditSectionTransitionEffectView = Marionette.ItemView.extend({
   mixins: [inputView],
@@ -18,7 +15,7 @@ export const EditSectionTransitionEffectView = Marionette.ItemView.extend({
         <span class="name"></span>
         <span class="inline_help"></span>
     </label>
-    <div class="radio_buttons_container" />
+    <div class="transitions_container" />
     `,
 
   events: {
@@ -27,7 +24,7 @@ export const EditSectionTransitionEffectView = Marionette.ItemView.extend({
 
   ui: {
     label: 'label',
-    container: ".radio_buttons_container"
+    container: ".transitions_container"
   },
 
   initialize: function() {
@@ -38,10 +35,16 @@ export const EditSectionTransitionEffectView = Marionette.ItemView.extend({
                 return translationKeyPrefix + '.transition.values.' + value;
             }, this);
         }
-  
+
         this.options.texts = _.map(this.options.translationKeys, function(key) {
           return I18n.t(key);
         });
+    }
+
+    if (!this.options.groups) {
+      this.options.groups = _.map(this.options.groupTanslationKeys, function(key) {
+        return I18n.t(key);
+      });
     }
   },
 
@@ -49,24 +52,22 @@ export const EditSectionTransitionEffectView = Marionette.ItemView.extend({
     this.ui.label.attr('for', this.cid);
     this.appendOptions();
     this.load();
-    //this.select();
     this.listenTo(this.model, 'change:' + this.options.propertyName, this.load);
   },
 
   appendOptions: function () {
     _.each(this.options.values, function(value, index) {
       var option = `<div class="${styles.transition} ${this.options.optionDisabled(value) ? styles['disabled'] : 'enabled'}">
-                   <div class="${styles[value]}"><div class="${styles.upper_section}">A</div><div class="${styles.lower_section}">B</div></div>
-                   <label><input type="radio" value="${value}" name="transitions"/>
-                   ${this.options.texts[index]}</label></div>`;
+                      <div class="${styles[value]}">
+                        <div class="${styles.upper_section}">A</div>
+                        <div class="${styles.lower_section}">B</div>
+                      </div>
+                      <label>
+                        <input type="radio" value="${value}" name="transitions"  ${this.options.optionDisabled(value) ? 'disabled' : ''}"/>
+                        ${this.options.texts[index]}
+                      </label>
+                    </div>`;
       this.ui.container.append($(option));
-        
-    //   if (this.options.optionDisabled &&
-    //     this.options.optionDisabled(value)) {
-    //   //option.setAttribute('disabled', true);
-    //   option.classList.add('disable');
-    // }
-    // console.log(this);
     }, this);
   },
 
@@ -80,28 +81,24 @@ export const EditSectionTransitionEffectView = Marionette.ItemView.extend({
     this.model.set(this.options.propertyName, configured.attr('value'));
   },
 
-  // select: function() {
-  //   var select = {};
-  //   _.each(this.ui.container.find('div'), function(div) {
-  //       if ($(div).hasClass(styles.active)) {
-  //           select = $(div);
-  //       }
-  //       else {
-  //           $(div).context.parentElement.classList.remove(styles.active);          
-  //       }
-  //   });
-  //   //select.context.parentElement.classList.add(styles.active);
-  //   console.log(select);
-  //},
-
   load: function() {
     if (!this.isClosed) {
-      _.each(this.options.values, function(value) {
-        this.ui.container
-          .find('input[value="'+value+'"]')
-          .prop('checked', this.model.get(this.options.propertyName)[value]);
-      }, this);
+      var value = this.model.get(this.options.propertyName);
+
+      if (this.model.has(this.options.propertyName) &&
+          this.ui.container.find('input[value="' + value +'"]:not([checked])').length) {
+
+        var select = {};
+        _.each(this.ui.container.find('div'), function(div) {
+                if (div.classList.contains(styles[value])) {
+                    select = $(div);
+                }
+                else {
+                    $(div).context.parentElement.classList.remove(styles.active);
+                }
+            });
+        select.context.parentElement.classList.add(styles.active);
+      }
     }
   }
 });
-

--- a/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.js
+++ b/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.js
@@ -63,7 +63,7 @@ export const EditSectionTransitionEffectView = Marionette.ItemView.extend({
                         <div class="${styles.lower_section}">B</div>
                       </div>
                       <label>
-                        <input type="radio" value="${value}" name="transitions"  ${this.options.optionDisabled(value) ? 'disabled' : ''}"/>
+                        <input type="radio" value="${value}" name="transitions"  ${this.options.optionDisabled(value) ? 'disabled' : ''}/>
                         ${this.options.texts[index]}
                       </label>
                     </div>`;

--- a/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.js
+++ b/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.js
@@ -1,0 +1,107 @@
+
+import $ from 'jquery';
+import I18n from 'i18n-js';
+import Marionette from 'backbone.marionette';
+import _ from 'underscore';
+//import {app, cssModulesUtils} from 'pageflow/editor';
+
+import {inputView} from 'pageflow/ui';
+
+import styles from './EditSectionTransitionEffectView.module.css';
+
+
+export const EditSectionTransitionEffectView = Marionette.ItemView.extend({
+  mixins: [inputView],
+
+  template: () => `
+    <label>
+        <span class="name"></span>
+        <span class="inline_help"></span>
+    </label>
+    <div class="radio_buttons_container" />
+    `,
+
+  events: {
+    'change': 'save'
+  },
+
+  ui: {
+    label: 'label',
+    container: ".radio_buttons_container"
+  },
+
+  initialize: function() {
+    if (!this.options.texts) {
+        if (!this.options.translationKeys) {
+            var translationKeyPrefix = this.options.attributeTranslationKeyPrefixes;
+            this.options.translationKeys = _.map(this.options.values, function(value) {
+                return translationKeyPrefix + '.transition.values.' + value;
+            }, this);
+        }
+  
+        this.options.texts = _.map(this.options.translationKeys, function(key) {
+          return I18n.t(key);
+        });
+    }
+  },
+
+  onRender: function() {
+    this.ui.label.attr('for', this.cid);
+    this.appendOptions();
+    this.load();
+    //this.select();
+    this.listenTo(this.model, 'change:' + this.options.propertyName, this.load);
+  },
+
+  appendOptions: function () {
+    _.each(this.options.values, function(value, index) {
+      var option = `<div class="${styles.transition} ${this.options.optionDisabled(value) ? styles['disabled'] : 'enabled'}">
+                   <div class="${styles[value]}"><div class="${styles.upper_section}">A</div><div class="${styles.lower_section}">B</div></div>
+                   <label><input type="radio" value="${value}" name="transitions"/>
+                   ${this.options.texts[index]}</label></div>`;
+      this.ui.container.append($(option));
+        
+    //   if (this.options.optionDisabled &&
+    //     this.options.optionDisabled(value)) {
+    //   //option.setAttribute('disabled', true);
+    //   option.classList.add('disable');
+    // }
+    // console.log(this);
+    }, this);
+  },
+
+  save: function() {
+    var configured = {};
+    _.each(this.ui.container.find('input'), function(input) {
+        if ($(input).is(':checked')) {
+            configured = $(input);
+        }
+    });
+    this.model.set(this.options.propertyName, configured.attr('value'));
+  },
+
+  // select: function() {
+  //   var select = {};
+  //   _.each(this.ui.container.find('div'), function(div) {
+  //       if ($(div).hasClass(styles.active)) {
+  //           select = $(div);
+  //       }
+  //       else {
+  //           $(div).context.parentElement.classList.remove(styles.active);          
+  //       }
+  //   });
+  //   //select.context.parentElement.classList.add(styles.active);
+  //   console.log(select);
+  //},
+
+  load: function() {
+    if (!this.isClosed) {
+      _.each(this.options.values, function(value) {
+        this.ui.container
+          .find('input[value="'+value+'"]')
+          .prop('checked', this.model.get(this.options.propertyName)[value]);
+      }, this);
+    }
+  }
+});
+

--- a/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.module.css
+++ b/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.module.css
@@ -13,11 +13,14 @@
 .disabled {
     pointer-events: none;
     opacity: 0.3;
-    cursor: not-allowed;
 }
 
 .active {
-    background: #AB3703 !important;
+    background: #6c757d !important;
+}
+
+.active label {
+    color: #ffffff;
 }
 
 .transition {
@@ -56,7 +59,7 @@
 .transition:hover .scroll .lower_section,
 .transition:hover .scrollOver .lower_section {
     animation: Scroll 2s ease infinite;
-} 
+}
 
 /*Reveal*/
 .transition:hover .reveal .upper_section {

--- a/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.module.css
+++ b/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.module.css
@@ -1,0 +1,164 @@
+.upper_section {
+    background: #50514f;
+    height: 100%;
+    width: 100%;
+}
+
+.lower_section {
+    background: #A2A2A2;
+    height: 100%;
+    width: 100%;
+}
+
+.disabled {
+    pointer-events: none;
+    opacity: 0.3;
+    cursor: not-allowed;
+}
+
+.active {
+    background: #AB3703 !important;
+}
+
+.transition {
+    padding: 15px 0;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    border-top: 1px solid #808080;
+    background: #e5e5e5;
+}
+.transition:hover,
+.transition input[type="radio"]:checked + label {
+     background: #ddd;
+}
+
+
+/*Fade*/
+.transition:hover .fade .upper_section {
+    visibility: hidden;
+    opacity: 0.5;
+}
+
+/*Fade Background Upper*/
+.transition:hover .fadeBg .upper_section {
+    visibility: hidden;
+    transform: translateY(-100%);
+}
+
+/*face Background Lower*/
+.transition:hover .fadeBg .lower_section {
+    transform: translateY(-100%);
+}
+
+/*Scroll and Scroll Over*/
+.transition:hover .scroll .upper_section,
+.transition:hover .scroll .lower_section,
+.transition:hover .scrollOver .lower_section {
+    animation: Scroll 2s ease infinite;
+} 
+
+/*Reveal*/
+.transition:hover .reveal .upper_section {
+    animation: Reveal 2s ease infinite;
+}
+
+/*Before After*/
+.transition:hover .beforeAfter .upper_section {
+    color: transparent;
+    height: 0;
+}
+
+.transition > div {
+    width: 30%;
+    height: 100%;
+    margin: 2%;
+    border-radius: 5%;
+    color: white;
+    text-align: center;
+    font-size: 26px;
+    overflow: hidden;
+}
+
+/*Fade + Reveal + Before After*/
+.fade,
+.reveal,
+.beforeAfter {
+    position: relative;
+}
+
+/*Fade + Reveal + Before After Lower Sections*/
+.fade .lower_section,
+.reveal .lower_section,
+.beforeAfter .lower_section {
+    position: absolute;
+}
+
+/*fade Upper Section*/
+.fade .upper_section {
+    transition: all 2s ease-in-out;
+    position: absolute;
+    z-index: 1;
+}
+
+/*Reveal Upper Section*/
+.reveal .upper_section {
+    position: absolute;
+    z-index: 1;
+}
+
+/*Before After Upper Section*/
+.beforeAfter .upper_section {
+    transition: all 2s ease-in-out;
+    position: absolute;
+    z-index: 1;
+}
+
+/*Fade Background*/
+.fadeBg .upper_section,
+.fadeBg .lower_section {
+    transition: all 2s ease-in-out;
+}
+
+/*Scroll + Scroll Over Upper Sections*/
+.scroll .upper_section,
+.scrollOver .upper_section {
+    height: 50%;
+}
+
+/*Scroll Lower Section*/
+.scroll .lower_section {
+    height: 70%;
+}
+
+
+/*Input*/
+.transition input {
+    opacity: 0;
+}
+
+/*Label*/
+.transition label {
+    display: block;
+    text-align: left;
+    height: 100%;
+    width: 70%;
+}
+
+/*Keyframes*/
+@keyframes Scroll {
+    50% {
+        transform: translateY(-30%);
+   }
+    100% {
+        transform: translateY(0);
+   }
+}
+@keyframes Reveal {
+    50% {
+        transform: translateY(-100%);
+   }
+    100% {
+        transform: translateY(0);
+   }
+}

--- a/entry_types/scrolled/package/src/editor/views/EditSectionTransitionView.js
+++ b/entry_types/scrolled/package/src/editor/views/EditSectionTransitionView.js
@@ -1,5 +1,6 @@
 import {EditConfigurationView} from 'pageflow/editor';
 import {SelectInputView} from 'pageflow/ui';
+import {EditSectionTransitionEffectView} from './EditSectionTransitionEffectView';
 import {getTransitionNames, getAvailableTransitionNames} from 'pageflow-scrolled/frontend';
 
 export const EditSectionTransitionView = EditConfigurationView.extend({
@@ -16,7 +17,7 @@ export const EditSectionTransitionView = EditConfigurationView.extend({
     );
 
     configurationEditor.tab('transition', function() {
-      this.input('transition', SelectInputView, {
+      this.input('transition', EditSectionTransitionEffectView, {
         values: getTransitionNames(),
         optionDisabled: (value) => !availableTransitions.includes(value)
       });

--- a/package/src/testHelpers/dominos/ui/index.js
+++ b/package/src/testHelpers/dominos/ui/index.js
@@ -3,5 +3,5 @@ export * from './ConfigurationEditorTab'
 export * from './Table'
 export * from './Tabs';
 export * from './inputs/ColorInput'
+export * from './inputs/RadioButtonGroupInput'
 export * from './inputs/SelectInput'
-export * from './inputs/TransitionsInput'

--- a/package/src/testHelpers/dominos/ui/index.js
+++ b/package/src/testHelpers/dominos/ui/index.js
@@ -4,3 +4,4 @@ export * from './Table'
 export * from './Tabs';
 export * from './inputs/ColorInput'
 export * from './inputs/SelectInput'
+export * from './inputs/TransitionsInput'

--- a/package/src/testHelpers/dominos/ui/inputs/RadioButtonGroupInput.js
+++ b/package/src/testHelpers/dominos/ui/inputs/RadioButtonGroupInput.js
@@ -2,11 +2,7 @@ import $ from 'jquery';
 
 import {Base} from './Base';
 
-export const TransitionsInput = Base.extend({
-  value: function() {
-    return this.$el.find('input').val();
-  },
-
+export const RadioButtonGroupInput = Base.extend({
   values: function() {
     return this.$el.find('input').map(function() {
       return $(this).attr('value');

--- a/package/src/testHelpers/dominos/ui/inputs/TransitionsInput.js
+++ b/package/src/testHelpers/dominos/ui/inputs/TransitionsInput.js
@@ -1,0 +1,21 @@
+import $ from 'jquery';
+
+import {Base} from './Base';
+
+export const TransitionsInput = Base.extend({
+  value: function() {
+    return this.$el.find('input').val();
+  },
+
+  values: function() {
+    return this.$el.find('input').map(function() {
+      return $(this).attr('value');
+    }).get();
+  },
+
+  enabledValues: function() {
+    return this.$el.find('input:not([disabled])').map(function() {
+      return $(this).attr('value');
+    }).get();
+  }
+});


### PR DESCRIPTION
REDMINE-17641

[PR-1455](https://github.com/codevise/pageflow/pull/1455)
- Created a thumbnail input preview for the section transitions.
- For the new section transition input view, changed the dropdown to radio button to add animations and select only one at a time. Hide the buttons.
- Created a new radio button template, added in the input view.
- Gave some basic stylings.
- Changed the selectInputView to thumbnailInputView in EditSectionTransitionView.

Update:

- Make thumbnail input preview specific to Pageflow Scrolled.
- Deleted the previously created files.
- Shifted the sass to css module.
