### PR TITLE
Correct fadebg animation

### DIFF
--- a/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.module.css
+++ b/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.module.css
@@ -46,7 +46,7 @@
 /*Fade Background Upper*/
 .transition:hover .fadeBg .upper_section {
     visibility: hidden;
-    transform: translateY(-100%);
+    opacity: 0.2;
 }
 
 /*face Background Lower*/


### PR DESCRIPTION
REDMINE-17721

(1/8)

- The **fadeBg** animation was incorrect, the upper-section was scrolling instead of fading away.
Fixed that by changing transform from translate to decreasing opacity.