### PR TITLE
Prevent gaps in cards

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/textBlock/TextBlock.module.css
+++ b/entry_types/scrolled/package/src/contentElements/textBlock/TextBlock.module.css
@@ -1,3 +1,5 @@
+.text h2,
+.text li,
 .text p {
   margin: 1em 0 0 0;
 }
@@ -9,5 +11,23 @@
 
 .text ol,
 .text ul {
+  margin: 0;
   padding-left: 20px;
+}
+
+.text blockquote {
+  padding: 0.5em 1em 0.5em 2em;
+  margin: 1em 0 0 0.5em;
+  position: relative;
+}
+
+.text blockquote::before {
+  content: "“";
+  font-size: 3em;
+  font-weight: bold;
+  color: #aaa;
+  position: absolute;
+  top: 0;
+  left: 0;
+  line-height: 1em;
 }


### PR DESCRIPTION
Use top margins only. Since margins can not collapse accross open
ended cards, bottom margins cause gaps to appear.

REDMINE-17759