### PR TITLE
Extend the existing user agent detection code for desktop browsers

### DIFF
--- a/entry_types/scrolled/package/src/editor/config.js
+++ b/entry_types/scrolled/package/src/editor/config.js
@@ -24,7 +24,10 @@ editor.registerEntryType('scrolled', {
   outlineView: EntryOutlineView,
 
   isBrowserSupported() {
-    return (!browser.agent.matchesMobilePlatform());
+    return (browser.agent.matchesDesktopChrome({minVersion: 20}) ||
+            browser.agent.matchesDesktopFirefox({minVersion: 20}) ||
+            browser.agent.matchesDesktopSafari({minVersion: 3}) ||
+            browser.agent.matchesDesktopEdge({minVersion: 20}));
   },
   browserNotSupportedView: BrowserNotSupportedView
 });

--- a/package/spec/frontend/browser/agent_spec.js
+++ b/package/spec/frontend/browser/agent_spec.js
@@ -64,7 +64,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15'
       );
 
-      expect(agent.matchesDesktopSafari({minVersion: 3})).toBe(true);
+      expect(agent.matchesDesktopSafari()).toBe(true);
     });
 
     it('returns false for Safari on iPhone', function() {
@@ -73,7 +73,16 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A403 Safari/602.1'
       );
 
-      expect(agent.matchesDesktopSafari({minVersion: 3})).toBe(false);
+      expect(agent.matchesDesktopSafari()).toBe(false);
+    });
+
+    it('returns false for Safari 3.2 if minVersion 4 is given', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_6; en-us) '+
+        'AppleWebKit/525.27.1 (KHTML, like Gecko) Version/3.2.1 Safari/525.27.1'
+      );
+
+      expect(agent.matchesDesktopSafari({minVersion: 4})).toBe(false);
     });
   });
 
@@ -84,13 +93,22 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36 Edg/83.0.478.58'
       );
 
-      expect(agent.matchesDesktopEdge({minVersion: 20})).toBe(true);
+      expect(agent.matchesDesktopEdge()).toBe(true);
     });
 
     it('returns false for Edge on Windows 10 mobile', function() {
       var agent = new Agent(
         'Mozilla/5.0 (Windows Mobile 10; Android 10.0; Microsoft; Lumia 950XL) '+
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Mobile Safari/537.36 Edge/40.15254.603'
+      );
+
+      expect(agent.matchesDesktopEdge()).toBe(false);
+    });
+
+    it('returns false for Edge 12 if minVersion 20 is given', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Windows NT 10.0) '+
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136'
       );
 
       expect(agent.matchesDesktopEdge({minVersion: 20})).toBe(false);
@@ -104,7 +122,7 @@ describe('pageflow.browser.Agent', function() {
         'Gecko/20100101 Firefox/78.0'
       );
 
-      expect(agent.matchesDesktopFirefox({minVersion: 20})).toBe(true);
+      expect(agent.matchesDesktopFirefox()).toBe(true);
     });
 
     it('returns false for SeaMonkey', function() {
@@ -113,7 +131,7 @@ describe('pageflow.browser.Agent', function() {
         'Gecko/20100101 Firefox/29.0 SeaMonkey/2.26'
       );
 
-      expect(agent.matchesDesktopFirefox({minVersion: 20})).toBe(false);
+      expect(agent.matchesDesktopFirefox()).toBe(false);
     });
 
     it('returns false for Firefox on android', function() {
@@ -122,18 +140,27 @@ describe('pageflow.browser.Agent', function() {
         'Gecko/68.0 Firefox/68.0'
       );
 
+      expect(agent.matchesDesktopFirefox()).toBe(false);
+    });
+
+    it('returns false for Firefox 17 when minVersion 20 is given', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:17.0) ' +
+        'Gecko/20100101 Firefox/17.0'
+      );
+
       expect(agent.matchesDesktopFirefox({minVersion: 20})).toBe(false);
     });
   });
 
   describe('#matchesDesktopChrome', function() {
-    it('returns true for Chrome', function() {
+    it('returns true for Chrome 83', function() {
       var agent = new Agent(
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36'
       );
 
-      expect(agent.matchesDesktopChrome({minVersion: 20})).toBe(true);
+      expect(agent.matchesDesktopChrome()).toBe(true);
     });
 
     it('returns false for Chrome on android', function() {
@@ -142,7 +169,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36'
       );
 
-      expect(agent.matchesDesktopChrome({minVersion: 20})).toBe(false);
+      expect(agent.matchesDesktopChrome()).toBe(false);
     });
 
     it('returns false for Chrome on iphone', function() {
@@ -151,45 +178,25 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/83.0.4103.88 Mobile/15E148 Safari/604.1'
       );
 
-      expect(agent.matchesDesktopChrome({minVersion: 20})).toBe(false);
+      expect(agent.matchesDesktopChrome()).toBe(false);
     });
-  });
 
