### PR TITLE
Add meta tags in scrolled

### DIFF
--- a/entry_types/scrolled/app/controllers/pageflow_scrolled/entries_controller.rb
+++ b/entry_types/scrolled/app/controllers/pageflow_scrolled/entries_controller.rb
@@ -4,10 +4,15 @@ module PageflowScrolled
     include Pageflow::EntriesControllerEnvHelper
 
     helper Pageflow::WidgetsHelper
+    helper Pageflow::PublicI18nHelper
+    helper Pageflow::SocialShareHelper
+    helper Pageflow::MetaTagsHelper
 
     def show
       @entry = get_published_entry_from_env
       @widget_scope = get_entry_mode_from_env
+
+      I18n.locale = @entry.locale
     end
   end
 end

--- a/entry_types/scrolled/app/controllers/pageflow_scrolled/entries_controller.rb
+++ b/entry_types/scrolled/app/controllers/pageflow_scrolled/entries_controller.rb
@@ -4,7 +4,6 @@ module PageflowScrolled
     include Pageflow::EntriesControllerEnvHelper
 
     helper Pageflow::WidgetsHelper
-    helper Pageflow::PublicI18nHelper
     helper Pageflow::SocialShareHelper
     helper Pageflow::MetaTagsHelper
 

--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/entry_json_seed_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/entry_json_seed_helper.rb
@@ -9,6 +9,7 @@ module PageflowScrolled
     include Pageflow::EntriesHelper
     include Pageflow::SocialShareLinksHelper
     include PageflowScrolled::I18nHelper
+    include Pageflow::MetaTagsHelper
 
     def scrolled_entry_json_seed_script_tag(scrolled_entry, options = {})
       seed_json = render_json do |json|

--- a/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
@@ -42,4 +42,4 @@
 
     <%= scrolled_entry_json_seed_script_tag(@entry, @seed_options || {}) %>
   </body>
-  <% end %>
+<% end %>

--- a/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<%= content_tag(:html, lang: I18n.locale) do %>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
@@ -8,8 +8,11 @@
       name="description"
       content="Pageflow Next Showcase"
     />
+
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700&display=swap" rel="stylesheet">
     <title>Pageflow Next Showcase</title>
+    <%= social_share_meta_tags_for(@entry) %>
+    <%= meta_tags_for_entry(@entry) %>
 
     <%= javascript_include_tag 'pageflow/videojs' %>
     <%= javascript_include_tag 'pageflow_scrolled/legacy' %>
@@ -39,4 +42,4 @@
 
     <%= scrolled_entry_json_seed_script_tag(@entry, @seed_options || {}) %>
   </body>
-</html>
+  <% end %>

--- a/entry_types/scrolled/spec/controllers/pageflow_scrolled/entries_controller_spec.rb
+++ b/entry_types/scrolled/spec/controllers/pageflow_scrolled/entries_controller_spec.rb
@@ -73,6 +73,14 @@ module PageflowScrolled
         expect(response.body).not_to have_selector('div.test_widget')
         expect(response.body).not_to have_meta_tag.with_name('some_test')
       end
+
+      it 'uses locale of entry' do
+        entry = create(:entry, :published, type_name: 'scrolled', published_revision_attributes: {locale: 'de'})
+
+        get_with_entry_env(:show, entry: entry)
+
+        expect(response.body).to have_selector('html[lang=de]')
+      end
     end
   end
 end


### PR DESCRIPTION
REDMINE-17778

Social sharing meta tags and meta tags
are rendered by paged in entry head. Same
can be used for scrolled

It adds the same helpers used for paged in scrolled
entry head

It also changes the lang attribute and reflect the entry
locale as in paged