### PR TITLE
Add story to test media autoplay

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/MediaPlayer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/MediaPlayer-spec.js
@@ -13,7 +13,7 @@ describe('MediaPlayer', () => {
     return [
       {type: 'audio/ogg', src: 'http://example.com/example.ogg'},
       {type: 'audio/m4a', src: 'http://example.com/example.m4a'},
-      {type: 'audio/mp3', src: 'http://example.com/example.ogg'}
+      {type: 'audio/mp3', src: 'http://example.com/example.mp3'}
     ];
   }
 
@@ -70,6 +70,19 @@ describe('MediaPlayer', () => {
     expect(queryPlayer()).toBeDefined();
     expect(media.getPlayer).toHaveBeenCalledWith(getVideoSources(),
                                                  expect.objectContaining({tagName: 'video'}))
+  });
+
+  it('supports appending a suffix to source urls', () => {
+    render(<MediaPlayer {...requiredProps()}
+                        sourceUrlSuffix="?test"
+                        sources={getVideoSources()} />);
+
+    expect(media.getPlayer).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({src: expect.stringMatching(/example.mp4\?test$/)}),
+      ],
+      expect.anything()
+    );
   });
 
   it('does not request new Player for same sources', () => {

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/index.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/index.js
@@ -64,7 +64,7 @@ function PreparedMediaPlayer(props){
     <>
       <PlayerContainer className={classNames(props.className, {[textTrackStyles.inset]: props.textTracksInset})}
                        type={props.type}
-                       sources={props.sources}
+                       sources={appendSuffix(props.sources, props.sourceUrlSuffix)}
                        textTrackSources={getTextTrackSources(props.textTracks.files)}
                        filePermaId={props.filePermaId}
                        poster={props.posterImageUrl}
@@ -83,4 +83,15 @@ PreparedMediaPlayer.defaultProps = {
   textTracks: {
     files: []
   }
+}
+
+function appendSuffix(sources, suffix) {
+  if (!suffix) {
+    return sources;
+  }
+
+  return sources.map(source => ({
+    ...source,
+    src: `${source.src}${suffix}`
+  }));
 }

--- a/entry_types/scrolled/package/src/frontend/__stories__/mediaPlayerAutoplay-stories.js
+++ b/entry_types/scrolled/package/src/frontend/__stories__/mediaPlayerAutoplay-stories.js
@@ -1,0 +1,91 @@
+import React, {useEffect, useState} from 'react';
+import {usePrevious} from '../usePrevious';
+import {normalizeAndMergeFixture, filePermaId} from 'pageflow-scrolled/spec/support/stories';
+
+import {media} from 'pageflow/frontend';
+import {RootProviders, AudioPlayer, VideoPlayer, usePlayerState} from 'pageflow-scrolled/frontend';
+
+export default {
+  title: 'Frontend/Media Player/Autoplay',
+  parameters: {
+    percy: {skip: true}
+  }
+}
+
+export const video = () =>
+  <RootProviders seed={normalizeAndMergeFixture({})}>
+    <Test Player={VideoPlayer} id={filePermaId('videoFiles', 'interview_toni')}/>
+  </RootProviders>
+
+export const audio = () =>
+  <RootProviders seed={normalizeAndMergeFixture({})}>
+    <Test Player={AudioPlayer} id={filePermaId('audioFiles', 'quicktime_jingle')} />
+  </RootProviders>
+
+function Test({Player, id, playerCount = 4}) {
+  const [playingIndex, setPlayingIndex] = useState();
+  const [generation, setGeneration] = useState(0);
+
+  function renderPlayers() {
+    return Array.from({length: playerCount}, (_, index) =>
+      <TestPlayer key={`${generation}-${index}`}
+                  Player={Player}
+                  id={id}
+                  sourceUrlSuffix={`?v=${index}`}
+                  playing={playingIndex === index} />
+    );
+  }
+
+  function* autoplayAllForever() {
+    while (true) {
+      setPlayingIndex(index => index < playerCount - 1 ? index + 1 : 0);
+      yield delay(3000);
+    }
+  }
+
+  return (
+    <div>
+      <button onClick={() => media.mute(false) }>Bless player pool</button>
+      <button onClick={() => run(autoplayAllForever())}>Autoplay all</button>
+      <button onClick={() => setGeneration(n => n + 1)}>Recreate Players</button>
+      Generation: {generation}
+
+      {renderPlayers()}
+    </div>
+  );
+}
+
+function TestPlayer({Player, playing, id, sourceUrlSuffix}) {
+  const [playerState, playerActions] = usePlayerState();
+  const previouslyPlaying = usePrevious(playing);
+
+  useEffect(() => {
+    if (previouslyPlaying && !playing) {
+      playerActions.pause();
+    }
+    else if (!previouslyPlaying && playing) {
+      playerActions.play();
+    }
+  }, [playerActions, previouslyPlaying, playing]);
+
+  return (
+    <div style={{width: 200, position: 'relative'}}>
+      {playerState.isPlaying ? 'Playing' : 'Paused'}
+      <Player id={id}
+              playsInline={true}
+              sourceUrlSuffix={sourceUrlSuffix}
+              playerState={playerState}
+              playerActions={playerActions} />
+    </div>
+  );
+}
+
+function delay(duration) {
+  return new Promise(resolve => setTimeout(resolve, duration));
+}
+
+async function run(commands) {
+  for (let c of commands) {
+    await c;
+  }
+}


### PR DESCRIPTION
* Add prop to `MediaPlayer` to allow appending suffix to source
  urls. This is used to reuse the one seed media file as multiple
  sources that are handled independently by the browser.

* Add a story that creates multiple players and tries to autoplay them
  one by one.

REDMINE-17770