-  describe('#minVersion', function() {
-    it('returns true for Chrome 83', function() {
+    it('returns false for Edge', function() {
       var agent = new Agent(
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
-        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36'
-      );
-
-      expect(agent.matchesDesktopChrome({minVersion: 20})).toBe(true);
-    });
-
-    it('returns false for Firefox 17', function() {
-      var agent = new Agent(
-        'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:17.0) ' +
-        'Gecko/20100101 Firefox/17.0'
-      );
-
-      expect(agent.matchesDesktopFirefox({minVersion: 20})).toBe(false);
-    });
-
-    it('returns true for Edge 83', function() {
-      var agent = new Agent(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '+
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36 Edg/83.0.478.58'
       );
 
-      expect(agent.matchesDesktopEdge({minVersion: 20})).toBe(true);
+      expect(agent.matchesDesktopChrome()).toBe(false);
     });
 
-    it('returns false for Safari 3.2', function() {
+    it('returns false for Chrome 12 when minVersion 20 is given', function() {
       var agent = new Agent(
-        'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_6; en-us) '+
-        'AppleWebKit/525.27.1 (KHTML, like Gecko) Version/3.2.1 Safari/525.27.1'
+        'Mozilla/5.0 (X11; Linux i686) ' +
+        'AppleWebKit/534.30 (KHTML, like Gecko) Slackware/Chrome/12.0.742.100 Safari/534.30'
       );
 
-      expect(agent.matchesDesktopSafari({minVersion: 20})).toBe(false);
+      expect(agent.matchesDesktopChrome({minVersion: 20})).toBe(false);
     });
   });
 });

--- a/package/spec/frontend/browser/agent_spec.js
+++ b/package/spec/frontend/browser/agent_spec.js
@@ -64,7 +64,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15'
       );
 
-      expect(agent.matchesDesktopSafari()).toBe(true);
+      expect(agent.matchesDesktopSafari({minVersion: 3})).toBe(true);
     });
 
     it('returns false for Safari on iPhone', function() {
@@ -73,7 +73,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A403 Safari/602.1'
       );
 
-      expect(agent.matchesDesktopSafari()).toBe(false);
+      expect(agent.matchesDesktopSafari({minVersion: 3})).toBe(false);
     });
   });
 
@@ -84,7 +84,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36 Edg/83.0.478.58'
       );
 
-      expect(agent.matchesDesktopEdge()).toBe(true);
+      expect(agent.matchesDesktopEdge({minVersion: 20})).toBe(true);
     });
 
     it('returns false for Edge on Windows 10 mobile', function() {
@@ -93,7 +93,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Mobile Safari/537.36 Edge/40.15254.603'
       );
 
-      expect(agent.matchesDesktopEdge()).toBe(false);
+      expect(agent.matchesDesktopEdge({minVersion: 20})).toBe(false);
     });
   });
 
