### PR TITLE
Default to empty link url in text area input view

### DIFF
--- a/package/src/ui/templates/inputs/textAreaInput.jst
+++ b/package/src/ui/templates/inputs/textAreaInput.jst
@@ -46,7 +46,7 @@
 
     <!-- wysihtml5 does not handle hidden fields correctly -->
     <div class="internal">
-      <input type="text" data-wysihtml5-dialog-field="href" class="current_url" value="http://">
+      <input type="text" data-wysihtml5-dialog-field="href" class="current_url" value="">
       <input type="text" data-wysihtml5-dialog-field="target" class="current_target" value="_blank">
     </div>
 

--- a/package/src/ui/views/inputs/TextAreaInputView.js
+++ b/package/src/ui/views/inputs/TextAreaInputView.js
@@ -146,7 +146,7 @@ export const TextAreaInputView = Marionette.ItemView.extend({
       var currentUrl = this.ui.urlInput.val();
 
       if (currentUrl.startsWith('#')) {
-        this.ui.displayUrlInput.val('http://');
+        this.ui.displayUrlInput.val('');
         this.ui.openInNewTabCheckBox.prop('checked', true);
       }
       else {


### PR DESCRIPTION
The default used to be "http://".

REDMINE-17842