### PR TITLE
Display pillar boxes for full width inline images

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/inlineImage/InlineImage.js
+++ b/entry_types/scrolled/package/src/contentElements/inlineImage/InlineImage.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import {Image, InlineCaption, useContentElementLifecycle} from 'pageflow-scrolled/frontend';
+import {
+  Image,
+  InlineCaption,
+  ViewportDependentPillarBoxes,
+  useContentElementLifecycle
+} from 'pageflow-scrolled/frontend';
 
 import styles from './InlineImage.module.css';
 
@@ -9,16 +14,17 @@ export function InlineImage({configuration}) {
   const {isPrepared} = useContentElementLifecycle();
 
   return (
-    <div className={classNames(styles.root)}>
-      <div className={styles.container}>
-        <div className={styles.spacer}>
-          <div className={styles.inner}>
-            <Image {...configuration}
-                   isPrepared={isPrepared}
-                   variant={configuration.position === 'full' ?  'large' : 'medium'} />
+    <div className={classNames(styles.root, {[styles.box]: configuration.position !== 'full'})}>
+      <ViewportDependentPillarBoxes aspectRatio={0.75}
+                                    position={configuration.position}>
+          <div className={styles.spacer}>
+            <div className={styles.inner}>
+              <Image {...configuration}
+                     isPrepared={isPrepared}
+                     variant={configuration.position === 'full' ?  'large' : 'medium'} />
+            </div>
           </div>
-        </div>
-      </div>
+      </ViewportDependentPillarBoxes>
       <InlineCaption text={configuration.caption} />
     </div>
   )

--- a/entry_types/scrolled/package/src/contentElements/inlineImage/InlineImage.module.css
+++ b/entry_types/scrolled/package/src/contentElements/inlineImage/InlineImage.module.css
@@ -1,5 +1,8 @@
 .root {
   position: relative;
+}
+
+.box {
   margin-top: 1em;
 }
 
@@ -13,10 +16,13 @@
 }
 
 .inner {
-  border: solid 2px #fff;
   position: absolute;
   top: 0;
   left: 0;
   bottom: 0;
   right: 0;
+}
+
+.box .inner {
+  border: solid 2px #fff;
 }


### PR DESCRIPTION
Prevent inline images from becoming taller than the viewport.

REDMINE-17708