### PR TITLE
Debounce saving editable text also when rerendered

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/inlineEditing/useCachedValue-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/inlineEditing/useCachedValue-spec.js
@@ -109,4 +109,21 @@ describe('useCachedValue', () => {
 
     expect(listener).not.toHaveBeenCalled();
   });
+
+  it('debounces onDebouncedChange call even if new function is passed during rerender', () => {
+    const listener = jest.fn();
+    const {result} = renderHook(() => useCachedValue('value', {
+      onDebouncedChange: value => { listener(value) },
+      delay: 1
+    }));
+
+    let [,setValue] = result.current;
+    act(() => setValue('new value'));
+    [,setValue] = result.current;
+    act(() => setValue('newer'));
+    jest.runAllTimers();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith('newer');
+  });
 });


### PR DESCRIPTION
Before `useCachedValue` created a new debounced function whenever
`onDebouncedChange` changed. The previous debounced function was not
cancelled causing old values to be reported to `onDebouncedChange`.

In the case of `EditableText`, these old values then were saved to the
entry state. In the triggered rerender, `useCachedValue` then regarded
these old values as outside updates and called `onReset`. Slate then
got confused with those frequent updates and caused an exception when
trying to update the DOM selection.