### PR TITLE
Abort playAndFadeIn if paused while waiting for play promise

### DIFF
--- a/package/src/frontend/mediaPlayer/volumeBinding.js
+++ b/package/src/frontend/mediaPlayer/volumeBinding.js
@@ -24,8 +24,10 @@ export const volumeBinding = function(player, settings, options) {
 
     return Promise.all([originalPlay.call(player)]).then(function() {
       listenToVolumeSetting();
-      return player.fadeVolume(player.targetVolume(), duration).then(null, function() {
-        return Promise.resolve();
+      return player.ifIntendingToPlay().then(function() {
+        return player.fadeVolume(player.targetVolume(), duration).then(null, function() {
+          return Promise.resolve();
+        });
       });
     });
   };


### PR DESCRIPTION
On a waveform audio page that has a atmo that is configured to pause
during page media playback, atmo resumes when seeking in the playing
waveform audio.

Wavesurfer pauses the media element while seeking. This causes the
atmo to be resumed and immediately faded out again. With the new async
promises, the following order of execution can be observed:

```
* Wavesurfer pauses before seek
* Atmo plays
| * Wavesurfer plays after seed
| * Atmo fades out (since it has not yet faded in yet this completes
| | immediately)
| * Atmo pauses
* Atmo fades in
```
Now two problems come into play:

* Audio5.js ignores the pause call [2] since it has not yet handled
  the `play` event and thinks that the player is still paused.

* The fade in happens even though the player has been paused in the
  meantime.

This commit only fixes the second problem. Atmo will still play muted
after the above scenario. We do not want to patch Audio5.js at this
point and also in Paged the atmo continued playing muted.

REDMINE-17786

[1] https://github.com/katspaugh/wavesurfer.js/blob/7af166d97009afd9e6b98726968dd0af3e1126b1/src/wavesurfer.js#L906

[2] https://github.com/codevise/pageflow/blob/master/vendor/assets/javascripts/audio5.min.js#L980