### PR TITLE
Switch player controls color from currentColor to white.

### DIFF
--- a/entry_types/scrolled/package/src/frontend/PlayerControls/ContextMenu.module.css
+++ b/entry_types/scrolled/package/src/frontend/PlayerControls/ContextMenu.module.css
@@ -29,7 +29,7 @@
 
 .contextMenuItemActiveIndicator {
   visibility: hidden;
-  fill: currentColor;
+  fill: white;
 }
 
 .contextMenuItemActiveIndicator.active {

--- a/entry_types/scrolled/package/src/frontend/PlayerControls/ControlBar.module.css
+++ b/entry_types/scrolled/package/src/frontend/PlayerControls/ControlBar.module.css
@@ -3,7 +3,7 @@
 }
 
 .backgroundColor {
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.5);
 }
 
 .foregroundLight {
@@ -54,13 +54,13 @@
 .controlsIcon {
   width: 24px;
   height: 24px;
-  fill: currentColor;
+  fill: white;
   cursor: pointer;
 }
 
 .playControl {
   text-decoration: none;
-  color: currentColor;
+  color: white;
 }
 
 .settingsIcon {

--- a/entry_types/scrolled/package/src/frontend/PlayerControls/ProgressIndicators.module.css
+++ b/entry_types/scrolled/package/src/frontend/PlayerControls/ProgressIndicators.module.css
@@ -20,12 +20,12 @@
 }
 
 .loadingProgressBar {
-  background: currentColor;
+  background: white;
   opacity: 0.25;
 }
 
 .playProgressBar {
-  background: currentColor;
+  background: white;
 }
 
 .sliderHandle {
@@ -35,7 +35,7 @@
   border-radius: 6.5px;
   position: absolute;
   top: -4px;
-  background: currentColor;
+  background: white;
   opacity: 0;
   transition: opacity 100ms;
 }

--- a/entry_types/scrolled/package/src/frontend/PlayerControls/TimeDisplay.module.css
+++ b/entry_types/scrolled/package/src/frontend/PlayerControls/TimeDisplay.module.css
@@ -2,5 +2,5 @@
   line-height: 24px;
   font-size: 15px;
   padding: 0 2px;
-  color: currentColor;
+  color: white;
 }


### PR DESCRIPTION
Since the black controls on white background are not used,
we can safely switch to always use white color for controls.

REDMINE-17733