### PR TITLE
Remove renderer memoization in development

### DIFF
--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/react_server_side_rendering_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/react_server_side_rendering_helper.rb
@@ -13,11 +13,11 @@ module PageflowScrolled
     end
 
     def self.renderer
-      @renderer ||=
-        ReactRenderer
-        .new(files: ['pageflow-scrolled-server.js'],
-             # Define required external globals.
-             code: 'function videojs() {};')
+      if Rails.env.development?
+        ReactServerSideRenderingHelper.new_renderer
+      else
+        @renderer ||= ReactServerSideRenderingHelper.new_renderer
+      end
     end
 
     # Normally react-rails either tries to auto detect which asset
@@ -28,6 +28,13 @@ module PageflowScrolled
       def asset_container_class
         ::React::ServerRendering::WebpackerManifestContainer
       end
+    end
+
+    def self.new_renderer
+      ReactRenderer
+        .new(files: ['pageflow-scrolled-server.js'],
+             # Define required external globals.
+             code: 'function videojs() {};')
     end
   end
 end


### PR DESCRIPTION
Having to restart the Rails server to synchronize server- and
client-side JS introduces an additional error source in many dev scenarios that
otherwise don't have anything to do with the SSR/CSR distinction.

To avoid this, we only memoize the renderer in environments that
aren't development.

REDMINE-18013