### PR TITLE
Wait for feature detection before booting editor

### DIFF
--- a/package/src/editor/base.js
+++ b/package/src/editor/base.js
@@ -17,18 +17,14 @@ export const startEditor = function(options) {
   I18n.translations = window.I18n.translations;
 
   $(function() {
-    editor.ensureBrowserSupport(() => { 
-      $.when(
+    editor.ensureBrowserSupport(() => {
+      Promise.all([
         $.getJSON('/editor/entries/' + options.entryId + '/seed'),
         browser.detectFeatures()
-      )
-        .done(function(result) {
-          app.start(result[0]);
-        })
-        .fail(function() {
-          alert('Error while starting editor.');
-        });
+      ]).then(
+        result => app.start(result[0]),
+        () => alert('Error while starting editor.')
+      );
     });
   });
-  
 };


### PR DESCRIPTION
`browser.detectFeatures` now returns a native `Promise` object. This
is not recognized as a promise by our version of `jQuery.when`. This
causes the editor to start before feature detection finished when
loading the seed data completes too fast. Code trying to access
browser featues then fails with a "Feature detection has not finished
yet" error.

`Promise.all` works for any "thenable" - in paricular jQuery promises
[1].

REDMINE-17882

[1] https://stackoverflow.com/questions/25061336/ecmascript-promise-all-method-works-with-jquery-deferred-why