### PR TITLE
Collapse inline selection toolbar for small viewports

### DIFF
--- a/entry_types/scrolled/package/src/frontend/inlineEditing/SelectionRect.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/SelectionRect.js
@@ -50,6 +50,7 @@ function renderToolbar({toolbarButtons, onToolbarButtonClick, start}) {
     return (
       <div className={styles.toolbar}>
         <Toolbar buttons={toolbarButtons}
+                 collapsible={true}
                  onButtonClick={onToolbarButtonClick} />
       </div>
     );

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/Toolbar.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/Toolbar.js
@@ -3,9 +3,10 @@ import classNames from 'classnames';
 
 import styles from './Toolbar.module.css';
 
-export function Toolbar({buttons, onButtonClick, iconSize}) {
+export function Toolbar({buttons, onButtonClick, iconSize, collapsible}) {
   return (
-    <div className={styles.Toolbar} contentEditable={false}>
+    <div className={classNames(styles.Toolbar, {[styles.collapsible]: collapsible})}
+         contentEditable={false}>
       {buttons.map(button => {
         const Icon = button.icon
 

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/Toolbar.module.css
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/Toolbar.module.css
@@ -1,18 +1,15 @@
 .Toolbar {
   background: #fff;
   box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  display: flex;
+  gap: 2px;
 }
 
 .button {
   border: 0;
   background: #fff;
   padding: 10px;
-  margin-right: 2px;
   opacity: 0.6;
-}
-
-.button:last-child {
-  margin-right: 0;
 }
 
 .button:hover {
@@ -22,4 +19,16 @@
 .activeButton {
   background: #ddd;
   opacity: 1;
+}
+
+@media (max-width: 460px) {
+  .collapsible .button {
+    display: none;
+  }
+
+  .collapsible:hover .button,
+  .collapsible:focus-within .button,
+  .collapsible .activeButton {
+    display: inline-block;
+  }
 }


### PR DESCRIPTION
Prevent toolbar from hiding "insert before" button.

REDMINE-17845