### PR TITLE
Do not create two nested links when closing link box with Enter

### DIFF
--- a/entry_types/scrolled/package/src/frontend/inlineEditing/EditableText/LinkInput.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/EditableText/LinkInput.js
@@ -19,7 +19,7 @@ export function LinkInput({onSubmit, onCancel}) {
   function handleKey(event) {
     if (event.key === 'Enter') {
       event.preventDefault();
-      submit();
+      ref.current.blur();
     }
     else if (event.key === 'Escape') {
       event.preventDefault();


### PR DESCRIPTION
`onSubmit` function was called twice: Once for enter key, once for
blur. Make enter key blur input, to only call function once.

REDMINE-17782