### PR TITLE
Fix Jest warnings caused by Backbone XHR

### DIFF
--- a/entry_types/scrolled/package/spec/editor/controllers/PreviewMessageController-spec.js
+++ b/entry_types/scrolled/package/spec/editor/controllers/PreviewMessageController-spec.js
@@ -8,10 +8,13 @@ import {
   postUpdateTransientContentElementStateMessage
 } from 'frontend/inlineEditing/postMessage';
 import {setupGlobals} from 'pageflow/testHelpers';
-import {normalizeSeed, factories, createIframeWindow} from 'support';
+import {useFakeXhr, normalizeSeed, factories, createIframeWindow} from 'support';
 
 describe('PreviewMessageController', () => {
-  let controller;
+  let controller, testContext;
+
+  beforeEach(() => testContext = {});
+  useFakeXhr(() => testContext);
 
   afterEach(() => {
     // Remove post message event listener


### PR DESCRIPTION
Use fake XHR to ignore request caused by auto saving models.