### PR TITLE
Move entry type registration to host app

### DIFF
--- a/config/initializers/entry_types.rb
+++ b/config/initializers/entry_types.rb
@@ -1,4 +1,0 @@
-Pageflow.configure do |config|
-  config.plugin(PageflowPaged.plugin)
-  config.plugin(PageflowScrolled.plugin)
-end

--- a/lib/generators/pageflow/initializer/templates/pageflow.rb
+++ b/lib/generators/pageflow/initializer/templates/pageflow.rb
@@ -3,7 +3,11 @@ Pageflow.configure do |config|
   # users.
   config.mailer_sender = 'change-me-at-config-initializers-pageflow@example.com'
 
-  # Plugins provide page types and widget types.
+  # Entry type plugins
+  config.plugin(PageflowPaged.plugin)
+  config.plugin(PageflowScrolled.plugin)
+
+  # Plugins that provide page types and widget types.
   config.plugin(Pageflow.built_in_page_types_plugin)
   config.plugin(Pageflow.built_in_widget_types_plugin)
   # config.plugin(Pageflow::Rainbow.plugin)


### PR DESCRIPTION
Registering entry types in a host app initializer allows disabling an
entry type in the host application. Before this was only possible via
feature flags, which could always be changed by system admins.

REDMINE-17852