### PR TITLE
Disable text tracks in backdrop videos

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/MediaPlayer/textTracks-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/MediaPlayer/textTracks-spec.js
@@ -89,6 +89,25 @@ describe('MediaPlayer', () => {
     );
   });
 
+  it('does not passes text tracks if text tracks are disabled', () => {
+    const textTracks = getTextTracks({
+      sampleTextTrack: {
+        id: 1
+      }
+    });
+    render(<MediaPlayer {...requiredProps()}
+                        textTracksDisabled={true}
+                        sources={getAudioSources()}
+                        textTracks={textTracks} />);
+
+    expect(media.getPlayer).toHaveBeenCalledWith(
+      getAudioSources(),
+      expect.objectContaining({
+        textTrackSources: []
+      })
+    );
+  });
+
   it('does not request new player when rerendered with deeply equal text tracks', () => {
     const {rerender} =
       render(<MediaPlayer {...requiredProps()}

--- a/entry_types/scrolled/package/src/frontend/Backdrop.js
+++ b/entry_types/scrolled/package/src/frontend/Backdrop.js
@@ -135,6 +135,7 @@ function BackgroundVideo(props) {
                  playerState={playerState}
                  playerActions={playerActions}
                  id={props.video}
+                 textTracksDisabled={true}
                  fit="cover"
                  loop={true}
                  playsInline={true} />

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/index.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/index.js
@@ -65,7 +65,7 @@ function PreparedMediaPlayer(props){
       <PlayerContainer className={classNames(props.className, {[textTrackStyles.inset]: props.textTracksInset})}
                        type={props.type}
                        sources={appendSuffix(props.sources, props.sourceUrlSuffix)}
-                       textTrackSources={getTextTrackSources(props.textTracks.files)}
+                       textTrackSources={getTextTrackSources(props.textTracks.files, props.textTracksDisabled)}
                        filePermaId={props.filePermaId}
                        poster={props.posterImageUrl}
                        loop={props.loop}

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/textTracks.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/textTracks.js
@@ -9,7 +9,11 @@ export function updateTextTracksMode(player, activeTextTrackFileId) {
   });
 }
 
-export function getTextTrackSources(textTrackFiles, textTracksEnabled) {
+export function getTextTrackSources(textTrackFiles, textTracksDisabled) {
+  if (textTracksDisabled) {
+    return [];
+  }
+
   return textTrackFiles
     .filter(textTrackFile => textTrackFile.isReady)
     .map(textTrackFile => ({


### PR DESCRIPTION
Backdrop videos are supposed to be atmo not content. Due to covering
object fit, text tracks might be clipped off anyway.

REDMINE-17791