### PR TITLE
Add existence check for dash source

### DIFF
--- a/package/src/frontend/VideoPlayer/filterSources.js
+++ b/package/src/frontend/VideoPlayer/filterSources.js
@@ -19,8 +19,10 @@ export const filterSources = function(playerElement) {
   else if (browser.has('mse and native hls support')) {
     // remove dash source to ensure hls is used
     const dashSource = playerElement.querySelector('source[type="application/dash+xml"]');
-    playerElement.removeChild(dashSource);
-    changed = true;
+    if(dashSource) {
+      playerElement.removeChild(dashSource);
+      changed = true;
+    }
   }
 
   if (changed) {


### PR DESCRIPTION
Safari complains about removing a non-existent child.

REDMINE-17646