### PR TITLE
Improve error messages when entry template creation fails

### DIFF
--- a/admins/pageflow/entry_templates.rb
+++ b/admins/pageflow/entry_templates.rb
@@ -24,6 +24,7 @@ module Pageflow
         @entry_template = EntryTemplate.new(
           entry_template_params.merge(account_id: permitted_params[:account_id])
         )
+        @page_title = page_title('new', @entry_template.entry_type)
         authorize!(:create, @entry_template)
         create! { redirect_path }
         update_widgets if @entry_template.errors.empty?
@@ -37,6 +38,7 @@ module Pageflow
       def update
         @entry_template = EntryTemplate.find(params[:id])
         @entry_template.assign_attributes(entry_template_params)
+        @page_title = page_title('edit', @entry_template.entry_type)
         params[:entry_template].delete('share_providers')
         params[:entry_template].delete('configuration')
         authorize!(:update, @entry_template)

--- a/app/models/pageflow/entry_template.rb
+++ b/app/models/pageflow/entry_template.rb
@@ -10,10 +10,7 @@ module Pageflow
     validates :entry_type, presence: true
     validates :entry_type,
               uniqueness: {
-                scope: :account,
-                message: I18n.t(
-                  'activerecord.models.pageflow/entry_template.unique_account_entry_type'
-                )
+                scope: :account
               }
 
     def translated_entry_type

--- a/app/views/admin/entry_templates/_form.html.erb
+++ b/app/views/admin/entry_templates/_form.html.erb
@@ -2,6 +2,7 @@
   <% account_config = Pageflow.config_for(resource.account) %>
   <% entry_type = resource.entry_type || params[:entry_type] %>
   <%= f.inputs do %>
+      <%= f.semantic_errors :entry_type %>
       <%= render('admin/accounts/theming_defaults_inline_help') %>
       <%= f.hidden_field :entry_type, value: entry_type %>
       <%= f.input :default_locale,

--- a/config/locales/new/edit_entry_templates.de.yml
+++ b/config/locales/new/edit_entry_templates.de.yml
@@ -4,11 +4,17 @@ de:
   activerecord:
     attributes:
       pageflow/entry_template:
-        translated_entry_type: Beitrags-Typ
+        entry_type: Beitrags-Typ
     models:
       pageflow/entry_template:
         one: Beitragsvorlage
-        unique_account_entry_type: Es existiert bereits eine Beitragsvorlage für diesen Beitrags-Typ für dieses Konto.
+        other: Beitragsvorlagen
+    errors:
+      models:
+        pageflow/entry_template:
+          attributes:
+            entry_type:
+              taken: bereits konfiguriert. Es existiert bereits eine Beitragsvorlage für den Beitrags-Typ in diesem Konto. Kehre zum Beitragsvorlagen-Tab zurück und bearbeite die existierende Beitragsvorlage anstatt eine neue anzulegen.
   pageflow:
     admin:
       accounts:

--- a/config/locales/new/edit_entry_templates.en.yml
+++ b/config/locales/new/edit_entry_templates.en.yml
@@ -4,11 +4,17 @@ en:
   activerecord:
     attributes:
       pageflow/entry_template:
-        translated_entry_type: Story type
+        entry_type: Story type
     models:
       pageflow/entry_template:
         one: Story template
-        unique_account_entry_type: A story template already exists for this story type for this account.
+        other: Story templates
+    errors:
+      models:
+        pageflow/entry_template:
+          attributes:
+            entry_type:
+              taken: already configured. A story template for the story type already exists in this account. Return to the story templates tab and edit the existing story template instead of creating a new one.
   pageflow:
     admin:
       accounts:


### PR DESCRIPTION
* Use conventional keys for validation error messages. Before, the
  error message translation lived below `attributes.models` which is
  reserved for model name translations. Localeapp complains about
  namespaces which contain pluralization keys (i.e. `one`) as well as
  other keys (i.e. the error message) and skips importing the former.

* Use Formtastic helper to actually render the error message in the
  form. Before, submitting the `new` form just re-rendered the form
  without any indication of an error, when an entry template of the
  same type had been created in the meantime. The Formtastic helper
  always prefixes the error message with the attribute name. We
  therefore have to go a bit out of our way to formulate the error
  message accordingly.

* Include a hint in the error message about what has to be done next.

* As a sort of drive-by fix, we also set the page title in the
  `create` and `update` actions. Before, the edit page reverted to an
  untranslated default title when the form rendered in the context of
  the `create` on validation failure.

REDMINE-17306, REDMINE-17793