### PR TITLE
Renders alt text for media

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/AudioPlayer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/AudioPlayer-spec.js
@@ -175,6 +175,6 @@ describe('AudioPlayer', () => {
         })
       });
 
-    expect(result.container.querySelector('audio')).toHaveAttribute('alt', ' ');
+    expect(result.container.querySelector('audio').hasAttribute('alt')).toBe(true);
   });
 });

--- a/entry_types/scrolled/package/spec/frontend/AudioPlayer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/AudioPlayer-spec.js
@@ -136,4 +136,45 @@ describe('AudioPlayer', () => {
       })
     );
   });
+
+  it('renders alt text', () => {
+    function getAudioFileSeedWithConfiguration({
+      id = 1,
+      permaId = 100,
+      basename = 'audio'
+    } = {}) {
+      return {
+        fileUrlTemplates: {
+          audioFiles: {
+            mp3: ':id_partition/:basename.mp3',
+            m4a: ':id_partition/:basename.m4a',
+            ogg: ':id_partition/:basename.ogg'
+          }
+        },
+        audioFiles: [
+          {id, permaId, isReady: true, basename, configuration: {alt: 'jingle'}}
+        ]
+      };
+    }
+
+    const result =
+      renderInEntry(<AudioPlayer {...requiredProps()} id={100} />, {
+        seed: getAudioFileSeedWithConfiguration({
+          permaId: 100
+        })
+      });
+
+    expect(result.container.querySelector('audio')).toHaveAttribute('alt', 'jingle');
+  });
+
+  it('renders empty alt attr', () => {
+    const result =
+      renderInEntry(<AudioPlayer {...requiredProps()} id={100} />, {
+        seed: getAudioFileSeed({
+          permaId: 100
+        })
+      });
+
+    expect(result.container.querySelector('audio')).toHaveAttribute('alt', ' ');
+  });
 });

--- a/entry_types/scrolled/package/spec/frontend/Image-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/Image-spec.js
@@ -185,6 +185,6 @@ describe('Image', () => {
         }
       });
 
-    expect(getByRole('img')).toHaveAttribute('alt', ' ');
+    expect(getByRole('img').hasAttribute('alt')).toBe(true);
   });
 });

--- a/entry_types/scrolled/package/spec/frontend/Image-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/Image-spec.js
@@ -155,4 +155,36 @@ describe('Image', () => {
                                          'name': 'some author'
                                        }});
   });
+
+  it('render alt text', () => {
+    const {getByRole} =
+      renderInEntry(<Image id={100} />, {
+        seed: {
+          imageFileUrlTemplates: {
+            large: ':id_partition/image.jpg'
+          },
+          imageFiles: [
+            {id: 1, permaId: 100, configuration: {alt: 'water'}}
+          ]
+        }
+      });
+
+    expect(getByRole('img')).toHaveAttribute('alt', 'water');
+  });
+
+  it('render empty alt attr', () => {
+    const {getByRole} =
+      renderInEntry(<Image id={100} />, {
+        seed: {
+          imageFileUrlTemplates: {
+            large: ':id_partition/image.jpg'
+          },
+          imageFiles: [
+            {id: 1, permaId: 100}
+          ]
+        }
+      });
+
+    expect(getByRole('img')).toHaveAttribute('alt', ' ');
+  });
 });

--- a/entry_types/scrolled/package/spec/frontend/VideoPlayer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/VideoPlayer-spec.js
@@ -135,4 +135,40 @@ describe('VideoPlayer', () => {
       })
     );
   });
+
+  it('renders alt text', () => {
+    function getVideoFileSeedWithConfiguration({
+      id = 1,
+      permaId = 100,
+      basename = 'video'
+    } = {}) {
+      return {
+        fileUrlTemplates: {
+          videoFiles: {
+            medium: ':id_partition/medium/:basename.mp4',
+            high: ':id_partition/high/:basename.mp4'
+          }
+        },
+        videoFiles: [
+          {id, permaId, isReady: true, basename, configuration: {alt: 'interview'}}
+        ]
+      };
+    }
+
+    const result =
+      renderInEntry(<VideoPlayer {...requiredProps()} id={100} />, {
+        seed: getVideoFileSeedWithConfiguration({permaId: 100})
+      });
+
+    expect(result.container.querySelector('video')).toHaveAttribute('alt', 'interview');
+  });
+
+  it('renders empty alt attr', () => {
+    const result =
+      renderInEntry(<VideoPlayer {...requiredProps()} id={100} />, {
+        seed: getVideoFileSeed({permaId: 100})
+      });
+
+    expect(result.container.querySelector('video')).toHaveAttribute('alt', ' ');
+  });
 });

