### PR TITLE
Separate scrolled and paged help entries

### DIFF
--- a/config/initializers/help_entries.rb
+++ b/config/initializers/help_entries.rb
@@ -1,10 +1,6 @@
 Pageflow.configure do |config|
-  config.help_entries.register('pageflow.help_entries.overview', priority: 100)
-  config.help_entries.register('pageflow.help_entries.meta_data', priority: 50)
   config.help_entries.register('pageflow.help_entries.files', priority: 40)
   config.help_entries.register('pageflow.help_entries.text_tracks', priority: 35)
-  config.help_entries.register('pageflow.help_entries.outline', priority: 30)
-  config.help_entries.register('pageflow.help_entries.page_options', priority: 20)
-  config.help_entries.register('pageflow.help_entries.atmo', priority: 7)
+
   config.help_entries.register('pageflow.help_entries.publishing', priority: 5)
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1449,22 +1449,6 @@ de:
             overview_button_enabled_disabled:
               inline_help: Diese Funktion steht in diesem Theme nicht zur Verfügung.
     help_entries:
-      atmo:
-        menu_item: Atmo Audio
-        text: |-
-          # Atmo Audio
-
-          Mit der „Atmo“ kann jede Seite, unabhängig vom Seitentyp, im Hintergrund Sound abspielen. Dabei kannst Du bestimmen, ob ein Sound nur auf einer Seite zu hören ist oder über mehrere Seiten ohne Unterbrechung läuft. Wähle dazu einfach für die benachbarten Seiten die selbe Audiodatei als Atmo aus.
-
-          Auf diese Weise lassen sich Kapitel akustisch voneinander absetzen und zusammenhängende Seiten stärker verweben.
-
-          Beim Seitentyp Video kann zusätzlich ausgwählt werden, ob der Hintergrundsound während der Video-Wiedergabe normal oder leiser weitergespielt oder ganz ausgeblendet werden soll.
-
-          Die Einstellung der Atmo-Sounds erreichst du bei jeder Seite über den Reiter „Optionen“.
-
-          Sollte Dich die Atmo während der Bearbeitung Deines Beitrags im Editor einmal stören, kannst Du sie mit der Tastenkombination „Alt + a“ vorübergehend stumm schalten. Um die Atmo wieder zu aktivieren, drücke einfach erneut „Alt + a“.
-
-          **ACHTUNG:** Atmo-Audios können aufgrund technischer Einschränkungen der Browserhersteller auf mobilen Geräten und mit Safari auf Desktop nicht wiedergegeben werden.
       files:
         menu_item: Dateien verwalten
         text: |-
@@ -1527,87 +1511,6 @@ de:
           werden. Hier können z.B. die beim Upload eingegebenen
           Metadaten (wie die Angaben zum Urheberrecht) noch einmal
           bearbeiten werden.
