### PR TITLE
Use consistent margins around content elements

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/inlineAudio/InlineAudio.module.css
+++ b/entry_types/scrolled/package/src/contentElements/inlineAudio/InlineAudio.module.css
@@ -1,3 +1,2 @@
 .root {
-  margin-top: 15px;
 }

--- a/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/InlineBeforeAfter.module.css
+++ b/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/InlineBeforeAfter.module.css
@@ -1,5 +1,0 @@
-.root {
-  position: relative;
-  margin: 0 auto;
-  min-height: 30px;
-}

--- a/entry_types/scrolled/package/src/contentElements/videoEmbed/VideoEmbed.module.css
+++ b/entry_types/scrolled/package/src/contentElements/videoEmbed/VideoEmbed.module.css
@@ -1,5 +1,4 @@
 .VideoEmbed {
-  margin-bottom: 15px;
 }
 
 .embedPlayer {

--- a/entry_types/scrolled/package/src/frontend/ContentElement.js
+++ b/entry_types/scrolled/package/src/frontend/ContentElement.js
@@ -4,6 +4,7 @@ import {api} from './api';
 import {withInlineEditingDecorator} from './inlineEditing';
 import {ContentElementAttributesProvider} from './useContentElementAttributes';
 import {ContentElementLifecycleProvider} from './useContentElementLifecycle';
+import {ContentElementMargin} from './ContentElementMargin';
 
 import styles from './ContentElement.module.css';
 
@@ -16,9 +17,11 @@ export const ContentElement = withInlineEditingDecorator(
       return (
         <ContentElementAttributesProvider id={props.id}>
           <ContentElementLifecycleProvider type={props.type}>
-            <Component sectionProps={props.sectionProps}
-                       configuration={props.itemProps}
-                       contentElementId={props.id} />
+            <ContentElementMargin position={props.itemProps.position}>
+              <Component sectionProps={props.sectionProps}
+                         configuration={props.itemProps}
+                         contentElementId={props.id} />
+            </ContentElementMargin>
           </ContentElementLifecycleProvider>
         </ContentElementAttributesProvider>
       );

--- a/entry_types/scrolled/package/src/frontend/ContentElementMargin.js
+++ b/entry_types/scrolled/package/src/frontend/ContentElementMargin.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import styles from './ContentElementMargin.module.css';
+
+export function ContentElementMargin({position, children}) {
+  if (position === 'full') {
+    return children;
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      {children}
+    </div>
+  );
+}

--- a/entry_types/scrolled/package/src/frontend/ContentElementMargin.module.css
+++ b/entry_types/scrolled/package/src/frontend/ContentElementMargin.module.css
@@ -1,0 +1,3 @@
+.wrapper {
+  margin: 1em 0;
+}

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/SelectionRect.module.css
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/SelectionRect.module.css
@@ -92,7 +92,7 @@
   display: inline-block;
   vertical-align: top;
   position: relative;
-  top: -8px;
+  top: -9px;
   padding: 2px 10px;
 }
 


### PR DESCRIPTION
Add top/bottom margin to all content elements - except for position
full to ensure the section backdrop does not become visible
above/below full width elements in single element sections.

REDMINE-17672