--- a/entry_types/scrolled/package/spec/frontend/VideoPlayer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/VideoPlayer-spec.js
@@ -169,6 +169,6 @@ describe('VideoPlayer', () => {
         seed: getVideoFileSeed({permaId: 100})
       });
 
-    expect(result.container.querySelector('video')).toHaveAttribute('alt', ' ');
+    expect(result.container.querySelector('video').hasAttribute('alt')).toBe(true);
   });
 });

--- a/entry_types/scrolled/package/src/frontend/AudioPlayer/index.js
+++ b/entry_types/scrolled/package/src/frontend/AudioPlayer/index.js
@@ -42,7 +42,7 @@ export function AudioPlayer(props) {
                        sources={processSources(audioFile)}
                        textTracksInset={props.position === 'full'}
                        posterImageUrl={posterImage && posterImage.isReady ? posterImage.urls.large : undefined}
-                       altText={audioFile.configuration.alt ? audioFile.configuration.alt : ' '}
+                       altText={audioFile.configuration.alt}
                        {...props} />
           <AudioStructuredData file={audioFile} />
         </div>

--- a/entry_types/scrolled/package/src/frontend/AudioPlayer/index.js
+++ b/entry_types/scrolled/package/src/frontend/AudioPlayer/index.js
@@ -42,6 +42,7 @@ export function AudioPlayer(props) {
                        sources={processSources(audioFile)}
                        textTracksInset={props.position === 'full'}
                        posterImageUrl={posterImage && posterImage.isReady ? posterImage.urls.large : undefined}
+                       altText={audioFile.configuration.alt ? audioFile.configuration.alt : ' '}
                        {...props} />
           <AudioStructuredData file={audioFile} />
         </div>

--- a/entry_types/scrolled/package/src/frontend/Image.js
+++ b/entry_types/scrolled/package/src/frontend/Image.js
@@ -35,7 +35,7 @@ function renderImageTag(props, image) {
   return (
     <img className={classNames(styles.root)}
          src={image.urls[props.variant]}
-         alt={image.configuration.alt ? image.configuration.alt : ' '}
+         alt={image.configuration.alt? image.configuration.alt : ''}
          style={{
            objectPosition: `${focusX}% ${focusY}%`
          }} />

--- a/entry_types/scrolled/package/src/frontend/Image.js
+++ b/entry_types/scrolled/package/src/frontend/Image.js
@@ -35,6 +35,7 @@ function renderImageTag(props, image) {
   return (
     <img className={classNames(styles.root)}
          src={image.urls[props.variant]}
+         alt={image.configuration.alt ? image.configuration.alt : ' '}
          style={{
            objectPosition: `${focusX}% ${focusY}%`
          }} />

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/PlayerContainer.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/PlayerContainer.js
@@ -5,7 +5,7 @@ import {useAtmo} from '../useAtmo';
 import './videojsBase.module.css';
 
 function PlayerContainer({
-  filePermaId, className, sources, textTrackSources, poster, type, playsInline, loop, controls, mediaEventsContextData, atmoDuringPlayback, onSetup, onDispose
+  filePermaId, className, sources, textTrackSources, poster, type, playsInline, loop, controls, mediaEventsContextData, atmoDuringPlayback, onSetup, onDispose, altText
 }){
   const playerWrapperRef = useRef(null);
   let atmo = useAtmo();
@@ -23,7 +23,8 @@ function PlayerContainer({
         loop: loop,
         controls: controls,
         hooks: atmoDuringPlayback ? atmo.createMediaPlayerHooks(atmoDuringPlayback) : {}, //create hooks only for inline media players
-        mediaEventsContextData
+        mediaEventsContextData,
+        altText
       });
 
       let playerElement = player.el();

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/index.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/index.js
@@ -77,7 +77,8 @@ function PreparedMediaPlayer(props){
                        mediaEventsContextData={eventContextData}
                        atmoDuringPlayback={props.atmoDuringPlayback}
                        onSetup={onSetup}
-                       onDispose={onDispose} />
+                       onDispose={onDispose}
+                       altText={props.altText} />
       <div className={styles.mask} onClick={props.onClick} />
     </>
   );

--- a/entry_types/scrolled/package/src/frontend/VideoPlayer/index.js
+++ b/entry_types/scrolled/package/src/frontend/VideoPlayer/index.js
@@ -43,6 +43,7 @@ export function VideoPlayer(props) {
                        sources={sources(videoFile, activeQuality)}
                        textTracksInset={props.position === 'full'}
                        posterImageUrl={posterImage && posterImage.isReady ? posterImage.urls.large : undefined}
+                       altText={videoFile.configuration.alt ? videoFile.configuration.alt : ' '}
                        {...props} />
           <VideoStructuredData file={videoFile} />
         </>

--- a/entry_types/scrolled/package/src/frontend/VideoPlayer/index.js
+++ b/entry_types/scrolled/package/src/frontend/VideoPlayer/index.js
@@ -43,7 +43,7 @@ export function VideoPlayer(props) {
                        sources={sources(videoFile, activeQuality)}
                        textTracksInset={props.position === 'full'}
                        posterImageUrl={posterImage && posterImage.isReady ? posterImage.urls.large : undefined}
-                       altText={videoFile.configuration.alt ? videoFile.configuration.alt : ' '}
+                       altText={videoFile.configuration.alt}
                        {...props} />
           <VideoStructuredData file={videoFile} />
         </>

--- a/package/spec/frontend/media/media_spec.js
+++ b/package/spec/frontend/media/media_spec.js
@@ -51,6 +51,16 @@ describe('media', function() {
       expect(player.getMediaElement().getAttribute('loop')).toBe('');
     });
 
+    it('sets alt attribute to player', function () {
+      let player = media.getPlayer(fileSources, {
+        tagName: 'audio',
+        altText: 'audio file'
+      });
+
+      expect(player.getMediaElement().hasAttribute('alt')).toBe(true);
+      expect(player.getMediaElement().getAttribute('alt')).toBe('audio file');
+    });
+
     it('updates player\'s context data', () => {
       let context = {
         page: {

--- a/package/src/frontend/media/MediaPool.js
+++ b/package/src/frontend/media/MediaPool.js
@@ -45,7 +45,7 @@ export class MediaPool {
     player = this.unAllocatedPlayers[playerType].pop();
     if (player) {
 
-      player.el().children[0].setAttribute('alt', altText); //add alt texts;
+      player.getMediaElement().setAttribute('alt', altText);
       player.pause();
       player.getMediaElement().loop = loop
       player.poster(poster);

--- a/package/src/frontend/media/MediaPool.js
+++ b/package/src/frontend/media/MediaPool.js
@@ -33,7 +33,7 @@ export class MediaPool {
     }
   }
   allocatePlayer({playerType, playerId, playsInline, mediaEventsContextData,
-                  hooks, poster, loop = false, controls = false}){
+                  hooks, poster, loop = false, controls = false, altText}){
     let player = undefined;
     if (!this.unAllocatedPlayers[playerType]) {
       this.populateMediaPool_();
@@ -44,7 +44,8 @@ export class MediaPool {
 
     player = this.unAllocatedPlayers[playerType].pop();
     if (player) {
-      
+
+      player.el().children[0].setAttribute('alt', altText); //add alt texts;
       player.pause();
       player.getMediaElement().loop = loop
       player.poster(poster);


### PR DESCRIPTION
REDMINE-17864

It renders alt texts if provided or empty
text for all background and inline images,
videos, and audios

beforeAfter images already had a mechanism
to render alt texts

We already get the files in video, and audio player.
It sends the value to MediaPool where it adds the attribute
to the player