### PR TITLE
Prevent empty space below entry

### DIFF
--- a/entry_types/scrolled/package/src/frontend/transitions/revealFadeOut.module.css
+++ b/entry_types/scrolled/package/src/frontend/transitions/revealFadeOut.module.css
@@ -3,7 +3,10 @@
 .backdrop {
   composes: clip from '../utils.module.css';
   position: absolute;
-  height: 200%;
+  /* We only want to clip the backdrop at the top. Extend it by the
+     height of one viewport to ensure it is still visible when the fade
+     is happening. */
+  height: calc(100% + 100vh);
 }
 
 .backdropInner {

--- a/entry_types/scrolled/package/src/frontend/transitions/revealFadeOutBg.module.css
+++ b/entry_types/scrolled/package/src/frontend/transitions/revealFadeOutBg.module.css
@@ -3,7 +3,10 @@
 .backdrop {
   composes: clip from '../utils.module.css';
   position: absolute;
-  height: 200%;
+  /* We only want to clip the backdrop at the top. Extend it by the
+     height of one viewport to ensure it is still visible when the fade
+     is happening. */
+  height: calc(100% + 100vh);
 }
 
 .backdropInner {


### PR DESCRIPTION
Reveal/fade out sections need to make their backdrop longer to apply
the clipping effect only at the top. Using height 200% works is the
same as 200vh as long as the section does not have a lot of
content. For longer sections this causes the backdrop to extend beyond
the next section. Change height to account for longer sections.

REDMINE-17838