### PR TITLE
Provide locale via separate context

### DIFF
--- a/entry_types/scrolled/package/spec/support/rendering.js
+++ b/entry_types/scrolled/package/spec/support/rendering.js
@@ -2,7 +2,8 @@ import React, {useEffect} from 'react';
 import {render} from '@testing-library/react'
 import {renderHook} from '@testing-library/react-hooks';
 
-import {EntryStateProvider, useEntryStateDispatch} from 'entryState';
+import {RootProviders} from 'frontend';
+import {useEntryStateDispatch} from 'entryState';
 import {normalizeSeed} from './normalizeSeed';
 
 /**
@@ -61,11 +62,11 @@ function createWrapper(seed, setup, originalWrapper) {
   return function Wrapper({children}) {
     return (
       <OriginalWrapper>
-        <EntryStateProvider seed={normalizedSeed}>
+        <RootProviders seed={normalizedSeed}>
           <Dispatcher callback={setup} seed={normalizedSeed}>
             {children}
           </Dispatcher>
-        </EntryStateProvider>
+        </RootProviders>
       </OriginalWrapper>
     );
   }

--- a/entry_types/scrolled/package/spec/support/stories.js
+++ b/entry_types/scrolled/package/spec/support/stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Entry, EntryStateProvider, setupI18n} from 'pageflow-scrolled/frontend';
+import {Entry, RootProviders, setupI18n} from 'pageflow-scrolled/frontend';
 import {browser} from 'pageflow/frontend';
 
 import {normalizeSeed} from './normalizeSeed';
@@ -56,9 +56,9 @@ export function storiesOfContentElement(module, options) {
   exampleStories(options).forEach(({title, seed, parameters = {}}) => {
     stories.add(title,
                 () =>
-                  <EntryStateProvider seed={seed}>
+                  <RootProviders seed={seed}>
                     <Entry />
-                  </EntryStateProvider>,
+                  </RootProviders>,
                 {
                   ...parameters,
                   viewport: {

--- a/entry_types/scrolled/package/src/frontend/RootProviders.js
+++ b/entry_types/scrolled/package/src/frontend/RootProviders.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import {EntryStateProvider} from '../entryState';
+import {LocaleProvider} from './i18n';
+
+export function RootProviders({seed, children}) {
+  return (
+    <EntryStateProvider seed={seed}>
+      <LocaleProvider>
+        {children}
+      </LocaleProvider>
+    </EntryStateProvider>
+  );
+}

--- a/entry_types/scrolled/package/src/frontend/SectionThumbnail.js
+++ b/entry_types/scrolled/package/src/frontend/SectionThumbnail.js
@@ -1,7 +1,8 @@
 import React, {useEffect} from 'react';
 import Measure from 'react-measure';
 
-import {EntryStateProvider, useEntryStateDispatch, useSectionStructure} from '../entryState';
+import {RootProviders} from './RootProviders';
+import {useEntryStateDispatch, useSectionStructure} from '../entryState';
 import Section from './Section';
 import {FullscreenHeightProvider} from './Fullscreen';
 import {StaticPreview} from './useScrollPositionLifecycle';
@@ -11,9 +12,9 @@ import styles from './SectionThumbnail.module.css';
 
 export function SectionThumbnail({seed, ...props}) {
   return (
-    <EntryStateProvider seed={seed}>
+    <RootProviders seed={seed}>
       <Inner {...props} />
-    </EntryStateProvider>
+    </RootProviders>
   );
 }
 

--- a/entry_types/scrolled/package/src/frontend/__stories__/MediaPlayer-stories.js
+++ b/entry_types/scrolled/package/src/frontend/__stories__/MediaPlayer-stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {normalizeAndMergeFixture, filePermaId} from 'pageflow-scrolled/spec/support/stories';
 
-import {EntryStateProvider, AudioPlayer, VideoPlayer, usePlayerState} from 'pageflow-scrolled/frontend';
+import {RootProviders, AudioPlayer, VideoPlayer, usePlayerState} from 'pageflow-scrolled/frontend';
 
 const stories = storiesOf('Frontend/Media Player', module);
 
@@ -12,11 +12,11 @@ stories.add(
     const [playerState, playerActions] = usePlayerState()
 
     return (
-        <EntryStateProvider seed={normalizeAndMergeFixture({})}>
+        <RootProviders seed={normalizeAndMergeFixture({})}>
           <VideoPlayer id={filePermaId('videoFiles', 'interview_toni')}
                        playerState={playerState}
                        playerActions={playerActions} />
-        </EntryStateProvider>
+        </RootProviders>
     );
   },
   {
@@ -30,14 +30,14 @@ stories.add(
     const [playerState, playerActions] = usePlayerState()
 
     return (
-      <EntryStateProvider seed={normalizeAndMergeFixture({})}>
+      <RootProviders seed={normalizeAndMergeFixture({})}>
         <div style={{height: '100vh'}}>
           <VideoPlayer id={filePermaId('videoFiles', 'interview_toni')}
                        fit="cover"
                        playerState={playerState}
                        playerActions={playerActions} />
         </div>
-      </EntryStateProvider>
+      </RootProviders>
     );
   },
   {
@@ -51,11 +51,11 @@ stories.add(
     const [playerState, playerActions] = usePlayerState()
 
     return (
-      <EntryStateProvider seed={normalizeAndMergeFixture({})}>
+      <RootProviders seed={normalizeAndMergeFixture({})}>
         <AudioPlayer id={filePermaId('audioFiles', 'quicktime_jingle')}
                      playerState={playerState}
                      playerActions={playerActions} />
-      </EntryStateProvider>
+      </RootProviders>
     );
   },
   {

--- a/entry_types/scrolled/package/src/frontend/__stories__/appearance-stories.js
+++ b/entry_types/scrolled/package/src/frontend/__stories__/appearance-stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Entry, EntryStateProvider} from 'pageflow-scrolled/frontend';
+import {Entry, RootProviders} from 'pageflow-scrolled/frontend';
 
 import {
   normalizeAndMergeFixture,
@@ -24,16 +24,16 @@ appearanceOptions.forEach(appearance => {
     .add(
       'Layout/Position',
       () =>
-        <EntryStateProvider seed={exampleSeed(appearance)}>
+        <RootProviders seed={exampleSeed(appearance)}>
           <Entry />
-        </EntryStateProvider>
+        </RootProviders>
     )
     .add(
       'Inverted',
       () =>
-        <EntryStateProvider seed={exampleSeed(appearance, true)}>
+        <RootProviders seed={exampleSeed(appearance, true)}>
           <Entry />
-        </EntryStateProvider>
+        </RootProviders>
     )
 });
 

--- a/entry_types/scrolled/package/src/frontend/__stories__/transitions-stories.js
+++ b/entry_types/scrolled/package/src/frontend/__stories__/transitions-stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Entry, EntryStateProvider} from 'pageflow-scrolled/frontend';
+import {Entry, RootProviders} from 'pageflow-scrolled/frontend';
 
 import {
   normalizeAndMergeFixture,
@@ -20,9 +20,9 @@ transitions.forEach(transition1 =>
     stories.add(
       `${transition1}/${transition2}`,
       () =>
-        <EntryStateProvider seed={exampleSeed(transition1, transition2)}>
+        <RootProviders seed={exampleSeed(transition1, transition2)}>
           <Entry />
-        </EntryStateProvider>,
+        </RootProviders>,
       {
         percy: {skip: true}
       }

--- a/entry_types/scrolled/package/src/frontend/i18n.js
+++ b/entry_types/scrolled/package/src/frontend/i18n.js
@@ -1,10 +1,27 @@
+import React, {useContext, createContext} from 'react';
 import I18n from 'i18n-js';
 import {useEntryMetadata} from '../entryState';
+
+const LocaleContext = createContext('en');
 
 export function setupI18n({defaultLocale, locale, translations}) {
   I18n.defaultLocale = defaultLocale;
   I18n.locale = locale;
   I18n.translations = translations;
+}
+
+export function LocaleProvider({children}) {
+  const {locale} = useEntryMetadata() || {};
+
+  return (
+    <LocaleContext.Provider value={locale}>
+      {children}
+    </LocaleContext.Provider>
+  );
+}
+
+export function useLocale() {
+  return useContext(LocaleContext);
 }
 
 /**
@@ -29,7 +46,7 @@ export function setupI18n({defaultLocale, locale, translations}) {
  * t('pageflow_scrolled.inline_editing.some.key')
  */
 export function useI18n({locale: scope} = {}) {
-  const {locale} = useEntryMetadata();
+  const locale = useLocale();
 
   return {
     t(key, options) {

--- a/entry_types/scrolled/package/src/frontend/index.js
+++ b/entry_types/scrolled/package/src/frontend/index.js
@@ -10,14 +10,15 @@ import {setupI18n} from './i18n';
 import './global.module.css';
 
 import styles from './foregroundBoxes/GradientBox.module.css';
-export const withShadowClassName = styles.withShadow;
 
-import {EntryStateProvider} from '../entryState';
+import {RootProviders} from './RootProviders';
 import {loadInlineEditingComponents} from './inlineEditing';
 
 import {browser} from 'pageflow/frontend';
 
 const editMode = window.location.pathname.indexOf('/editor/entries') === 0;
+
+export const withShadowClassName = styles.withShadow;
 
 export {api as frontend} from './api';
 
@@ -37,7 +38,7 @@ export * from './i18n';
 
 export * from './SectionThumbnail';
 export {default as Entry} from './Entry';
-export {EntryStateProvider, useFile} from '../entryState'
+export {useFile} from '../entryState'
 export {useContentElementConfigurationUpdate} from './useContentElementConfigurationUpdate';
 export {useContentElementEditorCommandSubscription} from './useContentElementEditorCommandSubscription';
 export {useContentElementEditorState} from './useContentElementEditorState';
@@ -47,6 +48,8 @@ export {ViewportDependentPillarBoxes} from './ViewportDependentPillarBoxes';
 export {EditableText} from './EditableText';
 
 export {getTransitionNames, getAvailableTransitionNames} from './transitions';
+
+export {RootProviders};
 
 window.pageflowScrolledRender = function(seed) {
   setupI18n(seed.i18n);
@@ -66,11 +69,9 @@ function render(seed) {
 
 function Root({seed}) {
   return (
-    <>
-      <EntryStateProvider seed={seed}>
-        <AppHeader />
-        <Entry />
-      </EntryStateProvider>
-    </>
+    <RootProviders seed={seed}>
+      <AppHeader />
+      <Entry />
+    </RootProviders>
   );
 }

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/__stories__/EditableText-stories.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/__stories__/EditableText-stories.js
@@ -4,7 +4,7 @@ import {EditableText} from '../EditableText';
 import {EditorStateProvider} from '../EditorState';
 import {ContentElementEditorStateProvider} from '../ContentElementEditorStateProvider';
 import {ContentElementAttributesProvider} from '../../useContentElementAttributes';
-import {EntryStateProvider} from 'pageflow-scrolled/frontend';
+import {RootProviders} from 'pageflow-scrolled/frontend';
 
 import {normalizeAndMergeFixture} from 'pageflow-scrolled/spec/support/stories';
 
@@ -29,7 +29,7 @@ export const darkBackground = () =>
 
 function Background({dark, children}) {
   return (
-    <EntryStateProvider seed={normalizeAndMergeFixture()}>
+    <RootProviders seed={normalizeAndMergeFixture()}>
       <EditorStateProvider>
         <ContentElementAttributesProvider id={1}>
           <ContentElementEditorStateProvider id={1}>
@@ -43,7 +43,7 @@ function Background({dark, children}) {
           </ContentElementEditorStateProvider>
         </ContentElementAttributesProvider>
       </EditorStateProvider>
-    </EntryStateProvider>
+    </RootProviders>
   );
 }
 


### PR DESCRIPTION
The main motivation for this change is to allow `useI18n` outside of
an `EntryStateProvider` by giving the `LocaleContext` `en` as default
value. This lets us use translations in low level components without
having to resort to tools like `renderInEntry`.

As a nice side effect, this change prevents having all components with
translations subscribe to the entry state context. Below a
`React.memo`, components with `useI18n` will now only rerender when
the locale changes.

REDMINE-17673, REDMINE-17376