@@ -104,7 +104,7 @@ describe('pageflow.browser.Agent', function() {
         'Gecko/20100101 Firefox/78.0'
       );
 
-      expect(agent.matchesDesktopFirefox()).toBe(true);
+      expect(agent.matchesDesktopFirefox({minVersion: 20})).toBe(true);
     });
 
     it('returns false for SeaMonkey', function() {
@@ -113,7 +113,7 @@ describe('pageflow.browser.Agent', function() {
         'Gecko/20100101 Firefox/29.0 SeaMonkey/2.26'
       );
 
-      expect(agent.matchesDesktopFirefox()).toBe(false);
+      expect(agent.matchesDesktopFirefox({minVersion: 20})).toBe(false);
     });
 
     it('returns false for Firefox on android', function() {
@@ -122,7 +122,7 @@ describe('pageflow.browser.Agent', function() {
         'Gecko/68.0 Firefox/68.0'
       );
 
-      expect(agent.matchesDesktopFirefox()).toBe(false);
+      expect(agent.matchesDesktopFirefox({minVersion: 20})).toBe(false);
     });
   });
 
@@ -133,7 +133,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36'
       );
 
-      expect(agent.matchesDesktopChrome()).toBe(true);
+      expect(agent.matchesDesktopChrome({minVersion: 20})).toBe(true);
     });
 
     it('returns false for Chrome on android', function() {
@@ -142,7 +142,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36'
       );
 
-      expect(agent.matchesDesktopChrome()).toBe(false);
+      expect(agent.matchesDesktopChrome({minVersion: 20})).toBe(false);
     });
 
     it('returns false for Chrome on iphone', function() {
@@ -151,7 +151,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/83.0.4103.88 Mobile/15E148 Safari/604.1'
       );
 
-      expect(agent.matchesDesktopChrome()).toBe(false);
+      expect(agent.matchesDesktopChrome({minVersion: 20})).toBe(false);
     });
   });
 
@@ -162,7 +162,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36'
       );
 
-      expect(agent.matchesDesktopChrome()).toBe(true);
+      expect(agent.matchesDesktopChrome({minVersion: 20})).toBe(true);
     });
 
     it('returns false for Firefox 17', function() {
@@ -171,7 +171,7 @@ describe('pageflow.browser.Agent', function() {
         'Gecko/20100101 Firefox/17.0'
       );
 
-      expect(agent.matchesDesktopFirefox()).toBe(false);
+      expect(agent.matchesDesktopFirefox({minVersion: 20})).toBe(false);
     });
 
     it('returns true for Edge 83', function() {
@@ -180,7 +180,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36 Edg/83.0.478.58'
       );
 
-      expect(agent.matchesDesktopEdge()).toBe(true);
+      expect(agent.matchesDesktopEdge({minVersion: 20})).toBe(true);
     });
 
     it('returns false for Safari 3.2', function() {
@@ -189,7 +189,7 @@ describe('pageflow.browser.Agent', function() {
         'AppleWebKit/525.27.1 (KHTML, like Gecko) Version/3.2.1 Safari/525.27.1'
       );
 
-      expect(agent.matchesDesktopSafari()).toBe(false);
+      expect(agent.matchesDesktopSafari({minVersion: 20})).toBe(false);
     });
   });
 });

