### PR TITLE
Fix responsive Datawrapper chart height hook

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/dataWrapperChart/useIframeHeight.js
+++ b/entry_types/scrolled/package/src/contentElements/dataWrapperChart/useIframeHeight.js
@@ -1,7 +1,8 @@
-import {useEffect, useRef} from 'react';
+import {useEffect, useState} from 'react';
 
 export function useIframeHeight(url) {
-  const height = useRef('400px');
+  const [height, setHeight] = useState('400px');
+
   useEffect(() => {
     window.addEventListener('message', receive);
 
@@ -9,14 +10,14 @@ export function useIframeHeight(url) {
       if (typeof event.data['datawrapper-height'] !== 'undefined') {
         for (var chartId in event.data['datawrapper-height']) {
           if (url.indexOf(chartId) > -1) {
-            const receivedHeight = event.data['datawrapper-height'][chartId] + 'px';
-            height.current = receivedHeight;
-          } 
+            setHeight(event.data['datawrapper-height'][chartId] + 'px');
+          }
         }
       }
     }
-    return () => document.removeEventListener('message', receive);
+
+    return () => window.removeEventListener('message', receive);
   }, [url]);
 
-  return height.current;
+  return height;
 }


### PR DESCRIPTION
* Store height in state to trigger React update when message
  arrives. Otherwise the chart is only resized next time the component
  is rendered.

* Ensure event handler is removed correctly. Previously it was added
  to `window` and removed from `document`. Change test to assert that
  messages are no longer processed instead of mocking the (wrong)
  implementation detail.

* Wrap `postMessage` calls in `act` calls to correctly trigger React
  updates in specs. Since post message events are handled
  asynchronously, we need to call `tick` inside `act` to make sure
  React is still awaiting state updates while the message is being
  processed. This relies on the fact that JSDOM implements
  `postMessage` by scheduling the event handler for immediate
  execution when the message is sent. `tick` therefore yields control
  to the event handler, making sure the state update is wrapped in
  `act`.

REDMINE-17670