-      meta_data:
-        menu_item: Titel und Optionen
-        text: "# Titel und Optionen\n\n## Allgemein\n\n### Titel des Pageflows\n\nHier kannst Du Deinem Pageflow einen Titel geben, der in der\nTitelleiste des Browserfensters angezeigt wird. Unter diesem\nTitel wird Dein Pageflow nach der Veröffentlichung auch in\nSuchmaschinen indiziert werden.\n\n### Sprache\n\nWähle hier, in welcher Sprache Dein Pageflow ausgespielt wird. Hierbei geht es um die Frontend-Elemente wie z.B. Scroll-Hinweise, die Mouse-over-Texte der Navigation und das Impressum.\n\n### Credits\n\nHier kannst Du Deine Impressums-Information im Freitext eingeben. Zudem können für alle Dateien unter „Dateien verwalten“ auch Bildrechte vergeben werden, die dann automatisch im Impressum angezeigt werden.\n\n## Erscheinungsbild\n\n### Multimedia Hinweis vor dem Start\n\nEntscheide, ob zu Beginn Deines Pageflows ein Hinweis angezeigt wird.\n\n### Kapitelanfang hervorheben\n\nMit dieser Option wird der Titel der jeweils ersten Seite\neines Kapitels größer dargestellt.\n\n## Neue Seiten hervorheben\n\nZeigt zum Start des Pageflows in einer Info-Box die seit dem letzten Besuch neu erstellen Seiten an. Da für dieses Features Cookies verwendet werden, erscheint bei Aktivierung - gemäss der DSGVO - automatisch ein Cookie-Hinweis am unteren Bildrand.\n\n### Home-Button anzeigen\n\nEs gibt die Möglichkeit, in der Navigation einen Button\nanzuzeigen, der auf eine externe Seite verlinkt, z.B. zurück\nauf die Homepage, von der aus Du den Pageflow verlinkt hast.\n\n\n### Übersicht-Button anzeigen\n\nDer Übersichts-Button in der Navigationsleiste kann ausgeblendet werden.\n\n### Home-Button-URL\n\nGib hier den Link ein, auf den ein Klick auf den Home-Button führen soll. Falls die Ziel-URL für alle Beiträge Deines Kontos identisch ist, kann über „Einstellungen“ auch eine allgemeine „Redirect-URL“ festgelegt werden, die sich auf alle Beiträge auswirkt.\n\n### Steuerungsgesten\n\nMit dieser Option kann die Steuerung für mobile Endgeräte auf horizontales Scrollen umgestellt werden.\n\n### Lade-Ansicht\n\nWähle die Art der Lade-Ansicht Deines Beitrags. Alternativ zur klassischen Ansicht kann hier ein individueller Lade-Indikator mit eigenem Hintergrund-Bild, animierter Titel- und Untertitel-Zeile und skalierbarer Unschärfe konfiguriert werden.\n\n### Player Controls\n\nWähle das Erscheinungsbild der Steuerungs-Elemente für Audio- und Video-Player, 360° Panorama- und Vorher/Nachher-Seiten aus. \n\n### Navigationsleiste\n\nWähle zwischen unterschiedlichen Navigationsleisten. Beachte, dass bei mobilen Endgeräten statt der Navigationsleiste aus Platzgründen in lediglich das Icon „Übersicht“ angezeigt wird. \n\n### Cookie Hinweis\n\nSobald Google Analytics oder das Feature „Neue Seiten hervorheben“ aktiviert ist, wird beim ersten Besuch des Beitrags automatisch ein Datenschutz-Hinweis angezeigt. Falls ein Beitrag in eine eigene Webseite mit eigenem Datenschutz-Hinweis eingebettet wird, kann dieser Hinweis optional ausgeblendet werden.  \n\n### Theme\nLege ein Font-Template für den Beitrag fest. \n\n## Social\n\n### Social Sharing Bild\n\nWähle hier das Bild aus, das beim Teilen des Pageflows in\nsozialen Netzwerken erscheinen soll.\n\n### Zusammenfassung\n\nTrage hier ein, welcher Beschreibungstext beim Teilen in\nsozialen Netzwerken angezeigt wird.\n\n### Social Sharing URL\n\nWenn Beiträge in eigene Webseiten (mit abweichender URL) eingebettet werden  kann hier eine individuelle URL festgelegt werden, die beim Teilen des Beitrags verwendet werden soll. \n\n### Social Share Links\n\nBestimme, welche Share-Buttons beim Klick auf die „Share-Funktion“ angezeigt werden soll."
-      outline:
-        menu_item: Kapitel und Seiten
-        text: |
-          # Kapitel und Seiten
-
-          Ein Pageflow besteht aus mindestens einem Kapitel mit
-          mindestens einer Seite. Es können beliebig viele Kapitel mit
-          beliebig vielen Seiten erstellt werden. Um Inhalte zu
-          erstellen, klicke
-
-          1. auf Neues Kaptitel, um eine erstes Kapitel zu erstellen
-          2. auf Neue Seite, um dem Kapitel eine Seite hinzuzufügen, und
-          3. auf diese Seite, um den Inhalt zu bearbeiten.
-
-          ## Aufbau eines Kapitels
-
-          Mit den „Kapiteln" strukturierst Du den Aufbau Deiner
-          Reportage - beispielsweise nach Themenschwerpunkten oder
-          Zeiträumen. Die Kapitel werden in der „Übersicht“ angezeigt
-          und dienen dem User als Orientierungshilfe. Deshalb ist es
-          ratsam die jeweiligen Kapitel mit Titeln zu versehen.
-
-          Wenn nur ein unbenanntes Kapitel angelegt wird, so verhält
-          sich Pageflow, als ob keine Kapitelstruktur vorhanden
-          ist. (Kapitel und Kapiteltitel werden in diesem Falle nicht
-          in der Übersicht bzw. Navigation dargestellt).
-      overview:
-        menu_item: Übersicht
-        text: |
-          # Übersicht
-
-          Dies ist der Editor zum Bearbeiten eines Pageflows. Mit
-          seiner Zweiteilung ermöglicht er die direkte Vorschau
-          während der Bearbeitung, zeigt Änderungen am Text oder neu
-          ausgewählte Dateien unmittelbar an und speichert diese
-          automatisch.
-
-          Die Seitenleiste kann durch einen Klick auf den Anfasser zur
-          Größenänderung ein- und ausgeblendet werden. Mit einem
-          Verschieben der Seitenleiste nach links und rechts kannst Du
-          die Größe des Vorschaufensters verändern. Wird das
-          Vorschaufenster schmal, und somit eher zu einem hochkantigen
-          Mobiltelefon-Format gestaucht, wird aus Platzgründen statt
-          der Navigationsleiste nur das Icon „Übersicht“ angezeigt.
-
-          Die Navigation des Editors ist unterteilt in die vier
-          Bereiche:
-
-          ## Titel und Optionen
-
-          Unter „Titel und Optionen“ kannst Du grundsätzliche
-          Parameter des Erscheinungsbildes, sowie Titel, Sprache,
-          Impressum etc. einstellen. Dazu können Texte festgelegt
-          werden, die beim Teilen des Beitrags über Social Media
-          Dienste angezeigt werden sollen.
-
-          Details findest Du unter: [Titel und Optionen](#pageflow.help_entries.meta_data)
-
-          ## Dateien verwalten
-
-          Unter „Dateien verwalten“ lädst Du die Mediendateien hoch,
-          die im Pageflow verwendet werden sollen. Du kannst hier auch
-          bereits hochgeladene Videos, Fotos und Audios
-          wiederverwenden.
-
-          Details findest Du unter: [Dateien verwalten](#pageflow.help_entries.files)
-
-          ## Gliederung
-
-          Über die „Gliederung“ kannst Du Kapitel und Seiten
-          hinzufügen, also die eigentlichen Inhalte bearbeiten. Per
-          Drag&Drop lassen sich Seiten und Kapitel auch jederzeit
-          umsortieren.
-
-          Details findest Du unter: [Kapitel und Seiten](#pageflow.help_entries.outline)
-      page_options:
-        menu_item: Allgemeine Seitenoptionen
-        text: "# Allgemeine Seitenoptionen\n\n### Titel\n\nHier gibst Du den Titel der jeweiligen Seite ein. Dieser\nwird nicht nur als Überschrift des Fliesstextes der Seite\nausgespielt, sondern dient zudem als Titel innerhalb der\nNavigation und der Übersicht. Wird eine einzelne Seite in\nsozialen Netzwerken geteilt, ist dieser Titel zugleich auch\nder Titel des Social Media-Beitrages.\n\n### Titel ausblenden\n\nOptional lässt sich der Titel auch ausblenden. Das heisst:\nEr wird nicht mehr als Überschrift im Fliesstext\nangezeigt. Er bleibt zur Identifikation einer Seite\nallerdings in Navigation, Übersicht und geteilten Beträgen\nerhalten.\n\n### Tagline und Untertitel\n\nHier kann wahlweise eine Tagline und/oder ein Untertitel\neingegeben werden. Falls Du ein Häkchen bei „Titel\nausblenden“ gesetzt hast, sind Tagline und Untertitel über\ndem Fliesstext ebenfalls nicht zu sehen.\n\n### Text\n\nDer Textblock kann mit den Buttons unterhalb des\nEingabefeldes formatiert werden. [ B=Fett / I=kursiv /\nU=unterstrichen „gekippte acht“=Link/URL auf fremde Seite\neinfügen].\n\nAlle Änderungen sind in der linken Frontend-Ansicht\nsichtbar, sobald das entsprechende Texteingabefeld im\nEditierbereich verlassen wurde.\n\n### Textposition\n\nWähle hier, ob der Text auf der linken oder rechten Seite\nangezeigt wird.\n\n### Intensität der Abblendung\n\nDie Intensität des Farbverlaufs dient der Lesbarkeit von\nTexten auf Videos oder Bildern.\n\nDurch den Schieberegler kann der Bildhintergrund so stark\nabgedunkelt bzw. aufgehellt werden, bis der Kontrast\nzwischen Bild und Text ausreichend ist.\n\n### Farben invertieren\n\nBeim Invertieren werden „hell“ und „dunkel“ vertauscht, die\nsonst weiße Schrift ändert sich dabei automatisch in\nschwarz.\n\nGrundsätzlich gilt: Helle Schrift für dunkle Bilder, dunkle\nSchrift für helle Bilder.\n\n### Thumbnail\n\nDas Thumbnail ersetzt das ansonsten automatisch generierte\nVorschaubild in der Navigation und in der Übersicht.\n\n### In Navigationsleiste anzeigen\n\nIst diese Option nicht gesetzt, wird die jeweilige Seite\nnicht in der Navigation repräsentiert, kann also nicht\ndirekt über die Navigation erreicht werden.\n\nDies bietet sich vor allem für Seiten an, die inhaltlich als\n„Unterseiten“ einer anderen Seite anzusehen sind.\n\n### Übergangseffekt\n\nEs gibt verschiedene Effekte, die sichtbar sind, wenn von einer Kapitelseite zur nächsten gescrollt oder geklickt wird. Zur Auswahl stehen Seitenübergänge, wie „Überblendung“, „Schwarzblende“ oder „Harter Schnitt“ die sich vertikal auswirken, zudem kann auch „Horizontal Scrollen“ von rechts oder links ausgewählt werden. \n\nWelcher Effekt verwendet wird, kann unter „Optionen“ individuell für jede Seite festgelegt werden.\n\n### Text verzögert einblenden\n\nBestimme mit dieser Option, ob Text und Abblendung mit zeitlicher Verzögerung angezeigt werden.\nHierbei sehen User zunächst nur den Hintergrund, dann erscheinen Titel, Tagline und Untertitel und mit minimaler Verzögerung schließlich der Fließtext.\n\nInsgesamt stehen drei Verzögerungslängen zur Verfügung: kurz = 1 Sekunde, mittel = 3 Sekunde, lang = 5 Sekunde.\n\nDieses Feature eignet sich zum Beispiel für Intros oder Kapitelanfänge.\n\n### Beschreibung für Übersicht\n\nHier kann der Text eingegeben werden, der angezeigt wird,\nwenn der User in der Übersicht mit der Mouse über die\njeweilige Seite fährt. Außerdem entspricht der hier\neingegebene Text"
       page_types:
         menu_item: Seitentypen
         text: |
@@ -1621,9 +1524,6 @@ de:
       publishing:
         menu_item: Veröffentlichen
         text: "# Veröffentlichen\n\nKlicke in der Gliederung auf die Schaltfläche\n„Veröffentlichen“ um Deinen Pageflow zu publizieren. Eine\nReportage kann entweder zeitlich unbegrenzt oder bis zu\neinem bestimmten Stichtag veröffentlicht\nwerden. \n\n### Passwortschutz\n\nAußerdem gibt es die Möglichkeit, Pageflows mit einem Passwort zu schützen. \nHierzu muss einfach das entsprechende Häkchen bei „Mit Passwort schützen\" gesetzt werden. \nDas System verwendet als Benutzernamen den Namen des Kontos und generiert ein Passwort, \nwelches auch manuell geändert werden kann. \n\nBeiträge, die bereits veröffentlicht sind, können nachträglich mit einem Passwort geschützt werden - und andersherum können auch geschützte Beiträge anschließend mit erneutem Klick auf „Veröffentlichen“ vom Passwortschutz befreit werden. Bei der Veröffentlichung werden die auszuführenden Schritte im Dialogfenster angezeigt und erklärt.\n\n### Änderungen nach der Veröffentlichung\n\nVeröffentlichte Pageflows können jederzeit manuell depubliziert werden. Sollte eine Reportage bereits veröffentlicht sein, werden nachträgliche Änderungen erst öffentlich sichtbar, sobald die Reportage erneut veröffentlicht wird. \n\n\n### Einbettung als iframe\n\nVeröffentlichte Beiträge können auch in die eigene Webseite eingebettet werden. Weitere Informationen findest Du in diesem [Artikel](https://pageflow.freshdesk.com/support/solutions/articles/11000002742-wie-kann-ich-einen-beitrag-in-eine-webseite-einbetten)\n\n### Einbettung iframe-Teaser \n\nVorschaubild zum Einbetten in Externe Webseiten Nach der Veröffentlichung erstellt das System ein Vorschaubild, das als iframe zur Verlinkung in eine externe Seite eingebunden werden kann.  Anhand des ausgespielten Codes lässt sich die\nGröße des iframes frei einstellen. Hierbei ist jedoch eine Mindesthöhe von 150px und und eine Mindestbreite von 220px zu beachten."
-      storylines:
-        menu_item: Erzählstränge
-        text: "# Erzählstränge\n\nErgänzend zur linearen Erzählung von „oben nach unten“, können auch weitere (non-lineare) Erzählstränge als Exkurse zu vertiefenden Inhalten genutzt werden. \n\nIn diesem [Blogartikel](https://www.pageflow.io/neues-pageflow-update) findest Du ein Beispiel.\n\nMit „Erzählstrang“ ist hier die zusammenhängende Kapitel- und Seitenabfolge gemeint, durch die ein User hindurch scrollt. Zu unterscheiden ist zwischen dem sogenannten Haupterzählstrang, in dem ein User zu Beginn eines Pageflows einsteigt, und weiteren untergeordneten Erzählsträngen. \n\nUm vom Haupterzählstrang einen Abzweig zu erstellen, benutze eine „Verweise“-Seite (Mosaik, Collage oder Hotspot) und lege auf der jeweiligen Seite unter „Verweise“ die entsprechenden Verknüpfungen an. \n\nDabei kann durch das Festlegen einer „übergeordneten Seite“ bestimmt werden, zu welcher Seite der User am Ende des Erzählstrangs  gelangt.\n\nOptisch unterstützt werden diese Exkurse in untergeordnete Erzählstränge durch einen horizontalen Seitenübergangseffekt, der beim Eintreten und Verlassen dieser Stränge automatisch eingestellt ist. \n\nErstellt werden diese Erzählstränge in der Gliederung über ein Klick auf die Plus-Schaltfläche neben der Erzählstrang-Auswahl. Dabei öffnet sich automatisch ein neues Kapitel, in dem dann weitere Seiten angelegt werden können.\n\n\n### Übergeordnete Seiten\n\nIn jedem Untererzählstrang muss eine „Übergeordnete Seite“ festgelegt werden, die bestimmt, wohin ein User beim zurück-scrollen gelangt. Mit einem Klick auf das Stift-Symbol neben der Erzählstrang-Auswahl kann diese Zielseite ausgewählt werden. Durch die Auswahl einer übergeordneten Seite erscheint auf allen Seiten eines untergeordneten Erzählstrangs zudem automatisch ein „Zurück“-Button, der zu der übergeordneten Seite führt. \n\n\n### Kapitel-Hierarchie\n\nDurch die Verwendung mehrerer „untergeordneter“ Erzählstränge und der Festlegung von übergeordneten Seiten ergibt sich eine Kapitelhierarchie, wie man sie auch von Buch-Gliederungen kennt:\n\n1. (Hauptstrang), 1.1 (Übergeordneter Unterstrang), 1.1.1 (vertiefende Seite im übergeordneten Unterstrang) und so weiter.\n\nDiese Hierarchie kann nachträglich in der Erzählstrang-Auswahl über ein Klick auf Stift-Symbol geändert werden. Ein untergeordneter Erzählstrang kann an dieser Stelle zudem auch nachträglich zum Haupt-Erzählstrang umsortiert werden.\n\n\n### Scroll-Nachfolger\n\nFalls der User von der letzten Seite eines Unterkapitels (1.1.1) auf eine andere Stelle im Beitrag geleitet werden soll (z.B. 2.1), kann hierzu ebenfalls über das Stiftsymbol in den Erzählstrang-Einstellungen der sogenannte „Scroll-Nachfolger“ festgelegt werden. Um in dem Beispiel zu bleiben wäre der folgende Ablauf denkbar: 1 -> 1.1 -> 1.1.1 -> 2.1\n\nAchtung: Während des Editierens wird immer nur das aktuell ausgewählte Kapitel angezeigt. Um zu den anderen Erzählsträngen zu gelangen klicke auf das Auswahlmenü „Erzählstrang“."
       text_tracks:
         menu_item: Textspuren
         text: |-

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -484,7 +484,7 @@ de:
     - Fr
     - Sa
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mär
@@ -510,7 +510,7 @@ de:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    -
+    - 
     - Januar
     - Februar
     - März
@@ -948,7 +948,7 @@ de:
       help_entries:
         page_type:
           menu_item: Audio
-          text: "# Audio\n\n*Wiedergabe von Audiodatei mit Steuerelementen* \n    \nHiermit kannst Du Audiodateien mit Hintergrund-Bild oder Hintergrund-Video und Textinhalten\nkombinieren. Wie beim Seitentyp „Video“ werden\nSteuerelemente angezeigt, und ebenso kann eine zusätzliche\nInfobox mit Text befüllt werden.\n\nTypische Anwendungsbeispiele: Interview, O-Töne,\nMusikstücke"
+          text: "# Audio\n\n*Wiedergabe von Audiodatei mit Steuerelementen* \n    \nHiermit kannst Du Audiodateien mit Hintergrund-Bild oder Hintergrund-Video und Textinhalten\nkombinieren. Wie beim Seitentyp „Video“ werden\nSteuerelemente angezeigt, und ebenso kann eine zusätzliche\nInfobox mit Text befüllt werden.\n\nUnter „Optionen“ kann das Erscheinungsbild des Players auf die Visualisierung der Waveform eines Audio-Files gewechselt werden.\n\nTypische Anwendungsbeispiele: Interview, O-Töne,\nMusikstücke"
       open: Audio anhören
       page_attributes:
         audio_player_controls_variant:
@@ -969,27 +969,7 @@ de:
       help_entries:
         page_type:
           menu_item: Hintergrund-Bild/-Video
-          text: |-
-            # Hintergrund-Bild/-Video
-
-            Bildschirmfüllendes Bild und Text
-
-            Mit dem Seitentyp „Hintergrund-Bild/-Video“ werden großformatige
-            Bilder oder Videos mit Text überlagert und zur optimalen Lesbarkeit
-            mit einem manuell einstellbaren Farbverlauf gepaart. über
-            die Auswahl des Bildausschnitts stellst Du sicher, dass
-            Dein Bild auch auf mobilen Endgeräten optimal dargestellt
-            wird. Wahlweise kann der Text für einen ausreichenden
-            Kontrast auch invertiert - also von hell in dunkel -
-            vertauscht werden. Das bietet sich bei hellen
-            Hintergrund-Bildern an.
-
-            User haben übrigens die Möglichkeit Farbverlauf und Text
-            im Front-End auszublenden, sofern Sie sich speziell für
-            das Hintergrund-Bild oder - Video interessieren.
-
-            Typische Anwendungsbeispiele: Präsentation, Teil einer
-            Bildergalerie, Portrait
+          text: "# Hintergrund-Bild/-Video\n\n*Bildschirmfüllendes Bild und Text*\n\nMit dem Seitentyp „Hintergrund-Bild/-Video“ werden großformatige Bilder oder Videos mit Text überlagert und zur optimalen Lesbarkeit mit einem manuell einstellbaren Farbverlauf gepaart. Über die Auswahl des Bildausschnitts stellst Du sicher, dass Dein Bild auch auf mobilen Endgeräten im Portrait-Modus den relevanten Ausschnitt deines Motivs zeigt. \n\nWahlweise kann der Text für einen ausreichenden\nKontrast auch invertiert - also von hell in dunkel -\nvertauscht werden. Das bietet sich bei hellen\nHintergrund-Bildern an.\n\nUser haben übrigens die Möglichkeit Farbverlauf und Text\nim Front-End auszublenden, sofern Sie sich speziell für\ndas Hintergrund-Bild oder - Video interessieren.\n\nTypische Anwendungsbeispiele: Präsentation, Teil einer\nBildergalerie, Portrait\n\n**Hinweis zum Ton bei Hintergrund-Videos:** Aufgrund technischer Einschränkungen, basierend auf der „Autoplay Policy“ der Browser-Hersteller, können Videos mit Ton nicht auf allen Geräten/Browsern automatisch abgespielt werden. \n\nUm die Wiedergabe von Videoloops auf mobilen Geräten und bei Safari auf Desktop und Tablets zu ermöglichen wird der Ton daher unterdrückt. Bei Chrome wird diese Einschränkung durch einen Unmute-Button umgangen, bei Firefox entscheiden Nutzer selbst, ob die automatische Wiedergabe von Audios zugelassen wird."
       page_type_category_name: Basic
       page_type_description: Bildschirmfüllendes Bild oder Video-Loop mit Text
       page_type_name: Hintergrund Bild/Video
@@ -1484,7 +1464,7 @@ de:
 
           Sollte Dich die Atmo während der Bearbeitung Deines Beitrags im Editor einmal stören, kannst Du sie mit der Tastenkombination „Alt + a“ vorübergehend stumm schalten. Um die Atmo wieder zu aktivieren, drücke einfach erneut „Alt + a“.
 
-          ACHTUNG: Atmo-Audios werden auf mobilen Geräten nicht wiedergegeben.
+          **ACHTUNG:** Atmo-Audios können aufgrund technischer Einschränkungen der Browserhersteller auf mobilen Geräten und mit Safari auf Desktop nicht wiedergegeben werden.
       files:
         menu_item: Dateien verwalten
         text: |-
@@ -1530,13 +1510,6 @@ de:
           die Verarbeitung noch nicht abgeschlossen ist. Während des
           Ladevorgangs kann also problemlos weiter gearbeitet werden.
 
-          ## Datei-Einstellungen bearbeiten
-
-          Für jede Datei kann über die Schaltfläche "Einstellungen
-          bearbeiten" ein Dialog mit weiteren Optionen angezeigt
-          werden. Hier können z.B. die beim Upload eingegebenen
-          Metadaten (wie die Angaben zum Urheberrecht) noch einmal
-          bearbeiten werden.
 
           ## Dateien wiederverwenden
 
@@ -1546,73 +1519,17 @@ de:
           "Dateien verwalten“ auf "Hinzufügen -> Wiederverwenden", um
           andere Beiträge nach Dateien zu durchsuchen und sie in den
           bearbeiteten Beitrag zu übernehmen.
+
+          ## Datei-Einstellungen bearbeiten
+
+          Für jede Datei kann über die Schaltfläche "Einstellungen
+          bearbeiten" ein Dialog mit weiteren Optionen angezeigt
+          werden. Hier können z.B. die beim Upload eingegebenen
+          Metadaten (wie die Angaben zum Urheberrecht) noch einmal
+          bearbeiten werden.
       meta_data:
         menu_item: Titel und Optionen
-        text: |
-          # Titel und Optionen
-
-          ## Allgemein
-
-          ### Titel des Pageflows
-
-          Hier kannst Du Deinem Pageflow einen Titel geben, der in der
-          Titelleiste des Browserfensters angezeigt wird. Unter diesem
-          Titel wird Dein Pageflow nach der Veröffentlichung auch in
-          Suchmaschinen indiziert werden.
-
-          ### Sprache
-
-          Wähle hier, in welcher Sprache Dein Pageflow ausgespielt
-          wird. Hierbei geht es um nicht editierbare Texte, wie
-          z.B. den Multimedia-Hinweis, Scroll-Hinweis, die Übersicht
-          und Impressum.
-
-          ### Impressum
-
-          Hier kannst Du Deine Impressums-Information im Freitext
-          eingeben.
-
-          ## Erscheinungsbild
-
-          ### Multimedia Hinweis vor dem Start
-
-          Entscheide, ob zu Beginn Deines Pageflows ein Hinweis angezeigt wird.
-
-          ### Kapitelanfang hervorheben
-
-          Mit dieser Option wird der Titel der jeweils ersten Seite
-          eines Kapitels größer dargestellt.
-
-          ## Neue Seiten hervorheben
-
-          Zeigt zum Start des Pageflows in einer Info-Box die seit dem
-          letzten Besuch neu erstellen Seiten an.
-
-          ### Home-Button anzeigen
-
-          Es gibt die Möglichkeit, in der Navigation einen Button
-          anzuzeigen, der auf eine externe Seite verlinkt, z.B. zurück
-          auf die Homepage, von der aus Du den Pageflow verlinkt hast.
-
-          ### Navigationsleiste
-
-          Wähle zwischen "Navigationsleiste mit Fortschrittsbalken“
-          oder "Navigationsleiste mit Thumbnails“. Beachte, dass bei
-          mobilen Endgeräten statt der Navigationsleiste aus
-          Platzgründen in beiden Fällen lediglich das Icon „Übersicht“
-          angezeigt wird.
-
-          ## Social
-
-          ### Social Sharing Bild
-
-          Wähle hier das Bild aus, das beim Teilen des Pageflows in
-          sozialen Netzwerken erscheinen soll.
-
-          ### Zusammenfassung
-
-          Trage hier ein, welcher Beschreibungstext beim Teilen in
-          sozialen Netzwerken angezeigt wird.
+        text: "# Titel und Optionen\n\n## Allgemein\n\n### Titel des Pageflows\n\nHier kannst Du Deinem Pageflow einen Titel geben, der in der\nTitelleiste des Browserfensters angezeigt wird. Unter diesem\nTitel wird Dein Pageflow nach der Veröffentlichung auch in\nSuchmaschinen indiziert werden.\n\n### Sprache\n\nWähle hier, in welcher Sprache Dein Pageflow ausgespielt wird. Hierbei geht es um die Frontend-Elemente wie z.B. Scroll-Hinweise, die Mouse-over-Texte der Navigation und das Impressum.\n\n### Credits\n\nHier kannst Du Deine Impressums-Information im Freitext eingeben. Zudem können für alle Dateien unter „Dateien verwalten“ auch Bildrechte vergeben werden, die dann automatisch im Impressum angezeigt werden.\n\n## Erscheinungsbild\n\n### Multimedia Hinweis vor dem Start\n\nEntscheide, ob zu Beginn Deines Pageflows ein Hinweis angezeigt wird.\n\n### Kapitelanfang hervorheben\n\nMit dieser Option wird der Titel der jeweils ersten Seite\neines Kapitels größer dargestellt.\n\n## Neue Seiten hervorheben\n\nZeigt zum Start des Pageflows in einer Info-Box die seit dem letzten Besuch neu erstellen Seiten an. Da für dieses Features Cookies verwendet werden, erscheint bei Aktivierung - gemäss der DSGVO - automatisch ein Cookie-Hinweis am unteren Bildrand.\n\n### Home-Button anzeigen\n\nEs gibt die Möglichkeit, in der Navigation einen Button\nanzuzeigen, der auf eine externe Seite verlinkt, z.B. zurück\nauf die Homepage, von der aus Du den Pageflow verlinkt hast.\n\n\n### Übersicht-Button anzeigen\n\nDer Übersichts-Button in der Navigationsleiste kann ausgeblendet werden.\n\n### Home-Button-URL\n\nGib hier den Link ein, auf den ein Klick auf den Home-Button führen soll. Falls die Ziel-URL für alle Beiträge Deines Kontos identisch ist, kann über „Einstellungen“ auch eine allgemeine „Redirect-URL“ festgelegt werden, die sich auf alle Beiträge auswirkt.\n\n### Steuerungsgesten\n\nMit dieser Option kann die Steuerung für mobile Endgeräte auf horizontales Scrollen umgestellt werden.\n\n### Lade-Ansicht\n\nWähle die Art der Lade-Ansicht Deines Beitrags. Alternativ zur klassischen Ansicht kann hier ein individueller Lade-Indikator mit eigenem Hintergrund-Bild, animierter Titel- und Untertitel-Zeile und skalierbarer Unschärfe konfiguriert werden.\n\n### Player Controls\n\nWähle das Erscheinungsbild der Steuerungs-Elemente für Audio- und Video-Player, 360° Panorama- und Vorher/Nachher-Seiten aus. \n\n### Navigationsleiste\n\nWähle zwischen unterschiedlichen Navigationsleisten. Beachte, dass bei mobilen Endgeräten statt der Navigationsleiste aus Platzgründen in lediglich das Icon „Übersicht“ angezeigt wird. \n\n### Cookie Hinweis\n\nSobald Google Analytics oder das Feature „Neue Seiten hervorheben“ aktiviert ist, wird beim ersten Besuch des Beitrags automatisch ein Datenschutz-Hinweis angezeigt. Falls ein Beitrag in eine eigene Webseite mit eigenem Datenschutz-Hinweis eingebettet wird, kann dieser Hinweis optional ausgeblendet werden.  \n\n### Theme\nLege ein Font-Template für den Beitrag fest. \n\n## Social\n\n### Social Sharing Bild\n\nWähle hier das Bild aus, das beim Teilen des Pageflows in\nsozialen Netzwerken erscheinen soll.\n\n### Zusammenfassung\n\nTrage hier ein, welcher Beschreibungstext beim Teilen in\nsozialen Netzwerken angezeigt wird.\n\n### Social Sharing URL\n\nWenn Beiträge in eigene Webseiten (mit abweichender URL) eingebettet werden  kann hier eine individuelle URL festgelegt werden, die beim Teilen des Beitrags verwendet werden soll. \n\n### Social Share Links\n\nBestimme, welche Share-Buttons beim Klick auf die „Share-Funktion“ angezeigt werden soll."
       outline:
         menu_item: Kapitel und Seiten
         text: |
@@ -1703,10 +1620,10 @@ de:
           in der linken Spalte.
       publishing:
         menu_item: Veröffentlichen
-        text: "# Veröffentlichen\n\nKlicke in der Gliederung auf die Schaltfläche\n„Veröffentlichen“ um Deinen Pageflow zu publizieren. Eine\nReportage kann entweder zeitlich unbegrenzt oder bis zu\neinem bestimmten Stichtag veröffentlicht\nwerden. \n\nAußerdem gibt es die Möglichkeit, Pageflows mit einem Passwort zu schützen. \nHierzu muss einfach das entsprechende Häkchen bei „Mit Passwort schützen\" gesetzt werden. \nDas System verwendet als Benutzernamen den Namen des Kontos und generiert ein Passwort, \nwelches auch manuell geändert werden kann. \n\nBeiträge, die bereits veröffentlicht sind, können nachträglich mit einem Passwort geschützt werden - \nund andersherum können auch geschützte Beiträge anschließend mit erneutem Klick auf „Veröffentlichen“ vom Passwortschutz befreit werden. \nBei der Veröffentlichung werden die auszuführenden Schritte im Dialogfenster angezeigt und erklärt.\n\nVeröffentlichte Pageflows können jederzeit manuell\ndepubliziert werden. Sollte eine Reportage bereits\nveröffentlicht sein, bleiben Änderungen solange öffentlich\nunsichtbar, bis die Reportage erneut veröffentlicht wird.\nEine Reportage kann stets nur von einem Redakteur zur\ngleichen Zeit bearbeitet werden.\n\nVorschaubild zum Einbetten in Externe Webseiten Nach der\nVeröffentlichung erstellt das System ein Vorschaubild, das\nals iframe zur Verlinkung in eine externe Seite eingebunden\nwerden kann.  Anhand des ausgespielten Codes lässt sich die\nGröße des iframes frei einstellen. Hierbei ist jedoch eine\nMindesthöhe von 150px und und eine Mindestbreite von 220px\nzu beachten."
+        text: "# Veröffentlichen\n\nKlicke in der Gliederung auf die Schaltfläche\n„Veröffentlichen“ um Deinen Pageflow zu publizieren. Eine\nReportage kann entweder zeitlich unbegrenzt oder bis zu\neinem bestimmten Stichtag veröffentlicht\nwerden. \n\n### Passwortschutz\n\nAußerdem gibt es die Möglichkeit, Pageflows mit einem Passwort zu schützen. \nHierzu muss einfach das entsprechende Häkchen bei „Mit Passwort schützen\" gesetzt werden. \nDas System verwendet als Benutzernamen den Namen des Kontos und generiert ein Passwort, \nwelches auch manuell geändert werden kann. \n\nBeiträge, die bereits veröffentlicht sind, können nachträglich mit einem Passwort geschützt werden - und andersherum können auch geschützte Beiträge anschließend mit erneutem Klick auf „Veröffentlichen“ vom Passwortschutz befreit werden. Bei der Veröffentlichung werden die auszuführenden Schritte im Dialogfenster angezeigt und erklärt.\n\n### Änderungen nach der Veröffentlichung\n\nVeröffentlichte Pageflows können jederzeit manuell depubliziert werden. Sollte eine Reportage bereits veröffentlicht sein, werden nachträgliche Änderungen erst öffentlich sichtbar, sobald die Reportage erneut veröffentlicht wird. \n\n\n### Einbettung als iframe\n\nVeröffentlichte Beiträge können auch in die eigene Webseite eingebettet werden. Weitere Informationen findest Du in diesem [Artikel](https://pageflow.freshdesk.com/support/solutions/articles/11000002742-wie-kann-ich-einen-beitrag-in-eine-webseite-einbetten)\n\n### Einbettung iframe-Teaser \n\nVorschaubild zum Einbetten in Externe Webseiten Nach der Veröffentlichung erstellt das System ein Vorschaubild, das als iframe zur Verlinkung in eine externe Seite eingebunden werden kann.  Anhand des ausgespielten Codes lässt sich die\nGröße des iframes frei einstellen. Hierbei ist jedoch eine Mindesthöhe von 150px und und eine Mindestbreite von 220px zu beachten."
       storylines:
         menu_item: Erzählstränge
-        text: "# Erzählstränge\n\nErgänzend zur linearen Erzählung von „oben nach unten“, können auch weitere (non-lineare) Erzählstränge als Exkurse zu vertiefenden Inhalten genutzt werden. Mit „Erzählstrang“ ist hier die zusammenhängende Kapitel- und Seitenabfolge gemeint, durch die ein User hindurch scrollt. Zu unterscheiden ist zwischen dem sogenannten Haupterzählstrang, in dem ein User zu Beginn eines Pageflows einsteigt, und weiteren untergeordneten Erzählsträngen. \n\nUm vom Haupterzählstrang einen Abzweig zu erstellen, benutze eine „Verweise“-Seite (Mosaik, Collage oder Hotspot) und lege auf der jeweiligen Seite unter „Verweise“ die entsprechenden Verknüpfungen an. \n\nDabei kann durch das Festlegen einer „übergeordneten Seite“ bestimmt werden, zu welcher Seite der User am Ende des Erzählstrangs  gelangt.\n\nOptisch unterstützt werden diese Exkurse in untergeordnete Erzählstränge durch einen horizontalen Seitenübergangseffekt, der beim Eintreten und Verlassen dieser Stränge automatisch eingestellt ist. \n\nErstellt werden diese Erzählstränge in der Gliederung über ein Klick auf die Plus-Schaltfläche neben der Erzählstrang-Auswahl. Dabei öffnet sich automatisch ein neues Kapitel, in dem dann weitere Seiten angelegt werden können.\n\n\n### Übergeordnete Seiten\n\nIn jedem Untererzählstrang muss eine „Übergeordnete Seite“ festgelegt werden, die bestimmt, wohin ein User beim zurück-scrollen gelangt. Mit einem Klick auf das Stift-Symbol neben der Erzählstrang-Auswahl kann diese Zielseite ausgewählt werden. Durch die Auswahl einer übergeordneten Seite erscheint auf allen Seiten eines untergeordneten Erzählstrangs zudem automatisch ein „Zurück“-Button, der zu der übergeordneten Seite führt. \n\n\n### Kapitel-Hierarchie\n\nDurch die Verwendung mehrerer „untergeordneter“ Erzählstränge und der Festlegung von übergeordneten Seiten ergibt sich eine Kapitelhierarchie, wie man sie auch von Buch-Gliederungen kennt:\n\n1. (Hauptstrang), 1.1 (Übergeordneter Unterstrang), 1.1.1 (vertiefende Seite im übergeordneten Unterstrang) und so weiter.\n\nDiese Hierarchie kann nachträglich in der Erzählstrang-Auswahl über ein Klick auf Stift-Symbol geändert werden. Ein untergeordneter Erzählstrang kann an dieser Stelle zudem auch nachträglich zum Haupt-Erzählstrang umsortiert werden.\n\n\n### Scroll-Nachfolger\n\nFalls der User von der letzten Seite eines Unterkapitels (1.1.1) auf eine andere Stelle im Beitrag geleitet werden soll (z.B. 2.1), kann hierzu ebenfalls über das Stiftsymbol in den Erzählstrang-Einstellungen der sogenannte „Scroll-Nachfolger“ festgelegt werden. Um in dem Beispiel zu bleiben wäre der folgende Ablauf denkbar: 1 -> 1.1 -> 1.1.1 -> 2.1\n\nAchtung: Während des Editierens wird immer nur das aktuell ausgewählte Kapitel angezeigt. Um zu den anderen Erzählsträngen zu gelangen klicke auf das Auswahlmenü „Erzählstrang“."
+        text: "# Erzählstränge\n\nErgänzend zur linearen Erzählung von „oben nach unten“, können auch weitere (non-lineare) Erzählstränge als Exkurse zu vertiefenden Inhalten genutzt werden. \n\nIn diesem [Blogartikel](https://www.pageflow.io/neues-pageflow-update) findest Du ein Beispiel.\n\nMit „Erzählstrang“ ist hier die zusammenhängende Kapitel- und Seitenabfolge gemeint, durch die ein User hindurch scrollt. Zu unterscheiden ist zwischen dem sogenannten Haupterzählstrang, in dem ein User zu Beginn eines Pageflows einsteigt, und weiteren untergeordneten Erzählsträngen. \n\nUm vom Haupterzählstrang einen Abzweig zu erstellen, benutze eine „Verweise“-Seite (Mosaik, Collage oder Hotspot) und lege auf der jeweiligen Seite unter „Verweise“ die entsprechenden Verknüpfungen an. \n\nDabei kann durch das Festlegen einer „übergeordneten Seite“ bestimmt werden, zu welcher Seite der User am Ende des Erzählstrangs  gelangt.\n\nOptisch unterstützt werden diese Exkurse in untergeordnete Erzählstränge durch einen horizontalen Seitenübergangseffekt, der beim Eintreten und Verlassen dieser Stränge automatisch eingestellt ist. \n\nErstellt werden diese Erzählstränge in der Gliederung über ein Klick auf die Plus-Schaltfläche neben der Erzählstrang-Auswahl. Dabei öffnet sich automatisch ein neues Kapitel, in dem dann weitere Seiten angelegt werden können.\n\n\n### Übergeordnete Seiten\n\nIn jedem Untererzählstrang muss eine „Übergeordnete Seite“ festgelegt werden, die bestimmt, wohin ein User beim zurück-scrollen gelangt. Mit einem Klick auf das Stift-Symbol neben der Erzählstrang-Auswahl kann diese Zielseite ausgewählt werden. Durch die Auswahl einer übergeordneten Seite erscheint auf allen Seiten eines untergeordneten Erzählstrangs zudem automatisch ein „Zurück“-Button, der zu der übergeordneten Seite führt. \n\n\n### Kapitel-Hierarchie\n\nDurch die Verwendung mehrerer „untergeordneter“ Erzählstränge und der Festlegung von übergeordneten Seiten ergibt sich eine Kapitelhierarchie, wie man sie auch von Buch-Gliederungen kennt:\n\n1. (Hauptstrang), 1.1 (Übergeordneter Unterstrang), 1.1.1 (vertiefende Seite im übergeordneten Unterstrang) und so weiter.\n\nDiese Hierarchie kann nachträglich in der Erzählstrang-Auswahl über ein Klick auf Stift-Symbol geändert werden. Ein untergeordneter Erzählstrang kann an dieser Stelle zudem auch nachträglich zum Haupt-Erzählstrang umsortiert werden.\n\n\n### Scroll-Nachfolger\n\nFalls der User von der letzten Seite eines Unterkapitels (1.1.1) auf eine andere Stelle im Beitrag geleitet werden soll (z.B. 2.1), kann hierzu ebenfalls über das Stiftsymbol in den Erzählstrang-Einstellungen der sogenannte „Scroll-Nachfolger“ festgelegt werden. Um in dem Beispiel zu bleiben wäre der folgende Ablauf denkbar: 1 -> 1.1 -> 1.1.1 -> 2.1\n\nAchtung: Während des Editierens wird immer nur das aktuell ausgewählte Kapitel angezeigt. Um zu den anderen Erzählsträngen zu gelangen klicke auf das Auswahlmenü „Erzählstrang“."
       text_tracks:
         menu_item: Textspuren
         text: |-
@@ -1961,7 +1878,7 @@ de:
       help_entries:
         page_type:
           menu_item: Video
-          text: "# Video\n\n*Wiedergabe einer Videodatei mit Steuerelementen* \n   \nAnders als bei „Hintergrund-Videos“ werden hier Textelemente nach ein\npaar Sekunden automatisch ausgeblendet, um die\nAufmerksamkeit auf das Bewegtbild zu lenken. Mit\nSteuerelementen kann der Nutzer das Video jederzeit\nstarten und pausieren, vor- oder zurückspulen. Ein\nweiterer Unterschied ist, dass Du wählen kannst, ob ein\nVideo automatisch gestartet wird, sobald die Seite\nangezeigt wird.  Als dezente Alternative oder Ergänzung zu\nden normalen Texteingabemöglichkeiten, kann eine\nsogenannte „Infobox“ mit Text befüllt werden.\n\nUnter Optionen lässt sich ein automatisches weiterscrollen am Ende des Videos aktivieren. \nDas kann nützlich sein, um einen nahtlosen Übergang zur nächsten Seite herzustellen.\n\nTypische Anwendungsbeispiele: Filme aller Art, Interviews,\nPortrait"
+          text: "# Video\n\n*Wiedergabe einer Videodatei mit Steuerelementen* \n   \nAnders als bei „Hintergrund-Videos“ werden hier Textelemente nach ein\npaar Sekunden automatisch ausgeblendet, um die\nAufmerksamkeit auf das Bewegtbild zu lenken. Mit\nSteuerelementen kann der Nutzer das Video jederzeit\nstarten und pausieren, vor- oder zurückspulen. Ein\nweiterer Unterschied ist, dass Du wählen kannst, ob ein\nVideo automatisch* gestartet wird, sobald die Seite\nangezeigt wird.  Als dezente Alternative oder Ergänzung zu\nden normalen Texteingabemöglichkeiten, kann eine\nsogenannte „Infobox“ mit Text befüllt werden.\n\nUnter Optionen lässt sich ein automatisches Weiterscrollen am Ende des Videos aktivieren. \nDas kann nützlich sein, um einen nahtlosen Übergang zur nächsten Seite herzustellen.\n\nTypische Anwendungsbeispiele: Filme aller Art, Interviews,\nPortrait\n\n*Hinweis zum Autoplay bei Videos: Aufgrund technischer Einschränkungen, basierend auf der „Autoplay Policy“ der Browser-Hersteller, können Videos mit Ton nicht auf allem Geräten/Browsern automatisch abgespielt werden. Bei Safari  und auf mobilen Geräten können Videos nur manuell gestartet werden. "
       page_attributes:
         mobile_poster_image_id:
           inline_help: Wird in der Mobilvariante gezeigt, bevor das Video startet.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -484,7 +484,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -510,7 +510,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -948,7 +948,7 @@ en:
       help_entries:
         page_type:
           menu_item: Audio
-          text: "# Audio\n\n*Playing audio-files with controls*\n    \nHere you can combine audio-files with pictures or background videos and\ntext-content. Controls similar to the page type „Video“\nare shown.  In addition to that you can write a\ndescription into an „Infobox“.\n\nExamples of application: interviews, direct quotes, music"
+          text: "# Audio\n\n*Playing audio-files with controls*\n    \nHere you can combine audio-files with pictures or background videos and\ntext-content. Controls similar to the page type \"Video“\nare shown.  In addition to that you can write a\ndescription into an „Infobox“.\n\nVia \"Options\" the appearance of the player can be changed to the visualization of the waveform of an audio file.\n\nExamples of application: interviews, direct quotes, music"
       open: Play audio
       page_attributes:
         audio_player_controls_variant:
@@ -969,25 +969,7 @@ en:
       help_entries:
         page_type:
           menu_item: Background Image/Video
-          text: |-
-            # Background Image/Video
-
-            Full-screen image or video loop and text
-
-            By using the page type „Background-Image/Video“, large pictures
-            or video loops are the background for the text and are paired with a
-            manually adjustable color gradient for an optimal
-            legibility. In order to have an optimal presentation on
-            mobile devices you can adjust the image detail to the
-            display. Optionally the text color can be inverted. This
-            is especially useful for bright background-images.
-
-            Users are able to hide the color-gradient and text in
-            the front-end, if they want to have a view of the
-            background image or video.
-
-            Examples: Presentation, part of a picture gallery,
-            portrait
+          text: "# Background Image/Video\n\n*Full-screen image or video loop and text*\n\nBy using the page type „Background-Image/Video“, large pictures\nor video loops are the background for the text and are paired with a\nmanually adjustable color gradient for an optimal\nlegibility. By adjusting the image section, you can ensure that your picture also shows the relevant section of your subject on mobile devices in portrait mode. \n\nOptionally the text color can be inverted. This\nis especially useful for bright background-images.\n\nUsers are able to hide the color-gradient and text in\nthe front-end, if they want to have a view of the\nbackground image or video.\n\nExamples: Presentation, part of a picture gallery,\nportrait\n\n**Note on sound for background video**: Due to technical restrictions based on the \"Autoplay Policy\" of the browser manufacturers, videos with sound cannot be played automatically on all devices/browsers. \n\nTo enable playback of video loops on mobile devices and in Safari on desktop and tablets, the sound is therefore suppressed. With Chrome this restriction is circumvented by a Unmute button, with Firefox users decide for themselves whether to allow automatic playback of audio."
       page_type_category_name: Basic
       page_type_description: Fullscreen image or video loop with text
       page_type_name: Background image/video
@@ -1484,10 +1466,10 @@ en:
 
           Should you ever feel distracted by the atmo audio while working on your story, you can use the hot key „Alt + a“ to temporarily mute it. Simply press „Alt + a“ again to reactivate atmo audio.
 
-          CAUTION: Atmo audio does not play on mobile devices.
+          **CAUTION:** Due to technical restrictions imposed by the browser manufacturers, ambient audio cannot be played on mobile devices and with Safari on the desktop.
       files:
         menu_item: Manage Files
-        text: |
+        text: |-
           # Manage Files
 
           Pageflow processes all major media formats (photo, audio,
@@ -1518,13 +1500,6 @@ en:
           finished. You can therefore continue your work during the
           loading process.
 
-          ## Copyrights of Files
-
-          If you click on the thumbnail of a media file (picture,
-          video, audio), you can add information with regards to its
-          copyright. This information is shown automatically in the
-          legal notice.
-
           ## Reuse Files
 
           Videos, audio files and pictures can be used in more than
@@ -1532,68 +1507,16 @@ en:
           uploaded several times. Click on „Manage Files“ and on
           „Add“/„Reuse“, to search for files in other articles and add
           them to a new one.
+
+          ## Edit File Settings and Copyright
+
+          If you click on the thumbnail of a media file (picture,
+          video, audio), you can add information with regards to its
+          copyright. This information is shown automatically in the
+          legal notice.
       meta_data:
         menu_item: Title and Options
-        text: |
-          # Title and Options
-
-          ## General
-
-          ### Title of the Pageflow
-
-          Here you can choose a title for your Pageflow. It will be
-          shown on the title bar of the browser window. It also acts
-          as an indicator for search engines once the report is
-          published.
-
-          ### Language
-
-          Decide in which language your Pageflow should be
-          displayed. This refers to text which cannot be edited - like
-          multimedia tips, scroll-indicators, the overview and the
-          legal notice.
-
-          ## Appearance
-
-          ### Multimedia tips before the start
-
-          Decide if tips or advice should be shown at the beginning of
-          your Pageflow.
-
-          ### Highlighting chapter beginnings
-
-          This option lets the title of the first page of a chapter
-          appear in a bigger font.
-
-          ### Highlighting new pages
-
-          At the beginning of a Pageflow an info-box shows new pages
-          that were created since the last visit.
-
-          ### Display Home-Button
-
-          You can have a button in the navigation, which hyperlinks to
-          an external website, for example back to the website from
-          which you hyperlinked to the Pageflow.
-
-          ### Navigation
-
-          Choose between two forms of navigation: The navigation with
-          a progress bar or the navigation with thumbnails. Please
-          note, that due to the lack of space on mobile devices only
-          the icon „Overview“ is shown.
-
-          ## Social
-
-          ### Social Sharing Picture
-
-          Choose a picture, which should be shown, if your Pageflow is
-          shared in social networks.
-
-          ### Summary
-
-          Here you can write a description, which is shown, when your
-          Pageflow is shared in social networks.
+        text: "# Title and Options\n\n## General\n\n### Title of the Pageflow\n\nHere you can choose a title for your Pageflow. It will be\nshown on the title bar of the browser window. It also acts\nas an indicator for search engines once the report is\npublished.\n\n### Language\n\nDecide in which language your Pageflow should be displayed. This refers to the frontend text such as multimedia tips, scroll-indicators, the overview and the legal notice.\n\n\n### Credits\nHere you can enter your imprint information in free text. In addition, image rights can be assigned for all files under \"Manage files\", which are then automatically displayed in the imprint.\n\n\n## Appearance\n\n### Multimedia tips before the start\n\nDecide if tips or advice should be shown at the beginning of\nyour Pageflow.\n\n### Highlighting chapter beginnings\n\nThis option lets the title of the first page of a chapter\nappear in a bigger font.\n\n### Highlighting new pages\n\nAt the beginning of a Pageflow an info-box shows new pages that were created since the last visit. Since cookies are used for this feature, a cookie notice appears automatically at the bottom of the screen when activated - in accordance with the GDPR.\n\n### Display Home-Button\n\nYou can have a button in the navigation, which hyperlinks to an external website, for example back to the website from which you hyperlinked to the Pageflow.\n\n\n### Show overview button\n\nThe overview button in the navigation bar can be hidden.\n\n### Home button URL\n\nEnter the link here to which a click on the Home button should lead. If the target URL is the same for all entries in your account, you can also set a general \"redirect URL\" via \"Settings\", which will affect all entries.\n\n### Control gestures\n\nWith this option the control for mobile devices can be switched to horizontal scrolling.\n\n### Loading view\n\nSelect the type of loading view of your entry. As an alternative to the classic view, an individual load indicator with its own background image, animated title and subtitle line and scalable blur can be configured here.\n\n### Player Controls\n\nSelect the appearance of the control elements for audio and video players, 360° panorama and before/after pages.\n\n### Navigation bar\n\nChoose between navigation bars. Please note, that due to the lack of space on mobile devices only the icon „Overview“ is shown.\n\n### Cookie notice\nAs soon as Google Analytics or the \"Highlight new pages\" feature is activated, a privacy notice is automatically displayed the first time the entry is visited. If an entry is embedded in a separate website with its own privacy notice, this notice can be optionally hidden.  \n\n\n### Theme\n\nSpecify a font template for the entry. \n\n\n## Social\n\n### Social Sharing Picture\n\nChoose a picture, which should be shown, if your Pageflow is\nshared in social networks.\n\n### Summary\n\nHere you can write a description, which is shown, when your\nPageflow is shared in social networks.\n\n### Social Sharing URL\n\nIf contributions are embedded in your own web pages (with a different URL), you can specify an individual URL here that is to be used when sharing the contribution. \n\n### Social Share Links\n\nDetermine which share buttons should be displayed when clicking on the \"Share function\". "
       outline:
         menu_item: Chapters and Pages
         text: |-
@@ -1676,10 +1599,10 @@ en:
           click on a page type on the left column.
       publishing:
         menu_item: Publishing
-        text: "# Publishing\n\nClick on the „Publish“ button to publish your Pageflow. A\nPageflow can be published at any point in time. \n\nBesides this, there is the possibility to publish Pageflows with \na password protection. Just activate „Protect with password“. \nPageflow uses the name of the account as user name and \nautomatically generates a password, which can be changed afterwords. \n\nAlready published stories can also be protected with a password by \npublishing another version - the other way round works as well. \nFor this please just click on the „Publishing“ button. The following \nsteps will then be shown and explained within the dialog window.\n\nPublished\nPageflows can also be depublished manually at any time. If a\nPageflow has already been published, changes will not be\nshown until you publish your report again.  A Pageflow can\nonly be edited by one author at one time.\n\nThumbnail for embedding the Pageflow on external websites\nAfter publishing your Pageflow, the system generates a\nthumbnail, which can be embedded as an iframe to the\nhyperlink of another website. By means of the code, the size\nof the iframe can be adjusted. The minimum size is a height\n150px and a width of 220px."
+        text: "# Publishing\n\nClick on the „Publish“ button to publish your Pageflow. An entry can either be published for an unlimited period of time or until a specific deadline.\n\nBesides this, there is the possibility to publish Pageflows with \na password protection. Just activate „Protect with password“. \nPageflow uses the name of the account as user name and \nautomatically generates a password, which can be changed afterwords. \n\nAlready published stories can also be protected with a password by \npublishing another version - the other way round works as well. \nFor this please just click on the „Publishing“ button. The following \nsteps will then be shown and explained within the dialog window.\n\n### Changes After Publishing\nPublished Pageflows can also be depublished manually at any time. If a\nPageflow has already been published, changes will not be\nshown until you publish your report again.  A Pageflow can\nonly be edited by one author at one time.\n\n### Embedding as iframe\nPublished articles can also be embedded in your own website. You can find more information in this [article](https://pageflow.freshdesk.com/support/solutions/articles/11000002744)  \n\n### Embedding iframe Teaser\nThumbnail for embedding the Pageflow on external websites\nAfter publishing your Pageflow, the system generates a\nthumbnail, which can be embedded as an iframe to the\nhyperlink of another website. By means of the code, the size of the iframe can be adjusted. The minimum size is a height 150px and a width of 220px."
       storylines:
         menu_item: Storylines
-        text: "# Storylines\n\nIn addition to linear narrations from top to bottom, further storylines can be used as non linear excursions to enlarge upon parts of a story. A „Storyline“ consists of chapters and pages, which users scroll through. Distinguishable is the so called main storyline from further subordinate ones. The user starts off in the main storyline and can then navigate to different excursions.\n\nTo create such an excursion from the main storyline use one of the „Link“ pages (Mosaic, Collage, Hotspot) and create the desired connections via „Links“.\n\nBy choosing a „Parent page“ you can determine to which page users return after scrolling the storyline´s last page.\n\nTransitions to subordinate storylines are visually supported by a horizontal animation as the default setting for entering and leaving. \n\nStorylines are created by clicking onto the plus button next to the storyline menu. Thereby a new chapter opens automatically in which further pages can be added. \n\n\n### Parent pages\n\nIn every subordinate  storyline a „Parent page“ must be determined to define where users land when scrolling back.\n\nThis target page can be chosen by clicking on the pen symbol next to the storyline menu. When a „Parent page“ is defined, a back button will be shown automatically in the subordinate storyline that will always lead users back to the „Parent page“.\n\n\n### Chapter hierarchy\n\nThe use of more than one „subordinary“ storylines and the definition of „Parent pages“ leads to a chapter hierarchy as known from books:\n\n1. (Main storyline), 1.1. (Superior sub storyline), 1.1.1. (Subordinate sub storyline) and so on.\n\nThis hierarchy can be edited afterwards by clicking on the pen symbol next to the storyline menu. A subordinate storyline can be turned into the main storyline as well.\n\n\n### Scroll successors\n\nIf you want to lead users from a last page of a subordinate chapter (1.1.1) to another position than\nthe „Parent page“ (e.g. to 2.1) you can define a „Scroll successor“. Therefore click on the blue pen symbol within the storyline settings. As an example the following sequence might be imaginable: 1 -> 1.1 -> 1.1.1 -> 2.1\n\nAttention: While editing only the selected chapter will be shown in the sidebar. To switch to the other chapters click onto the storyline menu."
+        text: "# Storylines\n\nIn addition to linear narrations from top to bottom, further storylines can be used as non linear excursions to enlarge upon parts of an  entry.\n\nPlease find a blog article and example [here](https://www.pageflow.io/en/update-storylines)\n\nA „Storyline“ consists of chapters and pages, which users scroll through. Distinguishable is the so called main storyline from further subordinate ones. The user starts off in the main storyline and can then navigate to different excursions.\n\nTo create such an excursion from the main storyline use one of the „Link“ pages (Mosaic, Collage, Hotspot) and create the desired connections via „Links“.\n\nBy choosing a „Parent page“ you can determine to which page users return after scrolling the storyline´s last page.\n\nTransitions to subordinate storylines are visually supported by a horizontal animation as the default setting for entering and leaving. \n\nStorylines are created by clicking onto the plus button next to the storyline menu. Thereby a new chapter opens automatically in which further pages can be added. \n\n\n### Parent pages\n\nIn every subordinate  storyline a „Parent page“ must be determined to define where users land when scrolling back.\n\nThis target page can be chosen by clicking on the pen symbol next to the storyline menu. When a „Parent page“ is defined, a back button will be shown automatically in the subordinate storyline that will always lead users back to the „Parent page“.\n\n\n### Chapter hierarchy\n\nThe use of more than one „subordinary“ storylines and the definition of „Parent pages“ leads to a chapter hierarchy as known from books:\n\n1. (Main storyline), 1.1. (Superior sub storyline), 1.1.1. (Subordinate sub storyline) and so on.\n\nThis hierarchy can be edited afterwards by clicking on the pen symbol next to the storyline menu. A subordinate storyline can be turned into the main storyline as well.\n\n\n### Scroll successors\n\nIf you want to lead users from a last page of a subordinate chapter (1.1.1) to another position than\nthe „Parent page“ (e.g. to 2.1) you can define a „Scroll successor“. Therefore click on the blue pen symbol within the storyline settings. As an example the following sequence might be imaginable: 1 -> 1.1 -> 1.1.1 -> 2.1\n\nAttention: While editing only the selected chapter will be shown in the sidebar. To switch to the other chapters click onto the storyline menu."
       text_tracks:
         menu_item: Text tracks
         text: |-
@@ -1936,7 +1859,7 @@ en:
       help_entries:
         page_type:
           menu_item: Video
-          text: "# Video\n\n*Playing a video with control*\n    \nIn contrast to „Background-Videos“ the text elements fade\nout after a few seconds, in order to draw attention to the\nvideo. With controls the user can start and pause the\nvideo or even fast-forward and rewind it. You can choose\nwhether the video should start automatically as soon as\nthe page is opened.\n\nAs an alternative to the normal text input, you can write\na description into an „Infobox“ with text.\n\nOn the „Options“ tab you can activate auto-scrolling to the next page at the end of a video. \nThis can be useful to create a seamless transition.\n\nExamples of application: Videos of all kinds, interviews,\nportraits"
+          text: "# Video\n\n*Playing a video with control*\n    \nIn contrast to „Background-Videos“ the text elements fade\nout after a few seconds, in order to draw attention to the\nvideo. With controls the user can start and pause the\nvideo or even fast-forward and rewind it. You can choose\nwhether the video should start automatically as soon as\nthe page is opened.\n\nAs an alternative to the normal text input, you can write\na description into an „Infobox“ with text.\n\nOn the „Options“ tab you can activate auto-scrolling to the next page at the end of a video. \nThis can be useful to create a seamless transition.\n\nExamples of application: Videos of all kinds, interviews, portraits\n\n*Note on autoplay for videos: Due to technical restrictions, based on the \"Autoplay Policy\" of the browser manufacturers, videos with sound cannot be played automatically on all devices/browsers. On Safari and mobile devices, videos can only be started manually."
       page_attributes:
         mobile_poster_image_id:
           inline_help: Displayed on mobile devices before the video starts.

--- a/config/locales/new/help.de.yml
+++ b/config/locales/new/help.de.yml
@@ -1,0 +1,66 @@
+de:
+  pageflow:
+    help_entries:
+      overview: DELETED
+      page_options: DELETED
+      atmo: DELETED
+      storylines: DELETED
+
+      meta_data:
+        menu_item: Titel und Optionen
+        text: |
+          # Titel und Optionen
+
+          Allgemeine Einstellungen für den Beitrag. Bitte einen
+          Unterpunkt auf der linken Seite auswählen.
+        general:
+          menu_item: Allgemein
+          text: |
+            # Allgemein
+
+            ## Titel des Pageflows
+
+            Hier kannst Du Deinem Pageflow einen Titel geben, der in der
+            Titelleiste des Browserfensters angezeigt wird. Unter diesem
+            Titel wird Dein Pageflow nach der Veröffentlichung auch in
+            Suchmaschinen indiziert werden.
+
+            ## Sprache
+
+            Wähle hier, in welcher Sprache Dein Pageflow ausgespielt
+            wird. Hierbei geht es um die Frontend-Elemente wie
+            z.B. Scroll-Hinweise, die Mouse-over-Texte der Navigation
+            und das Impressum.
+
+            ## Credits
+
+            Hier kannst Du Deine Impressums-Information im Freitext
+            eingeben. Zudem können für alle Dateien unter „Dateien
+            verwalten“ auch Bildrechte vergeben werden, die dann
+            automatisch im Impressum angezeigt werden.
+        social:
+          menu_item: Social
+          text: |
+            # Social
+
+            ## Social Sharing Bild
+
+            Wähle hier das Bild aus, das beim Teilen des Pageflows in
+            sozialen Netzwerken erscheinen soll.
+
+            ## Zusammenfassung
+
+            Trage hier ein, welcher Beschreibungstext beim Teilen in
+            sozialen Netzwerken angezeigt wird.
+
+            ## Social Sharing URL
+
+            Wenn Beiträge in eigene Webseiten (mit abweichender URL)
+            eingebettet werden kann hier eine individuelle URL
+            festgelegt werden, die beim Teilen des Beitrags verwendet
+            werden soll.
+
+            ## Social Share Links
+
+            Bestimme, welche Share-Buttons beim Klick auf die
+            „Share-Funktion“ angezeigt werden soll.

--- a/config/locales/new/help.en.yml
+++ b/config/locales/new/help.en.yml
@@ -1,0 +1,57 @@
+en:
+  pageflow:
+    help_entries:
+      overview: DELETED
+      page_options: DELETED
+      atmo: DELETED
+      storylines: DELETED
+
+      meta_data:
+        menu_item: Titel and Optionen
+        text: |
+          # Title and Options
+
+          General settings for the entry. Please select a sub item on the left.
+        general:
+          menu_item: General
+          text: |
+            # General
+
+            ## Title of the Pageflow
+
+            Here you can choose a title for your Pageflow. It will be
+            shown on the title bar of the browser window. It also acts
+            as an indicator for search engines once the report is
+            published.
+
+            ## Language
+
+            Decide in which language your Pageflow should be displayed. This refers to the frontend text such as multimedia tips, scroll-indicators, the overview and the legal notice.
+
+            ## Credits
+            Here you can enter your imprint information in free text. In addition, image rights can be assigned for all files under "Manage files", which are then automatically displayed in the imprint.
+        social:
+          menu_item: Social
+          text: |
+            # Social
+
+            ## Social Sharing Picture
+
+            Choose a picture, which should be shown, if your Pageflow is
+            shared in social networks.
+
+            ## Summary
+
+            Here you can write a description, which is shown, when your
+            Pageflow is shared in social networks.
+
+            ## Social Sharing URL
+
+            If contributions are embedded in your own web pages (with
+            a different URL), you can specify an individual URL here
+            that is to be used when sharing the contribution.
+
+            ## Social Share Links
+
+            Determine which share buttons should be displayed when
+            clicking on the "Share function".

--- a/entry_types/paged/config/initializers/features.rb
+++ b/entry_types/paged/config/initializers/features.rb
@@ -4,7 +4,7 @@ Pageflow.configure do |config|
     entry_type_config.features.register('delayed_text_fade_in')
 
     entry_type_config.features.register('storylines') do |feature_config|
-      feature_config.help_entries.register('pageflow.help_entries.storylines', priority: 7)
+      feature_config.help_entries.register('pageflow_paged.help_entries.storylines', priority: 7)
     end
 
     entry_type_config.features.register('editor_emulation_mode')

--- a/entry_types/paged/config/initializers/help_entries.rb
+++ b/entry_types/paged/config/initializers/help_entries.rb
@@ -1,0 +1,17 @@
+Pageflow.configure do |c|
+  c.for_entry_type(PageflowPaged.entry_type) do |config|
+    config.help_entries.register('pageflow_paged.help_entries.overview', priority: 100)
+
+    config.help_entries.register('pageflow_paged.help_entries.meta_data', priority: 50)
+    config.help_entries.register('pageflow.help_entries.meta_data.general',
+                                 priority: 100, parent: 'pageflow_paged.help_entries.meta_data')
+    config.help_entries.register('pageflow_paged.help_entries.meta_data.appearance',
+                                 priority: 75, parent: 'pageflow_paged.help_entries.meta_data')
+    config.help_entries.register('pageflow.help_entries.meta_data.social',
+                                 priority: 50, parent: 'pageflow_paged.help_entries.meta_data')
+
+    config.help_entries.register('pageflow_paged.help_entries.outline', priority: 30)
+    config.help_entries.register('pageflow_paged.help_entries.page_options', priority: 20)
+    config.help_entries.register('pageflow_paged.help_entries.atmo', priority: 7)
+  end
+end

--- a/entry_types/paged/config/locales/new/help.de.yml
+++ b/entry_types/paged/config/locales/new/help.de.yml
@@ -1,0 +1,162 @@
+de:
+  pageflow_paged:
+    help_entries:
+      overview:
+        menu_item: Übersicht
+        text: |
+          # Übersicht
+
+          Dies ist der Editor zum Bearbeiten eines Pageflows. Mit
+          seiner Zweiteilung ermöglicht er die direkte Vorschau
+          während der Bearbeitung, zeigt Änderungen am Text oder neu
+          ausgewählte Dateien unmittelbar an und speichert diese
+          automatisch.
+
+          Die Seitenleiste kann durch einen Klick auf den Anfasser zur
+          Größenänderung ein- und ausgeblendet werden. Mit einem
+          Verschieben der Seitenleiste nach links und rechts kannst Du
+          die Größe des Vorschaufensters verändern. Wird das
+          Vorschaufenster schmal, und somit eher zu einem hochkantigen
+          Mobiltelefon-Format gestaucht, wird aus Platzgründen statt
+          der Navigationsleiste nur das Icon „Übersicht“ angezeigt.
+
+          Die Navigation des Editors ist unterteilt in die vier
+          Bereiche:
+
+          ## Titel und Optionen
+
+          Unter „Titel und Optionen“ kannst Du grundsätzliche
+          Parameter des Erscheinungsbildes, sowie Titel, Sprache,
+          Impressum etc. einstellen. Dazu können Texte festgelegt
+          werden, die beim Teilen des Beitrags über Social Media
+          Dienste angezeigt werden sollen.
+
+          Details findest Du unter: [Titel und Optionen](#pageflow_paged.help_entries.meta_data)
+
+          ## Dateien verwalten
+
+          Unter „Dateien verwalten“ lädst Du die Mediendateien hoch,
+          die im Pageflow verwendet werden sollen. Du kannst hier auch
+          bereits hochgeladene Videos, Fotos und Audios
+          wiederverwenden.
+
+          Details findest Du unter: [Dateien verwalten](#pageflow.help_entries.files)
+
+          ## Gliederung
+
+          Über die „Gliederung“ kannst Du Kapitel und Seiten
+          hinzufügen, also die eigentlichen Inhalte bearbeiten. Per
+          Drag&Drop lassen sich Seiten und Kapitel auch jederzeit
+          umsortieren.
+
+          Details findest Du unter: [Kapitel und Seiten](#pageflow_paged.help_entries.outline)
+      meta_data:
+        menu_item: Titel und Optionen
+        text: |
+          # Titel und Optionen
+
+          Allgemeine Einstellungen für den Beitrag. Bitte einen
+          Unterpunkt auf der linken Seite auswählen.
+        appearance:
+          menu_item: Erscheinungsbild
+          text: |
+            # Erscheinungsbild
+
+            ## Multimedia Hinweis vor dem Start
+
+            Entscheide, ob zu Beginn Deines Pageflows ein Hinweis angezeigt wird.
+
+            ## Kapitelanfang hervorheben
+
+            Mit dieser Option wird der Titel der jeweils ersten Seite
+            eines Kapitels größer dargestellt.
+
+            ## Neue Seiten hervorheben
+
+            Zeigt zum Start des Pageflows in einer Info-Box die seit dem letzten Besuch neu erstellen Seiten an. Da für dieses Features Cookies verwendet werden, erscheint bei Aktivierung - gemäss der DSGVO - automatisch ein Cookie-Hinweis am unteren Bildrand.
+
+            ## Home-Button anzeigen
+
+            Es gibt die Möglichkeit, in der Navigation einen Button
+            anzuzeigen, der auf eine externe Seite verlinkt, z.B. zurück
+            auf die Homepage, von der aus Du den Pageflow verlinkt hast.
+
+            ## Übersicht-Button anzeigen
+
+            Der Übersichts-Button in der Navigationsleiste kann ausgeblendet werden.
+
+            ## Home-Button-URL
+
+            Gib hier den Link ein, auf den ein Klick auf den Home-Button führen soll. Falls die Ziel-URL für alle Beiträge Deines Kontos identisch ist, kann über „Einstellungen“ auch eine allgemeine „Redirect-URL“ festgelegt werden, die sich auf alle Beiträge auswirkt.
+
+            ## Steuerungsgesten
+
+            Mit dieser Option kann die Steuerung für mobile Endgeräte auf horizontales Scrollen umgestellt werden.
+
+            ## Lade-Ansicht
+
+            Wähle die Art der Lade-Ansicht Deines Beitrags. Alternativ zur klassischen Ansicht kann hier ein individueller Lade-Indikator mit eigenem Hintergrund-Bild, animierter Titel- und Untertitel-Zeile und skalierbarer Unschärfe konfiguriert werden.
+
+            ## Player Controls
+
+            Wähle das Erscheinungsbild der Steuerungs-Elemente für Audio- und Video-Player, 360° Panorama- und Vorher/Nachher-Seiten aus.
+
+            ## Navigationsleiste
+
+            Wähle zwischen unterschiedlichen Navigationsleisten. Beachte, dass bei mobilen Endgeräten statt der Navigationsleiste aus Platzgründen in lediglich das Icon „Übersicht“ angezeigt wird.
+
+            ## Cookie Hinweis
+
+            Sobald Google Analytics oder das Feature „Neue Seiten hervorheben“ aktiviert ist, wird beim ersten Besuch des Beitrags automatisch ein Datenschutz-Hinweis angezeigt. Falls ein Beitrag in eine eigene Webseite mit eigenem Datenschutz-Hinweis eingebettet wird, kann dieser Hinweis optional ausgeblendet werden.
+
+            ## Theme
+            Lege ein Font-Template für den Beitrag fest.
+      outline:
+        menu_item: Kapitel und Seiten
+        text: |
+          # Kapitel und Seiten
+
+          Ein Pageflow besteht aus mindestens einem Kapitel mit
+          mindestens einer Seite. Es können beliebig viele Kapitel mit
+          beliebig vielen Seiten erstellt werden. Um Inhalte zu
+          erstellen, klicke
+
+          1. auf Neues Kaptitel, um ein erstes Kapitel zu erstellen
+          2. auf Neue Seite, um dem Kapitel eine Seite hinzuzufügen, und
+          3. auf diese Seite, um den Inhalt zu bearbeiten.
+
+          ## Aufbau eines Kapitels
+
+          Mit den „Kapiteln" strukturierst Du den Aufbau Deiner
+          Reportage - beispielsweise nach Themenschwerpunkten oder
+          Zeiträumen. Die Kapitel werden in der „Übersicht“ angezeigt
+          und dienen dem User als Orientierungshilfe. Deshalb ist es
+          ratsam die jeweiligen Kapitel mit Titeln zu versehen.
+
+          Wenn nur ein unbenanntes Kapitel angelegt wird, so verhält
+          sich Pageflow, als ob keine Kapitelstruktur vorhanden
+          ist. (Kapitel und Kapiteltitel werden in diesem Falle nicht
+          in der Übersicht bzw. Navigation dargestellt).
+
+      storylines:
+        menu_item: Erzählstränge
+        text: "# Erzählstränge\n\nErgänzend zur linearen Erzählung von „oben nach unten“, können auch weitere (non-lineare) Erzählstränge als Exkurse zu vertiefenden Inhalten genutzt werden. \n\nIn diesem [Blogartikel](https://www.pageflow.io/neues-pageflow-update) findest Du ein Beispiel.\n\nMit „Erzählstrang“ ist hier die zusammenhängende Kapitel- und Seitenabfolge gemeint, durch die ein User hindurch scrollt. Zu unterscheiden ist zwischen dem sogenannten Haupterzählstrang, in dem ein User zu Beginn eines Pageflows einsteigt, und weiteren untergeordneten Erzählsträngen. \n\nUm vom Haupterzählstrang einen Abzweig zu erstellen, benutze eine „Verweise“-Seite (Mosaik, Collage oder Hotspot) und lege auf der jeweiligen Seite unter „Verweise“ die entsprechenden Verknüpfungen an. \n\nDabei kann durch das Festlegen einer „übergeordneten Seite“ bestimmt werden, zu welcher Seite der User am Ende des Erzählstrangs  gelangt.\n\nOptisch unterstützt werden diese Exkurse in untergeordnete Erzählstränge durch einen horizontalen Seitenübergangseffekt, der beim Eintreten und Verlassen dieser Stränge automatisch eingestellt ist. \n\nErstellt werden diese Erzählstränge in der Gliederung über ein Klick auf die Plus-Schaltfläche neben der Erzählstrang-Auswahl. Dabei öffnet sich automatisch ein neues Kapitel, in dem dann weitere Seiten angelegt werden können.\n\n\n### Übergeordnete Seiten\n\nIn jedem Untererzählstrang muss eine „Übergeordnete Seite“ festgelegt werden, die bestimmt, wohin ein User beim zurück-scrollen gelangt. Mit einem Klick auf das Stift-Symbol neben der Erzählstrang-Auswahl kann diese Zielseite ausgewählt werden. Durch die Auswahl einer übergeordneten Seite erscheint auf allen Seiten eines untergeordneten Erzählstrangs zudem automatisch ein „Zurück“-Button, der zu der übergeordneten Seite führt. \n\n\n### Kapitel-Hierarchie\n\nDurch die Verwendung mehrerer „untergeordneter“ Erzählstränge und der Festlegung von übergeordneten Seiten ergibt sich eine Kapitelhierarchie, wie man sie auch von Buch-Gliederungen kennt:\n\n1. (Hauptstrang), 1.1 (Übergeordneter Unterstrang), 1.1.1 (vertiefende Seite im übergeordneten Unterstrang) und so weiter.\n\nDiese Hierarchie kann nachträglich in der Erzählstrang-Auswahl über ein Klick auf Stift-Symbol geändert werden. Ein untergeordneter Erzählstrang kann an dieser Stelle zudem auch nachträglich zum Haupt-Erzählstrang umsortiert werden.\n\n\n### Scroll-Nachfolger\n\nFalls der User von der letzten Seite eines Unterkapitels (1.1.1) auf eine andere Stelle im Beitrag geleitet werden soll (z.B. 2.1), kann hierzu ebenfalls über das Stiftsymbol in den Erzählstrang-Einstellungen der sogenannte „Scroll-Nachfolger“ festgelegt werden. Um in dem Beispiel zu bleiben wäre der folgende Ablauf denkbar: 1 -> 1.1 -> 1.1.1 -> 2.1\n\nAchtung: Während des Editierens wird immer nur das aktuell ausgewählte Kapitel angezeigt. Um zu den anderen Erzählsträngen zu gelangen klicke auf das Auswahlmenü „Erzählstrang“."
+      page_options:
+        menu_item: Allgemeine Seitenoptionen
+        text: "# Allgemeine Seitenoptionen\n\n### Titel\n\nHier gibst Du den Titel der jeweiligen Seite ein. Dieser\nwird nicht nur als Überschrift des Fliesstextes der Seite\nausgespielt, sondern dient zudem als Titel innerhalb der\nNavigation und der Übersicht. Wird eine einzelne Seite in\nsozialen Netzwerken geteilt, ist dieser Titel zugleich auch\nder Titel des Social Media-Beitrages.\n\n### Titel ausblenden\n\nOptional lässt sich der Titel auch ausblenden. Das heisst:\nEr wird nicht mehr als Überschrift im Fliesstext\nangezeigt. Er bleibt zur Identifikation einer Seite\nallerdings in Navigation, Übersicht und geteilten Beträgen\nerhalten.\n\n### Tagline und Untertitel\n\nHier kann wahlweise eine Tagline und/oder ein Untertitel\neingegeben werden. Falls Du ein Häkchen bei „Titel\nausblenden“ gesetzt hast, sind Tagline und Untertitel über\ndem Fliesstext ebenfalls nicht zu sehen.\n\n### Text\n\nDer Textblock kann mit den Buttons unterhalb des\nEingabefeldes formatiert werden. [ B=Fett / I=kursiv /\nU=unterstrichen „gekippte acht“=Link/URL auf fremde Seite\neinfügen].\n\nAlle Änderungen sind in der linken Frontend-Ansicht\nsichtbar, sobald das entsprechende Texteingabefeld im\nEditierbereich verlassen wurde.\n\n### Textposition\n\nWähle hier, ob der Text auf der linken oder rechten Seite\nangezeigt wird.\n\n### Intensität der Abblendung\n\nDie Intensität des Farbverlaufs dient der Lesbarkeit von\nTexten auf Videos oder Bildern.\n\nDurch den Schieberegler kann der Bildhintergrund so stark\nabgedunkelt bzw. aufgehellt werden, bis der Kontrast\nzwischen Bild und Text ausreichend ist.\n\n### Farben invertieren\n\nBeim Invertieren werden „hell“ und „dunkel“ vertauscht, die\nsonst weiße Schrift ändert sich dabei automatisch in\nschwarz.\n\nGrundsätzlich gilt: Helle Schrift für dunkle Bilder, dunkle\nSchrift für helle Bilder.\n\n### Thumbnail\n\nDas Thumbnail ersetzt das ansonsten automatisch generierte\nVorschaubild in der Navigation und in der Übersicht.\n\n### In Navigationsleiste anzeigen\n\nIst diese Option nicht gesetzt, wird die jeweilige Seite\nnicht in der Navigation repräsentiert, kann also nicht\ndirekt über die Navigation erreicht werden.\n\nDies bietet sich vor allem für Seiten an, die inhaltlich als\n„Unterseiten“ einer anderen Seite anzusehen sind.\n\n### Übergangseffekt\n\nEs gibt verschiedene Effekte, die sichtbar sind, wenn von einer Kapitelseite zur nächsten gescrollt oder geklickt wird. Zur Auswahl stehen Seitenübergänge, wie „Überblendung“, „Schwarzblende“ oder „Harter Schnitt“ die sich vertikal auswirken, zudem kann auch „Horizontal Scrollen“ von rechts oder links ausgewählt werden. \n\nWelcher Effekt verwendet wird, kann unter „Optionen“ individuell für jede Seite festgelegt werden.\n\n### Text verzögert einblenden\n\nBestimme mit dieser Option, ob Text und Abblendung mit zeitlicher Verzögerung angezeigt werden.\nHierbei sehen User zunächst nur den Hintergrund, dann erscheinen Titel, Tagline und Untertitel und mit minimaler Verzögerung schließlich der Fließtext.\n\nInsgesamt stehen drei Verzögerungslängen zur Verfügung: kurz = 1 Sekunde, mittel = 3 Sekunde, lang = 5 Sekunde.\n\nDieses Feature eignet sich zum Beispiel für Intros oder Kapitelanfänge.\n\n### Beschreibung für Übersicht\n\nHier kann der Text eingegeben werden, der angezeigt wird,\nwenn der User in der Übersicht mit der Mouse über die\njeweilige Seite fährt. Außerdem entspricht der hier\neingegebene Text"
+      atmo:
+        menu_item: Atmo Audio
+        text: |-
+          # Atmo Audio
+
+          Mit der „Atmo“ kann jede Seite, unabhängig vom Seitentyp, im Hintergrund Sound abspielen. Dabei kannst Du bestimmen, ob ein Sound nur auf einer Seite zu hören ist oder über mehrere Seiten ohne Unterbrechung läuft. Wähle dazu einfach für die benachbarten Seiten die selbe Audiodatei als Atmo aus.
+
+          Auf diese Weise lassen sich Kapitel akustisch voneinander absetzen und zusammenhängende Seiten stärker verweben.
+
+          Beim Seitentyp Video kann zusätzlich ausgwählt werden, ob der Hintergrundsound während der Video-Wiedergabe normal oder leiser weitergespielt oder ganz ausgeblendet werden soll.
+
+          Die Einstellung der Atmo-Sounds erreichst du bei jeder Seite über den Reiter „Optionen“.
+
+          Sollte Dich die Atmo während der Bearbeitung Deines Beitrags im Editor einmal stören, kannst Du sie mit der Tastenkombination „Alt + a“ vorübergehend stumm schalten. Um die Atmo wieder zu aktivieren, drücke einfach erneut „Alt + a“.
+
+          **ACHTUNG:** Atmo-Audios können aufgrund technischer Einschränkungen der Browserhersteller auf mobilen Geräten und mit Safari auf Desktop nicht wiedergegeben werden.

--- a/entry_types/paged/config/locales/new/help.en.yml
+++ b/entry_types/paged/config/locales/new/help.en.yml
@@ -1,0 +1,153 @@
+en:
+  pageflow_paged:
+    help_entries:
+      overview:
+        menu_item: Overview
+        text: |-
+          # Overview
+
+          This is Pageflow’s editing platform. The division of the
+          screen into two allows you to edit your Pageflow and see a
+          preview at the same time. The editor shows modifications and
+          newly selected files directly and saves them automatically.
+
+          The sidebar can be hidden or shown. You can change the size
+          of the preview-window by pulling the sidebar to the right or
+          the left. If the preview-window is long and narrow like ´ a
+          smartphone, you will only be able to see the „overview“ icon
+          and not the entire navigation. This is due to lack of space.
+
+          The navigation is divided into four parts:
+
+          ## Title and Options
+
+          Under „Title and Options“ you can set up basic appearance
+          parameters as well as the title, language and legal
+          notice. You can also decide which content should be
+          displayed when sharing the report on social media platforms.
+
+          For more details see: [Title and Options](#pageflow_paged.help_entries.meta_data)
+
+          ## Manage Files
+
+          Under „Manage Files“ you can upload your media files, which
+          you want to use in Pageflow. Furthermore you can reuse
+          videos, photos and audio-files that have already been
+          uploaded.
+
+          For more details see: [Manage Files](#pageflow.help_entries.files)
+
+          ## Outline
+
+          Via the „Outline“ you can add chapters and pages - the
+          actual content. Per Drag and Drop you can resort the pages
+          and chapters any time.
+
+          For more details see: [Chapter and Pages](#pageflow_paged.help_entries.outline)
+      meta_data:
+        menu_item: Title and Options
+        text: |
+          # Title and Options
+
+          General settings for the entry. Please select a sub item on the left.
+        appearance:
+          menu_item: Appearance
+          text: |
+            # Appearance
+
+            ## Multimedia tips before the start
+
+            Decide if tips or advice should be shown at the beginning of
+            your Pageflow.
+
+            ## Highlighting chapter beginnings
+
+            This option lets the title of the first page of a chapter
+            appear in a bigger font.
+
+            ## Highlighting new pages
+
+            At the beginning of a Pageflow an info-box shows new pages that were created since the last visit. Since cookies are used for this feature, a cookie notice appears automatically at the bottom of the screen when activated - in accordance with the GDPR.
+
+            ## Display Home-Button
+
+            You can have a button in the navigation, which hyperlinks to an external website, for example back to the website from which you hyperlinked to the Pageflow.
+
+            ## Show overview button
+
+            The overview button in the navigation bar can be hidden.
+
+            ## Home button URL
+
+            Enter the link here to which a click on the Home button should lead. If the target URL is the same for all entries in your account, you can also set a general "redirect URL" via "Settings", which will affect all entries.
+
+            ## Control gestures
+
+            With this option the control for mobile devices can be switched to horizontal scrolling.
+
+            ## Loading view
+
+            Select the type of loading view of your entry. As an alternative to the classic view, an individual load indicator with its own background image, animated title and subtitle line and scalable blur can be configured here.
+
+            ## Player Controls
+
+            Select the appearance of the control elements for audio and video players, 360° panorama and before/after pages.
+
+            ## Navigation bar
+
+            Choose between navigation bars. Please note, that due to the lack of space on mobile devices only the icon „Overview“ is shown.
+
+            ## Cookie notice
+
+            As soon as Google Analytics or the "Highlight new pages" feature is activated, a privacy notice is automatically displayed the first time the entry is visited. If an entry is embedded in a separate website with its own privacy notice, this notice can be optionally hidden.
+
+            ## Theme
+
+            Specify a font template for the entry.
+      outline:
+        menu_item: Chapters and Pages
+        text: |-
+          # Chapters and Pages
+
+          A Pageflow consists of at least one chapter with at least
+          one page. You can create as many chapters and pages as you
+          want. In order to create content, click:
+
+          1. „New Chapter“ to create a new chapter,
+          2. „New Page“ to add a page,
+          3. onto the new page, in order to edit the content.
+
+          ## Structuring Chapters
+
+          You can structure the composition of your Pageflow with
+          chapters - e.g. thematically or chronologically . The
+          chapters are shown in the overview and help the users find
+          their way around. It is therefore advisable to give each
+          chapter a title.
+
+          If you create an unnamed chapter, Pageflow acts as if there
+          is no structure of chapters. The chapter and the title of
+          this chapter are consequently not shown in the
+          overview/navigation.
+      storylines:
+        menu_item: Storylines
+        text: "# Storylines\n\nIn addition to linear narrations from top to bottom, further storylines can be used as non linear excursions to enlarge upon parts of an  entry.\n\nPlease find a blog article and example [here](https://www.pageflow.io/en/update-storylines)\n\nA „Storyline“ consists of chapters and pages, which users scroll through. Distinguishable is the so called main storyline from further subordinate ones. The user starts off in the main storyline and can then navigate to different excursions.\n\nTo create such an excursion from the main storyline use one of the „Link“ pages (Mosaic, Collage, Hotspot) and create the desired connections via „Links“.\n\nBy choosing a „Parent page“ you can determine to which page users return after scrolling the storyline´s last page.\n\nTransitions to subordinate storylines are visually supported by a horizontal animation as the default setting for entering and leaving. \n\nStorylines are created by clicking onto the plus button next to the storyline menu. Thereby a new chapter opens automatically in which further pages can be added. \n\n\n### Parent pages\n\nIn every subordinate  storyline a „Parent page“ must be determined to define where users land when scrolling back.\n\nThis target page can be chosen by clicking on the pen symbol next to the storyline menu. When a „Parent page“ is defined, a back button will be shown automatically in the subordinate storyline that will always lead users back to the „Parent page“.\n\n\n### Chapter hierarchy\n\nThe use of more than one „subordinary“ storylines and the definition of „Parent pages“ leads to a chapter hierarchy as known from books:\n\n1. (Main storyline), 1.1. (Superior sub storyline), 1.1.1. (Subordinate sub storyline) and so on.\n\nThis hierarchy can be edited afterwards by clicking on the pen symbol next to the storyline menu. A subordinate storyline can be turned into the main storyline as well.\n\n\n### Scroll successors\n\nIf you want to lead users from a last page of a subordinate chapter (1.1.1) to another position than\nthe „Parent page“ (e.g. to 2.1) you can define a „Scroll successor“. Therefore click on the blue pen symbol within the storyline settings. As an example the following sequence might be imaginable: 1 -> 1.1 -> 1.1.1 -> 2.1\n\nAttention: While editing only the selected chapter will be shown in the sidebar. To switch to the other chapters click onto the storyline menu."
+      page_options:
+        menu_item: General Page Options
+        text: "# General Page Options\n\n### Title\n\nHere you can add the title of a particular page. This\ntitle is not only the headline of the text on the page, it\nalso functions as the title in the navigation and\noverview. If a single page is shared in social networks,\nthis title is also the title of the social media post.\n\n### Hide the title\n\nOptionally you can hide the title. Thus the title is not shown as the\nheading of the text body. For the identification of the page it\nremains visible in the navigation, overview and on social media posts.\n\n### Tagline and Subtitle\n\nHere you can optionally enter a tagline and/or a\nsubtitle. If you click on „Hide title“ the tagline and\nsubtitle are not shown either.\n\n### Text\n\nThe text-block can be formatted with the buttons underneath\nthe input field. [B= bold / I=italic / U=underlined /\ninfinity symbol= Link/URL to an external website]\n\nAll changes are visible in the left front-end-view as soon\nas you leave the appropriate input field in the editor.\n\n### Textposition\n\nDecide if the text should be shown on the left or right side.\n\n### Opacity of the gradient\n\nThe opacity of the gradient improves the legibility of\nthe text on background-videos or pictures.\n\nYou can use the slider to darken or lighten up the\nbackground until the contrast between text and background is\noptimal.\n\n### Invert colors\n\nIf you invert the colors, „bright“ and „dark“ are\ninterchanged. Thus the normally white font changes into\nblack.\n\nA general rule: Bright font for dark pictures, dark font for\nbright pictures.\n\n### Thumbnail\n\nThe thumbnail replaces the automatically generated\npreview-picture in the navigation and overview.\n\n### Display in navigation\n\nIf this option is not taken, the particular page is not\nrepresented in the navigation and therefore cannot be\nreached through it.  You can use this option if a page is\nsupposed to read more like a subpage of another page.\n\n### Transition effect\n\nThere are different scroll effects, which are visible when users enter or leave pages. You can use vertical transitions like „crossfade“ or „cut“ or „Fade to black“. Besides this you also can choose horizontal scrolling from right or left. You can determine which effect should be used for each individual page.\n\n### Fade in text after delay\n\nDefine whether text and gradient of a page should appear with a delay. \nUsers will first see the background image, then title, tagline and subtitle until finally the content text will be displayed.\n\nThere are three different durations of delay: short = 1 second, medium = 3 seconds, long = 5 seconds.\n\nThis feature fits best for intros or beginnings of chapters.\n\n### Description for the overview\n\nYou can enter a text, which appears when the user navigates\nwith the mouse over the particular page. This text matches\nwith the mouse-over-text for the page-type „Page References“\nas well as with the text, which appears when you share the\nPageflow in social networks."
+      atmo:
+        menu_item: Atmo Audio
+        text: |-
+          # Atmo Audio
+
+          This feature lets you add background audio to every page regardless of its page type. You can define if a sound should play only for one page or continue playing for more pages without interruption. Simply select the same atmo audio file for some adjacent pages.
+
+          That way chapters can be seperated acoustically and pages that belong together can be weaved to a stronger unit.
+
+          For the page type „Video“ there is a special option to pause background audio or continue at lower volume while the video is playing.
+
+          You find the atmo settings on the „Options“ tab of each page.
+
+          Should you ever feel distracted by the atmo audio while working on your story, you can use the hot key „Alt + a“ to temporarily mute it. Simply press „Alt + a“ again to reactivate atmo audio.
+
+          **CAUTION:** Due to technical restrictions imposed by the browser manufacturers, ambient audio cannot be played on mobile devices and with Safari on the desktop.

--- a/entry_types/scrolled/config/initializers/help_entries.rb
+++ b/entry_types/scrolled/config/initializers/help_entries.rb
@@ -1,0 +1,15 @@
+Pageflow.configure do |c|
+  c.for_entry_type(PageflowScrolled.entry_type) do |config|
+    config.help_entries.register('pageflow_scrolled.help_entries.overview', priority: 100)
+
+    config.help_entries.register('pageflow_scrolled.help_entries.meta_data', priority: 50)
+    config.help_entries.register('pageflow.help_entries.meta_data.general',
+                                 priority: 100, parent: 'pageflow_scrolled.help_entries.meta_data')
+    config.help_entries.register('pageflow.help_entries.meta_data.social',
+                                 priority: 50, parent: 'pageflow_scrolled.help_entries.meta_data')
+
+    config.help_entries.register('pageflow_scrolled.help_entries.outline', priority: 30)
+    config.help_entries.register('pageflow_scrolled.help_entries.sections', priority: 20)
+    config.help_entries.register('pageflow_scrolled.help_entries.content_elements', priority: 10)
+  end
+end

--- a/entry_types/scrolled/config/locales/new/de.yml
+++ b/entry_types/scrolled/config/locales/new/de.yml
@@ -1,5 +1,137 @@
 de:
   pageflow_scrolled:
+    help_entries:
+      overview:
+        menu_item: Übersicht
+        text: |
+          # Übersicht
+
+          Dies ist der Editor zum Bearbeiten Pageflows. Mit
+          seiner Zweiteilung ermöglicht er die direkte Vorschau
+          während der Bearbeitung, zeigt Änderungen am Text oder neu
+          ausgewählte Dateien unmittelbar an und speichert diese
+          automatisch.
+
+          ## Titel und Optionen
+
+          Unter „Titel und Optionen“ kannst Du grundsätzliche
+          Parameter des Erscheinungsbildes, sowie Titel, Sprache,
+          Impressum etc. einstellen. Dazu können Texte festgelegt
+          werden, die beim Teilen des Beitrags über Social Media
+          Dienste angezeigt werden sollen.
+
+          Details findest Du unter: [Titel und Optionen](#pageflow_scrolled.help_entries.meta_data)
+
+          ## Dateien verwalten
+
+          Unter „Dateien verwalten“ lädst Du die Mediendateien hoch,
+          die im Pageflow verwendet werden sollen. Du kannst hier auch
+          bereits hochgeladene Videos, Fotos und Audios
+          wiederverwenden.
+
+          Details findest Du unter: [Dateien verwalten](#pageflow.help_entries.files)
+
+          ## Gliederung
+
+          Über die „Gliederung“ kannst Du Kapitel und Abschnitte
+          hinzufügen, also die eigentlichen Inhalte bearbeiten. Per
+          Drag&Drop lassen sich Abschnitte und Kapitel auch jederzeit
+          umsortieren.
+
+          Details findest Du unter: [Kapitel und Abschnitte](#pageflow_scrolled.help_entries.outline)
+
+          ## Phone Vorschau
+
+          Über den Umschalter unten in der Seitenleiste neben dem
+          Hilfe-Button, kann in die Phone-Vorschau umgeschaltet
+          werden. Damit kannst Du testen wie Dein Beitrag im
+          Hochkant-Format aussieht und funktioniert.
+
+      meta_data:
+        menu_item: Titel und Optionen
+        text: |
+          # Titel und Optionen
+
+          Allgemeine Einstellungen für den Beitrag. Bitte einen
+          Unterpunkt auf der linken Seite auswählen.
+
+      outline:
+        menu_item: Kapitel, Abschnitte, Inhaltselemente
+        text: |
+          # Kapitel, Abschnitte, Inhaltselemente
+
+          Ein Pageflow besteht aus einem oder mehreren **Kapiteln**, die
+          jeweils mehere **Abschnitte** enthalten können. Je Abschnitt
+          kann ein Hintegrund (z.B. ein Bild oder ein Video-Loop)
+          festgelegt werden, der angezeigt wird, während sich der
+          Leser innerhalb des Abschnitts befindet.
+
+          Abschnitte beinhalten **Inhaltselemente**. Diese
+          können unterschiedlichen Typs sein (z.B. Text, Bilder,
+          Videos, Diagramme). Sie machen den eigentlichen
+          Inhalt des Beitrags aus, durch den der Leser scrollt.
+
+          Um Inhalte zu erstellen, klicke zunächst auf **„Neues
+          Kapitel"**, um ein erstes Kapitel zu erstellen. Wenn Du auf
+          die Kopfzeile des Kapitels klickst, kannst Du den Titel und
+          eine Beschreibung angegeben. Sobald beides eingetragen ist,
+          erscheint das Kapitel in der Navigationsleiste.
+
+          Klicke als nächstes auf **„Neuer Abschnitt"**, um dem Kapitel
+          einen Abschnitt hinzuzufügen. In der Vorschau auf der linken
+          Seite wird nun ein Auswahlrechteck um den neuen Abschnitt
+          gezeigt. In der Seitenleiste kannst du die Optionen des
+          Abschnitts bearbeiten. Hier kannst Du z.B. ein Bild oder
+          eine Farbe als Hintergrund fpr den Abschnitts
+          festlegen. Details findest Du unter:
+          [Abschnittsoptionen](#pageflow_scrolled.help_entries.sections)
+
+          Der Abschnitt enthält bereits einen Text-Block. Klicke auf
+          den Text, um diesen zu bearbeiten. Mit einem Klick in den
+          leeren Bereich neben dem Text, kannst Du wieder den
+          Abschnitt auswählen.
+
+          Wenn der Abschnitt ausgewählt ist, wird unterhalb des
+          letzten Elements ein Plus-Button mit der Beschriftung
+          **„Neues Element hinzufügen"** angezeigt. Wenn Du darauf
+          klickst, kannst Du auswählen was für einen Typ von
+          Inhaltselement du einfügen möchtest. Wenn ein Inhaltselement
+          per Klick auswählt wird, können in der Seitenleiste seine
+          Einstellungen bearbeitet werden. Details zu den verfügbaren
+          Inhaltselementen findest Du unter:
+          [Inhaltselemente](#pageflow_scrolled.help_entries.content_elements)
+
+          Oben und unten am Auswahlrechteck um ein Inhaltselement
+          befinden sich ebenfalls Plus-Buttons, über die weitere
+          Elemente vor oder nach dem ausgewählten Element eingefügt
+          werden können.
+
+      sections:
+        menu_item: Abschnittsoptionen
+        text: |
+          # Abschnittsoptionen
+
+          ## Layout
+
+          TODO
+
+          ## Hintergrund
+
+          TODO
+
+          ## Atmo
+
+          TODO
+
+          ## Transitionen
+
+          TODO
+      content_elements:
+        menu_item: Inhaltselemente
+        text: |
+          # Inhaltselemente
+
+          TODO
     public:
       navigation:
         chapter: Kapitel

--- a/entry_types/scrolled/config/locales/new/en.yml
+++ b/entry_types/scrolled/config/locales/new/en.yml
@@ -1,5 +1,51 @@
 en:
   pageflow_scrolled:
+    help_entries:
+      overview:
+        menu_item: Overview
+        text: |
+          # Overview
+
+          TODO
+      meta_data:
+        menu_item: Title and Options
+        text: |
+          # Title and Options
+
+          General settings for the entry. Please select a sub item on the left.
+      outline:
+        menu_item: Chapter, Sections, Content Elements
+        text: |
+          # Chapter, Sections, Content Elements
+
+          TODO
+
+      sections:
+        menu_item: Section Options
+        text: |
+          # Section Options
+
+          ## Layout
+
+          TODO
+
+          ## Background
+
+          TODO
+
+          ## Atmo Audio
+
+          TODO
+
+          ## Transitions
+
+          TODO
+      content_elements:
+        menu_item: Content Elements
+        text: |
+          # Content Elements
+
+          TODO
     public:
       navigation:
         chapter: Chapter


### PR DESCRIPTION
* Split title and options into multiple entries to make "general" and
 "social" reusable.

* Extract paged specific help entries into paged engine.

* Add outline for scrolled help entries.

REDMINE-17295, REDMINE-17296, REDMINE-17294