### PR TITLE
Fix segfault on media playback in Chrome

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/MediaPlayer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/MediaPlayer-spec.js
@@ -188,4 +188,50 @@ describe('MediaPlayer', () => {
 
     expect(player.changeVolumeFactor).toHaveBeenCalledWith(0.2, 500);
   });
+
+  it('sets initial current time on loadedmetadata event according to playerState', () => {
+    let state = {
+      ...getInitialPlayerState(),
+      currentTime: 5
+    };
+    const {getPlayer} =
+      render(<MediaPlayer {...requiredProps()}
+                          sources={getVideoSources()}
+                          playerState={state} />);
+    const player = getPlayer();
+
+    player.trigger('loadedmetadata');
+
+    expect(player.currentTime).toHaveBeenCalledWith(5);
+  });
+
+  it('does not set current time before loadedmetadata event', () => {
+    let state = {
+      ...getInitialPlayerState(),
+      currentTime: 5
+    };
+    const {getPlayer} =
+      render(<MediaPlayer {...requiredProps()}
+                          sources={getVideoSources()}
+                          playerState={state} />);
+    const player = getPlayer();
+
+    expect(player.currentTime).not.toHaveBeenCalledWith(expect.anything());
+  });
+
+  it('does not set current time on loadedmetadata event after component unmounted', () => {
+    let state = {
+      ...getInitialPlayerState(),
+      currentTime: 5
+    };
+    const {getPlayer, unmount} =
+      render(<MediaPlayer {...requiredProps()}
+                          sources={getVideoSources()}
+                          playerState={state} />);
+    const player = getPlayer();
+    unmount();
+    player.trigger('loadedmetadata');
+
+    expect(player.currentTime).not.toHaveBeenCalledWith(expect.anything());
+  });
 });

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/applyPlayerState.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/applyPlayerState.js
@@ -1,5 +1,5 @@
 export function applyPlayerState(player, playerState, playerActions){
-  player.currentTime(playerState.currentTime);
+  player.one('loadedmetadata', () => player.currentTime(playerState.currentTime));
   player.changeVolumeFactor(playerState.volumeFactor, 0);
 
   if (playerState.shouldPrebuffer) {

--- a/entry_types/scrolled/package/src/frontend/__stories__/MediaPlayer-stories.js
+++ b/entry_types/scrolled/package/src/frontend/__stories__/MediaPlayer-stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {storiesOf} from '@storybook/react';
 import {normalizeAndMergeFixture, filePermaId} from 'pageflow-scrolled/spec/support/stories';
 
@@ -62,3 +62,82 @@ stories.add(
     percy: {skip: true}
   }
 );
+
+stories.add(
+  'Media Audio Player - Stress Test',
+  () => {
+    const [playerState, playerActions] = usePlayerState()
+
+    return (
+      <RootProviders seed={normalizeAndMergeFixture({})}>
+        <StressTest playerState={playerState} playerActions={playerActions} >
+          {isPrepared =>
+            <AudioPlayer id={filePermaId('audioFiles', 'quicktime_jingle')}
+                         isPrepared={isPrepared}
+                         playerState={playerState}
+                         playerActions={playerActions} />}
+        </StressTest>
+      </RootProviders>
+    );
+  },
+  {
+    percy: {skip: true}
+  }
+);
+
+stories.add(
+  'Media Video Player - Stress Test',
+  () => {
+    const [playerState, playerActions] = usePlayerState()
+
+    return (
+      <RootProviders seed={normalizeAndMergeFixture({})}>
+        <StressTest playerState={playerState} playerActions={playerActions} >
+          {isPrepared =>
+            <VideoPlayer id={filePermaId('videoFiles', 'interview_toni')}
+                         isPrepared={isPrepared}
+                         playerState={playerState}
+                         playerActions={playerActions} />}
+        </StressTest>
+      </RootProviders>
+    );
+  },
+  {
+    percy: {skip: true}
+  }
+);
+
+function StressTest({playerState, playerActions, children}) {
+  const [isPrepared, setIsPrepared] = useState(false);
+
+  function* toggleForever() {
+    while (true) {
+      setIsPrepared(state => !state);
+      yield delay(100);
+      playerActions.play();
+      yield delay(100);
+      playerActions.pause();
+      yield delay(100);
+    }
+  }
+
+  return (
+    <div>
+      <button onClick={() => run(toggleForever())}>Start</button>
+      <br />
+      {isPrepared ? 'Prepared' : 'Not Prepated'}/
+      {playerState.isPlaying ? 'Playing' : 'Not Playing'}
+      {children(isPrepared)}
+    </div>
+  )
+}
+
+function delay(duration) {
+  return new Promise(resolve => setTimeout(resolve, duration));
+}
+
+async function run(commands) {
+  for (let c of commands) {
+    await c;
+  }
+}

--- a/entry_types/scrolled/package/src/frontend/__stories__/browserBugs-stories.js
+++ b/entry_types/scrolled/package/src/frontend/__stories__/browserBugs-stories.js
@@ -1,0 +1,93 @@
+import React, {useRef} from 'react';
+import {normalizeAndMergeFixture, filePermaId} from 'pageflow-scrolled/spec/support/stories';
+
+import {RootProviders, useFile} from 'pageflow-scrolled/frontend';
+
+export default {
+  title: 'Frontend/Browser Bugs',
+  parameters: {
+    percy: {skip: true}
+  }
+}
+
+export const chromeWebaudioCurrentTimeSegfault = () =>
+  <RootProviders seed={normalizeAndMergeFixture({})}>
+    <Test />
+  </RootProviders>;
+
+function Test() {
+  const file = useFile({collectionName: 'audioFiles',permaId: filePermaId('audioFiles', 'quicktime_jingle')});
+  const ref = useRef();
+  const audioElement = useRef();
+
+  function setup() {
+    const audio = document.createElement('audio');
+    
+    audio.setAttribute('controls', true);
+    audio.setAttribute('crossorigin', 'anonymous');
+
+    const audioContext = new AudioContext();
+    const gainNode = audioContext.createGain();
+
+    var source = audioContext.createMediaElementSource(audio);
+    source.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+
+    audioElement.current = audio;
+    ref.current.appendChild(audioElement.current);
+  }
+
+  function* loop() {
+    while (true) {
+      unalloc();
+      yield delay(200);
+      alloc();
+      yield delay(200);
+      audioElement.current.play()
+      yield delay(200);
+    }
+  }
+
+  function alloc() {
+    audioElement.current.currentTime = 0.171806;
+    setTimeout(() => audioElement.current.setAttribute('src', file.urls.ogg), 1);
+  }
+
+  function unalloc() {
+    const blank = 'data:audio/wav;base64,UklGRjIAAABXQVZFZm10IBA' +
+                  'AAAABAAEAIlYAAESsAAACABAAZGF0YRAAAAAAAAAAAAAAAAAAAAAAAA==';
+
+    audioElement.current.setAttribute('src', blank);
+  }
+
+  return (
+    <div>
+      <p>
+        Chrome 83 sometimes crashes with a SIGSEGV error when for
+        an <code>audio</code> element which is connected to an <code>AudioContext</code>:
+      </p>
+      <ol>
+        <li><code>src</code> is set to a blank audio file.</li>
+        <li><code>currentTime</code> is set to a positive value.</li>
+        <li><code>src</code> is updated to a longer audio file.</li>
+      </ol>
+      <p>
+        In production code, this happens when an unallocated media element is reused since
+        VideoJS updates sources with a timeout.
+      </p>
+      <button onClick={() => { setup(); run(loop()) }}>Reproduce</button>
+      <div ref={ref} />
+    </div>
+  )
+}
+
+function delay(duration) {
+  return new Promise(resolve => setTimeout(resolve, duration));
+}
+
+async function run(commands) {
+  for (let c of commands) {
+    await c;
+  }
+}
+


### PR DESCRIPTION
Observed on both Chrome 79 and 83 on Ubuntu. Playing an inline audio,
scrolling away, returning and playing again causes the browser tab to
crash with a `SIGSEGV` error.

Error can be reproduced for audio elements that are connected to an
audio context.

* Play audio so the current time in the player state progresses.

* Unallocated the player causing the blank audio file of zero duration
  to be assigned.

* Allocated the player again with the previous file aga. Video.js
  updates the source only after a delay. So when we restore the
  current time in `applyPlayerState` the zero duration audio file is
  actually still loaded.

* Next time the player is played, the tab is likely to crash.

The added `browserBug` story repeats these steps until the error
happens.

Setting `currentTime` only after metadata have loaded appears to fix
the issue.

Add story to stress test allocating/playing/unallocating media
players.

REDMINE-17745