### PR TITLE
Fix error when merging empty text blocks

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/textBlock/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/textBlock/editor.js
@@ -23,9 +23,15 @@ editor.contentElementTypes.register('textBlock', {
   },
 
   merge(configurationA, configurationB) {
+    // Value might still be empty if text block has not been edited
+    const value = (configurationA.value || []).concat(configurationB.value || []);
+
     return {
       ...configurationA,
-      value: configurationA.value.concat(configurationB.value),
+      // Slate.js does not like empty arrays as value.
+      // `inlineEditing/EditableText` sets default value, but only if
+      // `value` is falsy.
+      value: value.length ? value : undefined,
     };
   },
 


### PR DESCRIPTION
When deleting a content element that sits between two text blocks that
have not yet been edited, `merge` needs to handle configurations that
do not contain `value` properties.

REDMINE-17968