--- a/package/spec/frontend/browser/agent_spec.js
+++ b/package/spec/frontend/browser/agent_spec.js
@@ -81,7 +81,7 @@ describe('pageflow.browser.Agent', function() {
     it('returns true for Edge', function() {
       var agent = new Agent(
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
-        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246'
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36 Edg/83.0.478.58'
       );
 
       expect(agent.matchesDesktopEdge()).toBe(true);
@@ -100,8 +100,8 @@ describe('pageflow.browser.Agent', function() {
   describe('#matchesDesktopFirefox', function() {
     it('returns true for Firefox', function() {
       var agent = new Agent(
-        'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) ' +
-        'Gecko/20100101 Firefox/15.0.1'
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:78.0) ' +
+        'Gecko/20100101 Firefox/78.0'
       );
 
       expect(agent.matchesDesktopFirefox()).toBe(true);
@@ -136,15 +136,6 @@ describe('pageflow.browser.Agent', function() {
       expect(agent.matchesDesktopChrome()).toBe(true);
     });
 
-    it('returns false for Chromium', function() {
-      var agent = new Agent(
-        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.30 (KHTML, like Gecko) ' +
-        'Ubuntu/11.04 Chromium/12.0.742.112 Chrome/12.0.742.112 Safari/534.30'
-      );
-
-      expect(agent.matchesDesktopChrome()).toBe(false);
-    });
-
     it('returns false for Chrome on android', function() {
       var agent = new Agent(
         'Mozilla/5.0 (Linux; Android 10) '+
@@ -161,6 +152,44 @@ describe('pageflow.browser.Agent', function() {
       );
 
       expect(agent.matchesDesktopChrome()).toBe(false);
+    });
+  });
+
+  describe('#minVersion', function() {
+    it('returns true for Chrome 83', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36'
+      );
+
+      expect(agent.matchesDesktopChrome()).toBe(true);
+    });
+
+    it('returns false for Firefox 17', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:17.0) ' +
+        'Gecko/20100101 Firefox/17.0'
+      );
+
+      expect(agent.matchesDesktopFirefox()).toBe(false);
+    });
+
+    it('returns true for Edge 83', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '+
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36 Edg/83.0.478.58'
+      );
+
+      expect(agent.matchesDesktopEdge()).toBe(true);
+    });
+
+    it('returns false for Safari 3.2', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_6; en-us) '+
+        'AppleWebKit/525.27.1 (KHTML, like Gecko) Version/3.2.1 Safari/525.27.1'
+      );
+
+      expect(agent.matchesDesktopSafari()).toBe(false);
     });
   });
 });

--- a/package/spec/frontend/browser/agent_spec.js
+++ b/package/spec/frontend/browser/agent_spec.js
@@ -76,4 +76,91 @@ describe('pageflow.browser.Agent', function() {
       expect(agent.matchesDesktopSafari()).toBe(false);
     });
   });
+
+  describe('#matchesDesktopEdge', function() {
+    it('returns true for Edge', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246'
+      );
+
+      expect(agent.matchesDesktopEdge()).toBe(true);
+    });
+
+    it('returns false for Edge on Windows 10 mobile', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Windows Mobile 10; Android 10.0; Microsoft; Lumia 950XL) '+
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Mobile Safari/537.36 Edge/40.15254.603'
+      );
+
+      expect(agent.matchesDesktopEdge()).toBe(false);
+    });
+  });
+
+  describe('#matchesDesktopFirefox', function() {
+    it('returns true for Firefox', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) ' +
+        'Gecko/20100101 Firefox/15.0.1'
+      );
+
+      expect(agent.matchesDesktopFirefox()).toBe(true);
+    });
+
+    it('returns false for SeaMonkey', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (X11; Linux x86_64; rv:29.0) ' +
+        'Gecko/20100101 Firefox/29.0 SeaMonkey/2.26'
+      );
+
+      expect(agent.matchesDesktopFirefox()).toBe(false);
+    });
+
+    it('returns false for Firefox on android', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Android 10; Mobile; rv:68.0) '+
+        'Gecko/68.0 Firefox/68.0'
+      );
+
+      expect(agent.matchesDesktopFirefox()).toBe(false);
+    });
+  });
+
+  describe('#matchesDesktopChrome', function() {
+    it('returns true for Chrome', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36'
+      );
+
+      expect(agent.matchesDesktopChrome()).toBe(true);
+    });
+
+    it('returns false for Chromium', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.30 (KHTML, like Gecko) ' +
+        'Ubuntu/11.04 Chromium/12.0.742.112 Chrome/12.0.742.112 Safari/534.30'
+      );
+
+      expect(agent.matchesDesktopChrome()).toBe(false);
+    });
+
+    it('returns false for Chrome on android', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Linux; Android 10) '+
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36'
+      );
+
+      expect(agent.matchesDesktopChrome()).toBe(false);
+    });
+
+    it('returns false for Chrome on iphone', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) '+
+        'AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/83.0.4103.88 Mobile/15E148 Safari/604.1'
+      );
+
+      expect(agent.matchesDesktopChrome()).toBe(false);
+    });
+  });
 });

