### PR TITLE
Sync entry metadata model into entry state

### DIFF
--- a/package/src/editor/models/EntryMetadata.js
+++ b/package/src/editor/models/EntryMetadata.js
@@ -17,5 +17,10 @@ export const EntryMetadata = Configuration.extend({
       this.trigger('change');
       this.parent.save();
     });
+  },
+
+  // Pageflow Scrolled only synchronizes saved records to entry state.
+  isNew() {
+    return false;
   }
 });


### PR DESCRIPTION
`EntryMetadata` model does not have an id, but it still represents a
saved record that needs to be synced to entry state. Otherwise credits
and sharing options do not get updated.

REDMINE-17781