### PR TITLE
Fix heading default value logic

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/EditableInlineText-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/EditableInlineText-spec.js
@@ -6,6 +6,12 @@ import {render} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect'
 
 describe('EditableInlineText', () => {
+  it('renders empty string by default', () => {
+    const {container} = render(<EditableInlineText />);
+
+    expect(container.innerHTML).toEqual('')
+  });
+
   it('renders text from value', () => {
     const value = [{
       type: 'heading',
@@ -15,6 +21,25 @@ describe('EditableInlineText', () => {
     }];
 
     const {queryByText} = render(<EditableInlineText value={value} />);
+
+    expect(queryByText('Some text')).toBeInTheDocument()
+  });
+
+  it('supports default value', () => {
+    const {queryByText} = render(<EditableInlineText defaultValue="Some default" />);
+
+    expect(queryByText('Some default')).toBeInTheDocument()
+  });
+
+  it('prefers value over defaultValue', () => {
+    const value = [{
+      type: 'heading',
+      children: [
+        {text: 'Some text'}
+      ]
+    }];
+
+    const {queryByText} = render(<EditableInlineText value={value} defaultValue="Some default" />);
 
     expect(queryByText('Some text')).toBeInTheDocument()
   });

--- a/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableInlineText-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableInlineText-spec.js
@@ -57,4 +57,23 @@ describe('EditableInlineText', () => {
 
     expect(queryByText('Some placeholder')).not.toBeInTheDocument()
   });
+
+  it('supports default value', () => {
+    const {queryByText} = render(<EditableInlineText defaultValue="Some default" />);
+
+    expect(queryByText('Some default')).toBeInTheDocument()
+  });
+
+  it('prefers value over defaultValue', () => {
+    const value = [{
+      type: 'heading',
+      children: [
+        {text: 'Some text'}
+      ]
+    }];
+
+    const {queryByText} = render(<EditableInlineText value={value} defaultValue="Some default" />);
+
+    expect(queryByText('Some text')).toBeInTheDocument()
+  });
 });

--- a/entry_types/scrolled/package/src/contentElements/heading/Heading.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/Heading.js
@@ -16,19 +16,15 @@ export function Heading({configuration, sectionProps}) {
   const updateConfiguration = useContentElementConfigurationUpdate();
   const {t} = useI18n({locale: 'ui'});
 
-  const legacyDefault = useMemo(() => [{
-    type: 'heading',
-    children: [{ text: configuration.children }],
-  }], [configuration.children]);
-
-  const value = configuration.value || legacyDefault;
+  const legacyValue = configuration.children;
 
   return (
     <h1 className={classNames(styles.root,
                               {[styles.first]: firstSectionInEntry},
                               {[withShadowClassName]: !sectionProps.invert})}>
       <Text scaleCategory={firstSectionInEntry ? 'h1' : 'h2'} inline={true}>
-        <EditableInlineText value={value}
+        <EditableInlineText value={configuration.value}
+                            defaultValue={legacyValue}
                             placeholder={t('pageflow_scrolled.inline_editing.type_heading')}
                             onChange={value => updateConfiguration({value})} />
       </Text>

--- a/entry_types/scrolled/package/src/frontend/EditableInlineText.js
+++ b/entry_types/scrolled/package/src/frontend/EditableInlineText.js
@@ -2,7 +2,7 @@ import {withInlineEditingAlternative} from './inlineEditing';
 
 export const EditableInlineText = withInlineEditingAlternative(
   'EditableInlineText',
-  function EditableInlineText({value}) {
-    return value[0]?.children[0]?.text || '';
+  function EditableInlineText({value, defaultValue = ''}) {
+    return value ? value[0]?.children[0]?.text : defaultValue;
   }
 );

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/EditableInlineText.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/EditableInlineText.js
@@ -5,12 +5,14 @@ import {Slate, Editable, withReact} from 'slate-react';
 import {TextPlaceholder} from './TextPlaceholder';
 import {useCachedValue} from './useCachedValue';
 
-export const EditableInlineText = memo(function EditableInlineText({value, placeholder, onChange}) {
+export const EditableInlineText = memo(function EditableInlineText({
+  value, defaultValue = '', placeholder, onChange
+}) {
   const editor = useMemo(() => withSingleLine(withReact(createEditor())), []);
   const [cachedValue, setCachedValue] = useCachedValue(value, {
     defaultValue: [{
       type: 'heading',
-      children: [{ text: '' }],
+      children: [{ text: defaultValue }],
     }],
     onDebouncedChange: onChange
   });


### PR DESCRIPTION
Move default value logic to `EditableInlineText` component. Prevent
generating invalid default children when default value is undefined.

REDMINE-17798