### PR TITLE
Only show focus outline after keyboard input

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/focusOutline-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/focusOutline-spec.js
@@ -1,0 +1,36 @@
+import {useFocusOutlineVisible, FocusOutlineProvider} from 'frontend/focusOutline';
+import styles from 'frontend/focusOutline.module.css';
+
+import {renderHook, act} from '@testing-library/react-hooks';
+import {fireEvent} from '@testing-library/dom';
+
+describe('focus outline', () => {
+  it('is hidden by default', () => {
+    const {result} = renderHook(() => useFocusOutlineVisible(),
+                                {wrapper: FocusOutlineProvider});
+
+    expect(document.body.classList.contains(styles.focusOutlineDisabled)).toBe(true)
+    expect(result.current).toBe(false);
+  });
+
+  it('is enabled after keyboard event', () => {
+    const {result} = renderHook(() => useFocusOutlineVisible(),
+                                {wrapper: FocusOutlineProvider});
+
+    act(() => { fireEvent.keyDown(document.body); });
+
+    expect(document.body.classList.contains(styles.focusOutlineDisabled)).toBe(false)
+    expect(result.current).toBe(true);
+  });
+
+  it('is disabled focus after mouse event', () => {
+    const {result} = renderHook(() => useFocusOutlineVisible(),
+                                {wrapper: FocusOutlineProvider});
+
+    act(() => { fireEvent.keyDown(document.body); });
+    act(() => { fireEvent.mouseDown(document.body); });
+
+    expect(document.body.classList.contains(styles.focusOutlineDisabled)).toBe(true)
+    expect(result.current).toBe(false);
+  });
+});

--- a/entry_types/scrolled/package/src/frontend/RootProviders.js
+++ b/entry_types/scrolled/package/src/frontend/RootProviders.js
@@ -2,13 +2,16 @@ import React from 'react';
 
 import {EntryStateProvider} from '../entryState';
 import {LocaleProvider} from './i18n';
+import {FocusOutlineProvider} from './focusOutline';
 
 export function RootProviders({seed, children}) {
   return (
-    <EntryStateProvider seed={seed}>
-      <LocaleProvider>
-        {children}
-      </LocaleProvider>
-    </EntryStateProvider>
+    <FocusOutlineProvider>
+      <EntryStateProvider seed={seed}>
+        <LocaleProvider>
+          {children}
+        </LocaleProvider>
+      </EntryStateProvider>
+    </FocusOutlineProvider>
   );
 }

--- a/entry_types/scrolled/package/src/frontend/focusOutline.js
+++ b/entry_types/scrolled/package/src/frontend/focusOutline.js
@@ -1,0 +1,41 @@
+import React, {createContext, useContext, useState, useEffect} from 'react';
+
+import styles from './focusOutline.module.css';
+
+const FocusVisibleContext = createContext();
+
+export function useFocusOutlineVisible() {
+  return useContext(FocusVisibleContext);
+}
+
+export function FocusOutlineProvider({children}) {
+  const [value, setValue] = useState()
+
+  useEffect(() => {
+    document.body.addEventListener('keydown', enable);
+    document.body.addEventListener('mousedown', disable);
+
+    disable();
+
+    return () => {
+      document.body.removeEventListener('keydown', enable);
+      document.body.removeEventListener('mousedown', disable);
+    };
+
+    function enable() {
+      document.body.classList.remove(styles.focusOutlineDisabled)
+      setValue(true);
+    }
+
+    function disable() {
+      document.body.classList.add(styles.focusOutlineDisabled)
+      setValue(false);
+    }
+  }, []);
+
+  return (
+    <FocusVisibleContext.Provider value={value}>
+      {children}
+    </FocusVisibleContext.Provider>
+  );
+}

--- a/entry_types/scrolled/package/src/frontend/focusOutline.module.css
+++ b/entry_types/scrolled/package/src/frontend/focusOutline.module.css
@@ -1,0 +1,11 @@
+a:focus,
+button:focus,
+[tabindex]:focus {
+  outline: 3px solid #518ad2;
+}
+
+.focusOutlineDisabled [tabindex]:focus,
+.focusOutlineDisabled button:focus,
+.focusOutlineDisabled a:focus {
+  outline: none;
+}


### PR DESCRIPTION
Prevent showing focus outline after clicking player control buttons.

REDMINE-17736