### PR TITLE
Do not fail if media element for waveform cannot be found

### DIFF
--- a/entry_types/scrolled/package/src/frontend/PlayerControls/WaveformPlayerControls/Wavesurfer.js
+++ b/entry_types/scrolled/package/src/frontend/PlayerControls/WaveformPlayerControls/Wavesurfer.js
@@ -260,11 +260,13 @@ class Wavesurfer extends Component {
     if (selectorOrElt instanceof global.HTMLElement) {
       this._loadAudio(selectorOrElt, audioPeaks);
     } else {
-      if (!global.document.querySelector(selectorOrElt)) {
-        throw new Error('Media Element not found!');
+      // Ignore if media element cannot be found. There are edge cases
+      // where React already unmounted the corresponding media element,
+      // but the parent Waveform component still holds the old media
+      // element id.
+      if (global.document.querySelector(selectorOrElt)) {
+        this._loadAudio(global.document.querySelector(selectorOrElt), audioPeaks);
       }
-
-      this._loadAudio(global.document.querySelector(selectorOrElt), audioPeaks);
     }
   }
 


### PR DESCRIPTION
When adding a caption to a waveform audio content element, the
`Waveform` and the `MediaPlayer` components get unmounted and
recreated wrapped in a `Figure` component. Removing the `MediaPlayer`
dispatches the `discardMediaElementId` action, but this only gets
processed for the next render. When the `Waveform` component is
mounted wrapped in the `Figure` component, the stored media element id
has not yet changed, still the `MediaPlayer` component is not yet
mounted again. Trying to look up the media element fails.

If we ignore the missing media element. The `Waveform` will get
unmounted again once the `discardMediaElementId` action has been
processed. Once the new `Audio` component has been mounted it
dispatches a `saveMediaElementId` action which in turn causes a new
`Waveform` component to be rendered. This time looking up the media
element succeeds.

REDMINE-17677