### PR TITLE
Add logic to detect IOS 13 Safari on iPad

### DIFF
--- a/package/src/frontend/browser/Agent.js
+++ b/package/src/frontend/browser/Agent.js
@@ -178,8 +178,9 @@ export const Agent = function(userAgent) {
   //with multi-touch support other than IOS/iPadOS
   //See: https://stackoverflow.com/a/58064481
   function matchesiPadSafari13AndAbove() {
-    return navigator.maxTouchPoints > 1 &&
-            navigator.platform === 'MacIntel';       
+    return agent.matchesSafari() &&
+           navigator.maxTouchPoints > 1 &&
+           navigator.platform === 'MacIntel';       
   }
 };
 

--- a/package/src/frontend/browser/Agent.js
+++ b/package/src/frontend/browser/Agent.js
@@ -63,9 +63,11 @@ export const Agent = function(userAgent) {
     matchesMobileSafari: function() {
       var matchers = [/iPod/i, /iPad/i, /iPhone/i];
 
-      return matchers.some(function(matcher) {
-        return userAgent.match(matcher);
-      });
+      return (matchers.some(function(matcher) {
+              return userAgent.match(matcher);
+             }) &&
+             !window.MSStream) || //IE exclusion from being detected as an iOS device;
+             matchesiPadSafari13AndAbove();
     },
 
     /**
@@ -76,8 +78,9 @@ export const Agent = function(userAgent) {
       var matchers = [/iPod/i, /iPad/i, /iPhone/i, /Android/i, /Silk/i, /IEMobile/i];
 
       return matchers.some(function(matcher) {
-        return userAgent.match(matcher);
-      });
+              return userAgent.match(matcher);
+             }) ||
+             matchesiPadSafari13AndAbove();
     },
 
     /**
@@ -167,6 +170,16 @@ export const Agent = function(userAgent) {
   function matchesMinVersion(exp, version) {
     var match = userAgent.match(exp);
     return match && match[1] && parseInt(match[1], 10) >= version;   
+  }
+
+  //After ios13 update, iPad reports the same user string
+  //as Safari on Dekstop MacOS.
+  //At the time of this writing there are no other devices
+  //with multi-touch support other than IOS/iPadOS
+  //See: https://stackoverflow.com/a/58064481
+  function matchesiPadSafari13AndAbove() {
+    return navigator.maxTouchPoints > 1 &&
+            navigator.platform === 'MacIntel';       
   }
 };
 


### PR DESCRIPTION
REDMINE-17737

After IOS 13 update, iPad reports the same user string
as Safari on Dekstop MacOS

It adds further support of detecting multi touch devices

At the time of this writing there are no other devices
with multi-touch support other than IOS/iPadOS

Also, adds a check for IE devices to be detected as
IOS devices