### PR TITLE
String literals in SQL should only be enclosed by single quotes

### DIFF
--- a/app/models/pageflow/account_role_query.rb
+++ b/app/models/pageflow/account_role_query.rb
@@ -32,7 +32,7 @@ module Pageflow
           INNER JOIN pageflow_memberships ON
           pageflow_memberships.user_id = :user_id AND
           pageflow_memberships.entity_id = pageflow_accounts.id AND
-          pageflow_memberships.entity_type = "Pageflow::Account" AND
+          pageflow_memberships.entity_type = 'Pageflow::Account' AND
           pageflow_memberships.role IN (:roles)
         SQL
       end

--- a/app/models/pageflow/managed_user_query.rb
+++ b/app/models/pageflow/managed_user_query.rb
@@ -26,7 +26,7 @@ module Pageflow
         <<-SQL
           INNER JOIN pageflow_memberships account_memberships ON
           account_memberships.user_id = users.id AND
-          account_memberships.entity_type = "Pageflow::Account"
+          account_memberships.entity_type = 'Pageflow::Account'
         SQL
       end
 

--- a/app/policies/pageflow/folder_policy.rb
+++ b/app/policies/pageflow/folder_policy.rb
@@ -24,9 +24,9 @@ module Pageflow
         user.accounts.joins(sanitize_sql_array([
           'LEFT OUTER JOIN pageflow_memberships as pageflow_memberships_2 ON ' \
           'pageflow_memberships_2.user_id = :user_id AND ' \
-          'pageflow_memberships_2.entity_type = "Pageflow::Account" AND ' \
+          'pageflow_memberships_2.entity_type = \'Pageflow::Account\' AND ' \
           'pageflow_memberships_2.entity_id = pageflow_accounts.id AND ' \
-          'pageflow_memberships_2.role IN ("previewer", "editor", "publisher", "manager")',
+          'pageflow_memberships_2.role IN (\'previewer\', \'editor\', \'publisher\', \'manager\')',
           user_id: user.id])).where('pageflow_memberships_2.entity_id IS NOT NULL')
       end
     end

--- a/app/policies/pageflow/membership_policy.rb
+++ b/app/policies/pageflow/membership_policy.rb
@@ -19,9 +19,9 @@ module Pageflow
       private
 
       def permissions_appropriate
-        sanitize_sql_array(['pageflow_memberships.entity_type = "Pageflow::Account" AND ' \
+        sanitize_sql_array(['pageflow_memberships.entity_type = \'Pageflow::Account\' AND ' \
                             'pageflow_memberships.entity_id IN (:managed_account_ids) OR ' \
-                            'pageflow_memberships.entity_type = "Pageflow::Entry" AND ' \
+                            'pageflow_memberships.entity_type = \'Pageflow::Entry\' AND ' \
                             'pageflow_memberships.entity_id IN (:common_entry_ids) OR '\
                             'pageflow_memberships.user_id = :user_id',
                             managed_account_ids: managed_account_ids,

--- a/app/policies/pageflow/theming_policy.rb
+++ b/app/policies/pageflow/theming_policy.rb
@@ -25,8 +25,8 @@ module Pageflow
                             'pageflow_memberships.user_id = :user_id AND ' \
                             'pageflow_themings.account_id IN (:accounts_ids) AND ' \
                             'pageflow_memberships.entity_id IN (:accounts_ids) AND ' \
-                            'pageflow_memberships.entity_type = "Pageflow::Account" AND ' \
-                            'pageflow_memberships.role IN ("publisher", "manager")',
+                            'pageflow_memberships.entity_type = \'Pageflow::Account\' AND ' \
+                            'pageflow_memberships.role IN (\'publisher\', \'manager\')',
                             user_id: user.id, accounts_ids: accounts_ids])
       end
 

--- a/app/policies/pageflow/user_policy.rb
+++ b/app/policies/pageflow/user_policy.rb
@@ -16,7 +16,7 @@ module Pageflow
                                  .new(@user, Account).member_addable.map(&:id)
 
           scope.joins(:memberships)
-            .where('pageflow_memberships.entity_type = "Pageflow::Account"')
+            .where('pageflow_memberships.entity_type = \'Pageflow::Account\'')
             .where(membership_in_managed_account(manager_accounts_ids)).distinct
         end
       end


### PR DESCRIPTION
Double quotes will work with mysql, but will break postgresql.
This fixes an error message after logging in with a non-admin user, while using a postgresql db.