### PR TITLE
Fix dummy app generation with Thor 1.0

### DIFF
--- a/spec/support/pageflow/dummy/rails_template.rb
+++ b/spec/support/pageflow/dummy/rails_template.rb
@@ -35,8 +35,7 @@ gsub_file('app/assets/javascripts/application.js', %r'//=.*', '')
 
 # Recreate db. Ignore if it does not exist.
 
-log :rake, 'db:drop:all'
-in_root { run('rake db:environment:set db:drop:all 2> /dev/null', verbose: false) }
+in_root { run('rake db:environment:set db:drop:all', capture: true, abort_on_failure: false) }
 rake 'db:create:all'
 
 # Install pageflow and the tested engine via their generators.


### PR DESCRIPTION
Pass `abort_on_failure` option to explictly ignore failing `rake
db:drop` command when no databases exist. Failures used to be ignored.

REDMINE-17780