### PR TITLE
Improve scrolled editor blank slate

### DIFF
--- a/app/assets/stylesheets/pageflow/editor/base.scss
+++ b/app/assets/stylesheets/pageflow/editor/base.scss
@@ -1,5 +1,7 @@
 @import "bourbon";
 
+@import "pageflow/fonts";
+
 @import "pageflow/jquery_ui";
 @import "pageflow/ui";
 @import "pageflow/animations";

--- a/entry_types/scrolled/config/locales/new/de.yml
+++ b/entry_types/scrolled/config/locales/new/de.yml
@@ -552,8 +552,6 @@ de:
         create_chapter: Klicke jetzt auf <em>Neues Kapitel</em>, um ein erstes Kapitel zu erstellen.
         create_section: Klicke dann auf <em>Neuer Abschnitt</em>, um dem Kapitel einen ersten Abschnitt hinzuzufügen.
         create_content_element: Über die <em>Plus-Buttons</em> in der Vorschau kannst Du Elemente hinzufügen.
-        edit_content_element: Klicke auf Elemente in der Vorschau, um ihre Einstellungen in der Seitenleiste zu bearbeiten.
-        edit_section: Klicke auf eine freie Fläche, um den Abschnitt zu markieren.
         header: Dies ist ein leerer Pageflow.
         intro: Pageflows bestehen aus Kapiteln und Abschnitten. In der Seitenleiste rechts findest Du die Gliederung.
         outro: Hier siehst Du dann die Vorschau deines Pageflows.

--- a/entry_types/scrolled/config/locales/new/en.yml
+++ b/entry_types/scrolled/config/locales/new/en.yml
@@ -460,8 +460,6 @@ en:
         create_chapter: Click <em>New chapter</em> to create your first chapter.
         create_section: Click <em>New section</em> within the chapter to add a section.
         create_content_element: Use the <em>Plus buttons</em> inside the preview to add text blocks and other elements.
-        edit_content_element: Click on elements in the preview and edit their settings in the sidebar.
-        edit_section: Click an empty space to select a section.
         header: This is an empty Pageflow.
         intro: Pageflows consist of chapters and sections. The sidebar on the right shows the outline of your story.
         outro: In this area, a live preview will be shown.

--- a/entry_types/scrolled/package/src/editor/views/BlankEntryView.js
+++ b/entry_types/scrolled/package/src/editor/views/BlankEntryView.js
@@ -12,8 +12,6 @@ export const BlankEntryView = Marionette.ItemView.extend({
         <li>${t('pageflow_scrolled.editor.blank_entry.create_chapter')}</li>
         <li>${t('pageflow_scrolled.editor.blank_entry.create_section')}</li>
         <li>${t('pageflow_scrolled.editor.blank_entry.create_content_element')}</li>
-        <li>${t('pageflow_scrolled.editor.blank_entry.edit_content_element')}</li>
-        <li>${t('pageflow_scrolled.editor.blank_entry.edit_section')}</li>
       </ol>
       <p>${t('pageflow_scrolled.editor.blank_entry.outro')}</p>
     </div>


### PR DESCRIPTION
* Blank slate styles in `pageflow/editor` use Source Sans Pro. So far
  that was only defined in `pageflow/application.scss`. Also import it
  `pageflow/editor.scss` to make it available for Pageflow
  Scrolled. For Paged the duplicate definition should not hurt.

* Since the blank slate page disappears as soon as the first section
  has been added, it does not make sense to include steps with
  instructions about adding and editing content elements. Keep a third
  item since there maybe is a chance that the user reads ahead one
  item and since a two item list looks weird.

REDMINE-17841