### PR TITLE
Change default of text-shadow for gradient box

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/heading/Heading.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/Heading.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import {withShadowClassName} from 'pageflow-scrolled/frontend';
 
 import {Text} from 'pageflow-scrolled/frontend';
 
@@ -7,7 +8,8 @@ import styles from './Heading.module.css';
 
 export function Heading({configuration}) {
   return (
-    <h1 className={classNames(styles.root, {[styles.first]: configuration.first})}>
+    <h1 className={classNames(styles.root, {[styles.first]: configuration.first},
+                              withShadowClassName)}>
       <Text scaleCategory={configuration.first ? 'h1' : 'h2'} inline={true}>
         {configuration.children}
       </Text>

--- a/entry_types/scrolled/package/src/contentElements/textBlock/TextBlock.module.css
+++ b/entry_types/scrolled/package/src/contentElements/textBlock/TextBlock.module.css
@@ -1,7 +1,3 @@
-.text {
-  text-shadow: none;
-}
-
 .text p {
   margin: 1em 0;
 }

--- a/entry_types/scrolled/package/src/frontend/InlineCaption.module.css
+++ b/entry_types/scrolled/package/src/frontend/InlineCaption.module.css
@@ -2,5 +2,4 @@
   padding: 3px 10px 5px;
   background-color: #fff;
   color: #222;
-  text-shadow: none;
 }

--- a/entry_types/scrolled/package/src/frontend/foregroundBoxes/GradientBox.module.css
+++ b/entry_types/scrolled/package/src/frontend/foregroundBoxes/GradientBox.module.css
@@ -16,7 +16,7 @@
   bottom: -100vh;
 }
 
-.gradient {
+.gradient .withShadow {
   text-shadow: 0px 1px 5px black;
 }
 

--- a/entry_types/scrolled/package/src/frontend/index.js
+++ b/entry_types/scrolled/package/src/frontend/index.js
@@ -8,6 +8,10 @@ import Entry from './Entry';
 import {setupI18n} from './i18n';
 
 import './global.module.css';
+
+import styles from './foregroundBoxes/GradientBox.module.css';
+export const withShadowClassName = styles.withShadow;
+
 import {EntryStateProvider} from '../entryState';
 import {loadInlineEditingComponents} from './inlineEditing';
 


### PR DESCRIPTION
Instead of setting text-shadow default for all content inside
a gradient box, export withShadow class and use it only on
headlines inside gradient boxes for now.
This makes the CSS class available for all content elements
which desire a text shadow when placed inside a gradient box,
but removes the necessity to explicitly overwrite the text-shadow
if not.

REDMINE-17686