--- a/package/src/frontend/browser/Agent.js
+++ b/package/src/frontend/browser/Agent.js
@@ -9,9 +9,15 @@ export const Agent = function(userAgent) {
     },
 
     matchesDesktopSafari: function(options) {
-      return this.matchesSafari() &&
-             !this.matchesMobilePlatform() &&
-             matchesMinVersion(/Version\/(\d+)/i, options.minVersion);
+      if (options) {
+        return this.matchesSafari() &&
+               !this.matchesMobilePlatform() &&
+               matchesMinVersion(/Version\/(\d+)/i, options.minVersion);
+      }
+      else {
+        return this.matchesSafari() &&
+               !this.matchesMobilePlatform()
+      }     
     },
 
     matchesDesktopSafari9: function() {
@@ -91,21 +97,39 @@ export const Agent = function(userAgent) {
     },
 
     matchesDesktopChrome: function(options) {
-      return this.matchesChrome() &&
-             !this.matchesMobilePlatform() &&
-             matchesMinVersion(/Chrome\/(\d+)/i, options.minVersion);
+      if (options) {
+        return this.matchesChrome() &&
+               !this.matchesMobilePlatform() &&
+               matchesMinVersion(/Chrome\/(\d+)/i, options.minVersion);
+      }
+      else {
+        return this.matchesChrome() &&
+               !this.matchesMobilePlatform()
+      }     
     },
 
     matchesDesktopFirefox: function(options) {
-      return this.matchesFirefox() &&
-             !this.matchesMobilePlatform() &&
-             matchesMinVersion(/Firefox\/(\d+)/i, options.minVersion);
+      if (options) {
+        return this.matchesFirefox() &&
+               !this.matchesMobilePlatform() &&
+               matchesMinVersion(/Firefox\/(\d+)/i, options.minVersion);
+      }
+      else {
+        return this.matchesFirefox() &&
+               !this.matchesMobilePlatform();
+      }      
     },
     
     matchesDesktopEdge: function(options) {
-      return this.matchesEdge() &&
-             !this.matchesMobilePlatform() &&
-             matchesMinVersion(/Edg\/(\d+)/i, options.minVersion);
+      if (options) {
+        return this.matchesEdge() &&
+               !this.matchesMobilePlatform() &&
+               matchesMinVersion(/Edg\/(\d+)/i, options.minVersion);
+      }
+      else {
+        return this.matchesEdge() &&
+               !this.matchesMobilePlatform();
+      }     
     },
     
     /**

--- a/package/src/frontend/browser/Agent.js
+++ b/package/src/frontend/browser/Agent.js
@@ -9,7 +9,7 @@ export const Agent = function(userAgent) {
     },
 
     matchesDesktopSafari: function() {
-      return this.matchesSafari() && !this.matchesMobilePlatform();
+      return this.matchesSafari() && !this.matchesMobilePlatform() && minVersion(/Version\/(\d+)/i, 4);
     },
 
     matchesDesktopSafari9: function() {
@@ -89,15 +89,15 @@ export const Agent = function(userAgent) {
     },
 
     matchesDesktopChrome: function() {
-      return this.matchesChrome() && !this.matchesMobilePlatform();
+      return this.matchesChrome() && !this.matchesMobilePlatform() && minVersion(/Chrome\/(\d+)/i, 25);
     },
 
     matchesDesktopFirefox: function() {
-      return this.matchesFirefox() && !this.matchesMobilePlatform();
+      return this.matchesFirefox() && !this.matchesMobilePlatform() && minVersion(/Firefox\/(\d+)/i, 20);
     },
     
     matchesDesktopEdge: function() {
-      return this.matchesEdge() && !this.matchesMobilePlatform();
+      return this.matchesEdge() && !this.matchesMobilePlatform() && minVersion(/Edg\/(\d+)/i, 20);
     },
     
     /**
@@ -105,8 +105,7 @@ export const Agent = function(userAgent) {
    * @return {boolean}
    */
     matchesChrome: function() {
-      return matches(/Chrome\//i) &&
-             !matches(/Chromium/i);
+      return matches(/Chrome\//i);
     },
     
     /**
@@ -123,7 +122,7 @@ export const Agent = function(userAgent) {
    * @return {boolean}
    */
     matchesEdge: function() {
-      return matches(/Edge\//i);
+      return matches(/Edg\//i);
     }
   };
 
@@ -134,6 +133,26 @@ export const Agent = function(userAgent) {
   function captureGroupGreaterOrEqual(exp, version) {
     var match = userAgent.match(exp);
     return match && match[1] && parseInt(match[1], 10) >= version;
+  }
+
+  function minVersion(exp, version) {
+    var match = userAgent.match(exp);
+    //Chrome
+    if (match[0].includes('Chrome')) {
+      return match && match[1] && parseInt(match[1], 10) >= version;
+    }
+    //Edge
+    if (match[0].includes('Edg')) {
+      return match && match[1] && parseInt(match[1], 10) >= version;
+    }
+    //Safari
+    if (match[0].includes('Version')) {
+      return match && match[1] && parseInt(match[1], 10) >= version;
+    }
+    //Firefox
+    if (match[0].includes('Firefox')) {
+      return match && match[1] && parseInt(match[1], 10) >= version;
+    }    
   }
 };
 

--- a/package/src/frontend/browser/Agent.js
+++ b/package/src/frontend/browser/Agent.js
@@ -39,7 +39,7 @@ export const Agent = function(userAgent) {
 
     matchesSafari11AndAbove: function() {
       return this.matchesSafari() &&
-             captureGroupGreaterOrEqual(/Version\/(\d+)/i, 11);
+             matchesMinVersion(/Version\/(\d+)/i, 11);
     },
 
     matchesSafari: function() {
@@ -113,7 +113,9 @@ export const Agent = function(userAgent) {
    * @return {boolean}
    */
     matchesChrome: function() {
-      return matches(/Chrome\//i);
+      // - Edge also reports to be a Chrome
+      return matches(/Chrome\//i) &&
+              !matches(/Edg/i);
     },
     
     /**
@@ -138,29 +140,9 @@ export const Agent = function(userAgent) {
     return !!userAgent.match(exp);
   }
 
-  function captureGroupGreaterOrEqual(exp, version) {
-    var match = userAgent.match(exp);
-    return match && match[1] && parseInt(match[1], 10) >= version;
-  }
-
   function matchesMinVersion(exp, version) {
     var match = userAgent.match(exp);
-    //Chrome
-    if (match[0].includes('Chrome')) {
-      return match && match[1] && parseInt(match[1], 10) >= version;
-    }
-    //Edge
-    if (match[0].includes('Edg')) {
-      return match && match[1] && parseInt(match[1], 10) >= version;
-    }
-    //Safari
-    if (match[0].includes('Version')) {
-      return match && match[1] && parseInt(match[1], 10) >= version;
-    }
-    //Firefox
-    if (match[0].includes('Firefox')) {
-      return match && match[1] && parseInt(match[1], 10) >= version;
-    }    
+    return match && match[1] && parseInt(match[1], 10) >= version;   
   }
 };
 

--- a/package/src/frontend/browser/Agent.js
+++ b/package/src/frontend/browser/Agent.js
@@ -86,6 +86,44 @@ export const Agent = function(userAgent) {
      */
     matchesFacebookInAppBrowser: function() {
       return userAgent.match(/FBAN/) && userAgent.match(/FBAV/);
+    },
+
+    matchesDesktopChrome: function() {
+      return this.matchesChrome() && !this.matchesMobilePlatform();
+    },
+
+    matchesDesktopFirefox: function() {
+      return this.matchesFirefox() && !this.matchesMobilePlatform();
+    },
+    
+    matchesDesktopEdge: function() {
+      return this.matchesEdge() && !this.matchesMobilePlatform();
+    },
+    
+    /**
+   * Returns true on Google Chrome.
+   * @return {boolean}
+   */
+    matchesChrome: function() {
+      return matches(/Chrome\//i) &&
+             !matches(/Chromium/i);
+    },
+    
+    /**
+   * Returns true on Firefox.
+   * @return {boolean}
+   */
+    matchesFirefox: function() {
+      return matches(/Firefox\//i) &&
+            !matches(/Seamonkey/i);
+    },
+    
+    /**
+   * Returns true on Microsoft Edge.
+   * @return {boolean}
+   */
+    matchesEdge: function() {
+      return matches(/Edge\//i);
     }
   };
 

--- a/package/src/frontend/browser/Agent.js
+++ b/package/src/frontend/browser/Agent.js
@@ -8,8 +8,10 @@ export const Agent = function(userAgent) {
       return matches(/\bSilk\b/);
     },
 
-    matchesDesktopSafari: function() {
-      return this.matchesSafari() && !this.matchesMobilePlatform() && minVersion(/Version\/(\d+)/i, 4);
+    matchesDesktopSafari: function(options) {
+      return this.matchesSafari() &&
+             !this.matchesMobilePlatform() &&
+             matchesMinVersion(/Version\/(\d+)/i, options.minVersion);
     },
 
     matchesDesktopSafari9: function() {
@@ -88,16 +90,22 @@ export const Agent = function(userAgent) {
       return userAgent.match(/FBAN/) && userAgent.match(/FBAV/);
     },
 
-    matchesDesktopChrome: function() {
-      return this.matchesChrome() && !this.matchesMobilePlatform() && minVersion(/Chrome\/(\d+)/i, 25);
+    matchesDesktopChrome: function(options) {
+      return this.matchesChrome() &&
+             !this.matchesMobilePlatform() &&
+             matchesMinVersion(/Chrome\/(\d+)/i, options.minVersion);
     },
 
-    matchesDesktopFirefox: function() {
-      return this.matchesFirefox() && !this.matchesMobilePlatform() && minVersion(/Firefox\/(\d+)/i, 20);
+    matchesDesktopFirefox: function(options) {
+      return this.matchesFirefox() &&
+             !this.matchesMobilePlatform() &&
+             matchesMinVersion(/Firefox\/(\d+)/i, options.minVersion);
     },
     
-    matchesDesktopEdge: function() {
-      return this.matchesEdge() && !this.matchesMobilePlatform() && minVersion(/Edg\/(\d+)/i, 20);
+    matchesDesktopEdge: function(options) {
+      return this.matchesEdge() &&
+             !this.matchesMobilePlatform() &&
+             matchesMinVersion(/Edg\/(\d+)/i, options.minVersion);
     },
     
     /**
@@ -135,7 +143,7 @@ export const Agent = function(userAgent) {
     return match && match[1] && parseInt(match[1], 10) >= version;
   }
 
-  function minVersion(exp, version) {
+  function matchesMinVersion(exp, version) {
     var match = userAgent.match(exp);
     //Chrome
     if (match[0].includes('Chrome')) {


### PR DESCRIPTION
REDMINE-17565
We want to restrict entry to editor on certain devices and browsers.

- [X] Extend the existing user agent detection code to cover all cases we need to recognize.

> Extend the Agent API to cover four most used desktop browsers.

- [X] Add tests with example user agent codes.

> Extend the agent-specs to cover all the newly added cases.