### PR TITLE
Extend editor api to detect browser

### DIFF
--- a/doc/creating_entry_types.md
+++ b/doc/creating_entry_types.md
@@ -190,6 +190,24 @@ const appearanceInputs = (tabView, _options) => {
 Pageflow is looking for translation keys of the form
 `pageflow.entry_types.paged.editor.entry_metadata_configuration_attributes.manual_start.{inline_help,label}`.
 
+The `browserNotSupportedView` is a Backbone view that will be displayed if the access to editor needs to be blocked due to browser compatibility issues.
+```javascript
+import {editor} from 'pageflow/editor;
+import {browser} from 'pageflow/frontend';
+
+import {BrowserNotSupportedView} from './views/BrowserNotSupportedView';
+
+editor.registerEntryType('rainbow', {
+  // ...
+
+  isBrowserSupported() {
+    return browser.has('some feature required to use the editor');
+  },
+
+  browserNotSupportedView: BrowserNotSupportedView
+});
+``` 
+
 ### REST Controllers
 
 Entry types can define new editor controllers, which can then be used

--- a/entry_types/scrolled/package/src/editor/config.js
+++ b/entry_types/scrolled/package/src/editor/config.js
@@ -9,6 +9,9 @@ import {EntryPreviewView} from './views/EntryPreviewView';
 import {SideBarRouter} from './routers/SideBarRouter';
 import {SideBarController} from './controllers/SideBarController';
 
+import {browser} from 'pageflow/frontend';
+import {BrowserNotSupportedView} from './views/BrowserNotSupportedView';
+
 editor.registerEntryType('scrolled', {
   entryModel: ScrolledEntry,
 
@@ -18,7 +21,12 @@ editor.registerEntryType('scrolled', {
       editor
     });
   },
-  outlineView: EntryOutlineView
+  outlineView: EntryOutlineView,
+
+  isBrowserSupported() {
+    return (!browser.agent.matchesMobilePlatform());
+  },
+  browserNotSupportedView: BrowserNotSupportedView
 });
 
 editor.registerSideBarRouting({

--- a/entry_types/scrolled/package/src/editor/views/BrowserNotSupportedView.js
+++ b/entry_types/scrolled/package/src/editor/views/BrowserNotSupportedView.js
@@ -1,0 +1,30 @@
+import $ from 'jquery';
+import Marionette from 'backbone.marionette';
+import {cssModulesUtils} from 'pageflow/ui';
+
+import styles from './BrowserNotSupportedView.module.css'
+
+export const BrowserNotSupportedView = Marionette.ItemView.extend({
+  template: () => `
+     <div class="${styles.main}" />
+  `,
+
+  className: styles.main,
+
+  ui: cssModulesUtils.ui(styles, 'main'),
+
+  onShow() {
+    this.appendOptions();
+  },
+
+  appendOptions() {
+    
+    var container = `<div class='${styles.container}'>
+                        <h1>Your Browser is not Supported</h1>
+                        <p>To use the editor please use one of the latest browsers</p>
+                    </div>`;
+          
+    this.ui.main.append($(container));
+  }
+});
+

--- a/entry_types/scrolled/package/src/editor/views/BrowserNotSupportedView.module.css
+++ b/entry_types/scrolled/package/src/editor/views/BrowserNotSupportedView.module.css
@@ -1,0 +1,18 @@
+.main {
+    height: 100vh;
+    width: 100vw;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.container {
+    color: #000000;
+    opacity: 0.5;
+    height: auto;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+}

--- a/package/spec/editor/api-spec.js
+++ b/package/spec/editor/api-spec.js
@@ -124,4 +124,44 @@ describe('pageflow.EditorApi', () => {
       expect(entry.setupFromEntryTypeSeed).toHaveBeenCalledWith(undefined, state);
     });
   });
+
+  describe('#ensureBrowserSupport', () => {
+    it('expects to start the editor for only latest browsers', () => {
+      var api = new EditorApi();
+      var EntryModel = Backbone.Model.extend();
+      var BrowserNotSupportedView = Backbone.View.extend();
+      var start = jest.fn();
+
+      api.registerEntryType('test', {
+        entryMode: EntryModel,
+        isBrowserSupported() {
+            return true
+        },
+        browserNotSupportedView: BrowserNotSupportedView
+      });
+
+      var entry = api.ensureBrowserSupport(start);
+
+      expect(start).toBeCalled();
+    });
+
+    it('expects to block the editor for old browsers and mobile devices', () => {
+      var api = new EditorApi();
+      var EntryModel = Backbone.Model.extend();
+      var BrowserNotSupportedView = Backbone.View.extend();
+      var start = jest.fn();
+
+      api.registerEntryType('test', {
+        entryMode: EntryModel,
+        isBrowserSupported() {
+            return false
+        },
+        browserNotSupportedView: BrowserNotSupportedView
+      });
+
+      var entry = api.ensureBrowserSupport(start);
+
+      expect(start).not.toBeCalled();
+    });
+  });
 });

--- a/package/src/editor/api/index.js
+++ b/package/src/editor/api/index.js
@@ -92,6 +92,10 @@ export const EditorApi = Object.extend(
    *   Backbone view that will render the live preview of the entry.
    * @param {function} options.EntryOutlineView
    *   Backbone view that will be rendered in the side bar.
+   * @param {function} options.isBrowserSupported
+   *  Checks to see if the browser is supported.
+   * @param {function} options.browserNotSupportedView
+   *  Backbone view that will be rendered if the browser is not supported.
    */
   registerEntryType(name, options) {
     this.entryType = {name, ...options};
@@ -301,5 +305,23 @@ export const EditorApi = Object.extend(
 
     this.commonPageConfigurationTabs.apply(view);
     return view;
+  },
+
+  ensureBrowserSupport: function(start) {
+    if (this.entryType.isBrowserSupported) {
+      const isBrowserSupported = this.entryType.isBrowserSupported();
+  
+      if (isBrowserSupported) {
+          start();
+      }
+      else {
+          const browserNotSupportedView = new this.entryType.browserNotSupportedView();
+          app.mainRegion.show(browserNotSupportedView);
+      }
+    }
+    else {
+      start();
+    }
+
   }
 });

--- a/package/src/editor/base.js
+++ b/package/src/editor/base.js
@@ -17,15 +17,18 @@ export const startEditor = function(options) {
   I18n.translations = window.I18n.translations;
 
   $(function() {
-    $.when(
-      $.getJSON('/editor/entries/' + options.entryId + '/seed'),
-      browser.detectFeatures()
-    )
-      .done(function(result) {
-        app.start(result[0]);
-      })
-      .fail(function() {
-        alert('Error while starting editor.');
-      });
+    editor.ensureBrowserSupport(() => { 
+      $.when(
+        $.getJSON('/editor/entries/' + options.entryId + '/seed'),
+        browser.detectFeatures()
+      )
+        .done(function(result) {
+          app.start(result[0]);
+        })
+        .fail(function() {
+          alert('Error while starting editor.');
+        });
+    });
   });
+  
 };


### PR DESCRIPTION
REDMINE-17565

- [X] Extend editor in pageflow/editor API to let entry types provide: added

> - [X] A function that is called in startEditor to check whether the current browser is supported added
> - [X] A view that is rendered instead of the editor if the function returns false.

- Created a new view, which will be rendered if the browser is not supported.
- Provide a function in `entry_type/scrolled/package/src/editor` to detect the type of browser and a view to display.
- Extended the `pageflow/editor` api to include a callback function which will get the result from scroll and either then start the app or display the view.