### PR TITLE
Deal with duplicated rules in extracted CSS

### DIFF
--- a/entry_types/scrolled/package/src/frontend/PlayerControls/MenuBarButton.module.css
+++ b/entry_types/scrolled/package/src/frontend/PlayerControls/MenuBarButton.module.css
@@ -56,7 +56,12 @@
 .subMenuItemButton {
   composes: unstyledButton from '../utils.module.css';
   width: 100%;
-  padding: 5px 10px 5px 25px;
   color: #fff;
   white-space: nowrap;
+}
+
+/* see https://github.com/css-modules/css-modules/issues/195
+   and https://github.com/egoist/rollup-plugin-postcss/issues/26 */
+button.subMenuItemButton {
+  padding: 5px 10px 5px 25px;
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,6 +44,7 @@ const plugins = ({extractCss} = {}) => [
   postcss({
     modules: true,
     extract: extractCss,
+    minimize: extractCss,
     plugins: [autoprefixer]
   }),
   babel({


### PR DESCRIPTION
CSS modules rules can not reliably override rules from composed rules
[1]. Use more specific selector to ensure menu button can override
padding of unstyled button.

PostCSS Rollup plugin generates duplicate rules when importing another
rule in multiple places [2]. Enable minification to remove those
duplicates in extracted CSS.

REDMINE-17871

[1] see https://github.com/css-modules/css-modules/issues/195
[2] https://github.com/egoist/rollup-plugin-postcss/issues/26