### PR TITLE
Work around Minicolors problem with updating swatches

### DIFF
--- a/package/src/ui/views/inputs/ColorInputView.js
+++ b/package/src/ui/views/inputs/ColorInputView.js
@@ -68,12 +68,24 @@ export const ColorInputView = Marionette.ItemView.extend({
   },
 
   updateSettings: function() {
+    this.resetSwatchesInStoredSettings();
+
     this.ui.input.minicolors('settings', {
       defaultValue: this.defaultValue(),
       swatches: this.getSwatches()
     });
 
     this.load();
+  },
+
+  // see https://github.com/claviska/jquery-minicolors/issues/287
+  resetSwatchesInStoredSettings: function() {
+    const settings = this.ui.input.data('minicolors-settings');
+
+    if (settings) {
+      delete settings.swatches;
+      this.ui.input.data('minicolors-settings', settings);
+    }
   },
 
   load: function() {


### PR DESCRIPTION
Minicolors can not handle when settings are updated with a shorter
array of swatches than initially passed (see
https://github.com/claviska/jquery-minicolors/issues/287).

Minicolors converts the swatch strings to object and stores the
converted settings. When settings are updated, the new settings and
the old are deeply merged. If the new settings contain less swatch
colors, merging in the old settings adds a bunch of items to the
swatches array that have already been converted to objects. When
Minicolor proceeds to process the settings then, it cannot handle the
already converted items in the swatches array.

Minicolors stores its settings via `jQuery#data`. So before updating
the settings, we now remove the `swatches` property from the stored
settings. This way the settings object resulting from the deep merge
will only contan the new swatch color values.

REDMINE-17994