### PR TITLE
Use empty inline images in appearance stories

### DIFF
--- a/entry_types/scrolled/package/spec/support/stories.js
+++ b/entry_types/scrolled/package/spec/support/stories.js
@@ -268,7 +268,7 @@ export function examplePositionedElement({sectionId, position, caption}) {
     typeName: 'inlineImage',
     configuration: {
       position,
-      id: filePermaId('imageFiles', 'turtle'),
+      id: null,
       caption
     }
   }


### PR DESCRIPTION
Prevent big images from loading to slowly and thus not showing up in
snapshots causing false positives on Percy.

REDMINE-17741