### PR TITLE
Fix progress indicator in scrolled navigation bar

### DIFF
--- a/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
@@ -79,6 +79,7 @@
 }
 
 .progressBar {
+  position: relative;
   background-color: rgba(194,194,194,0.8);
   height: 8px;
   width: 100%;


### PR DESCRIPTION
Setting the height of the navigation bar to zero to make the first
chapter start at the very top (codevise/pageflow#1568) broke the
position of the red progress indicator. Turn progress bar into offset
parent of indicator.

REDMINE-17877