### PR TITLE
Let first chapter begin at the very top

### DIFF
--- a/entry_types/scrolled/package/src/frontend/Entry.module.css
+++ b/entry_types/scrolled/package/src/frontend/Entry.module.css
@@ -5,3 +5,9 @@
   background-color: #000;
   color: #fff;
 }
+
+.Entry > div:first-child {
+  /* Let content begin below navigation bar. Navigation bar has zero
+     height to let first chapter start at the very top. */
+  padding-top: 58px;
+}

--- a/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
@@ -17,6 +17,7 @@
   z-index: 10000;
   width: 100%;
   text-align: center;
+  height: 0;
 }
 
 .navigationBarExpanded {


### PR DESCRIPTION
Prevent scrolling when clicking the first chapter link after loading
the document. Before, the first chapter began right below the
navigation bar. Now the navigation bar no longer has a height. We have
added a padding to the first chapter to prevent content or the section
selection rect from being hidden behind the navigation bar.

REDMINE-17874