### PR TITLE
Turn react and react-dom into peer dependencies of pageflow-scrolled

### DIFF
--- a/doc/contributing/node_package_development.md
+++ b/doc/contributing/node_package_development.md
@@ -77,6 +77,25 @@ You can return to using the version specified in the `package.json`
 file, by running `yarn unlink pageflow`/`yarn unlink
 pageflow-scrolled` and `yarn install --force`.
 
+If you see errors of the form "hooks can only be called inside the
+body of a function component", you need to make sure that only one
+copy of React is loaded. In the above setup, there is a copy of React
+in `my-projects/pageflow/node_modules/react` and in
+`my-projects/pageflow-host-app/node_modules/react`. When
+`pageflow-scrolled` is linked, imports of `react` inside
+`pageflow-scrolled` will load the module from
+`my-projects/pageflow/node_modules`. If there are other packages in
+the host application which import `react`, they will load the module
+from the host application's `node_modules` directory. To fix this, we
+need to link the `react` package so that only the copy from the host
+application is used:
+
+    $ cd my-projects/pageflow-host-app/node_modules/react
+    $ yarn link
+
+    $ cd my-projects/pageflow/
+    $ yarn link react
+
 ### Building for Release
 
 To output a production ready build, run from the repository run:

--- a/entry_types/scrolled/package/package.json
+++ b/entry_types/scrolled/package/package.json
@@ -11,9 +11,7 @@
     "debounce": "^1.2.0",
     "intersection-observer": "^0.7.0",
     "prop-types": "^15.7.2",
-    "react": "^16.9.0",
     "react-compare-image": "https://github.com/codevise/react-compare-image#offset-width-fix",
-    "react-dom": "^16.9.0",
     "react-draggable": "^4.4.2",
     "react-player": "^1.15.2",
     "react-measure": "^2.3.0",
@@ -23,7 +21,9 @@
     "whatwg-fetch": "^3.0.0"
   },
   "peerDependencies": {
-    "pageflow": "15.1.0"
+    "pageflow": "15.1.0",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
   },
   "devDependencies": {
     "@percy/storybook": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10000,7 +10000,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.8.3, react-dom@^16.9.0:
+react-dom@^16.8.3:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
   integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
@@ -10193,15 +10193,6 @@ react@^16.8.3:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
   integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@^16.9.0:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Since only one copy of React is allowed to be loaded at a time, soon
as other Paegflow plugin packages that define content elements are
added to a host application, we need to make sure that all Pageflow
packages share a React version.

`pageflow-scrolled` can therefore no longer declare `react` as a
normal dependency, but instead needs to rely on the host application
to install a shared copy of React.

When running `yarn install` in the root of the `pageflow` repository,
React packages will still be installed into the root `node_modules`
directory since they are transitive dependencies of other packages
`pageflow-scrolled` depends on.

This has the positive side effect that - for example when running Jest -
React can still be imported. On the other hand, when linking the
`pagefow-scrolled` package in a host application, React will now be
loaded from that root `node_modules` directory, while other (not
linked) packages in the host application still load React from the
host application's `node_modules` directory. To prevent errors, we
therefore need to link the `react` package as described in the updated
"Node pacakge development" guide.

REDMINE-17383