### PR TITLE
Prevent resuming atmo of other section

### DIFF
--- a/entry_types/scrolled/package/src/frontend/Atmo.js
+++ b/entry_types/scrolled/package/src/frontend/Atmo.js
@@ -66,9 +66,9 @@ export class Atmo {
       return this.multiPlayer.changeVolumeFactor(1);
     }
   }
-  update() {    
+  update() {
     if (!this.disabled) {
-      if (this.backgroundMedia.muted || this.atmoSourceId == undefined) {
+      if (this.backgroundMedia.muted) {
         this.multiPlayer.fadeOutAndPause();
       }
       else {

--- a/entry_types/scrolled/package/src/frontend/useAtmo.js
+++ b/entry_types/scrolled/package/src/frontend/useAtmo.js
@@ -34,11 +34,9 @@ export function AtmoProvider({children}){
 
   let updateAtmo = function ({audioFilePermaId, sources}) {
     let currentAtmo = atmoConfig.current;
-    if (currentAtmo.atmo) {
-      if (sources) {
-        currentAtmo.pool.mapSources(audioFilePermaId, sources);
-      }
 
+    if (currentAtmo.atmo) {
+      currentAtmo.pool.mapSources(audioFilePermaId, sources);
       currentAtmo.atmo.atmoSourceId = audioFilePermaId;
       currentAtmo.atmo.update();
     }

--- a/package/spec/frontend/media/PlayerSourceIDMap_spec.js
+++ b/package/spec/frontend/media/PlayerSourceIDMap_spec.js
@@ -44,6 +44,19 @@ describe('PlayerSourceIDMap', () => {
     expect(media.releasePlayer).toHaveBeenCalledWith(firstPlayer);
   });
 
+  it('does not request same player again', () => {
+    const media = fakeMedia();
+    const map = new PlayerSourceIDMap(media)
+    const sources = [{src: 'some/audio.mp3'}];
+
+    map.mapSources(5, sources);
+    map.get(5);
+    map.get(5);
+
+    expect(media.releasePlayer).not.toHaveBeenCalled();
+    expect(media.getPlayer).toHaveBeenCalledTimes(1);
+  });
+
   it('reuses previous player if it is requested again', () => {
     const media = fakeMedia();
     const map = new PlayerSourceIDMap(media, {playerOptions: {some: 'option'}})
@@ -57,6 +70,27 @@ describe('PlayerSourceIDMap', () => {
 
     expect(media.releasePlayer).not.toHaveBeenCalled();
     expect(media.getPlayer).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null players for undefined id', () => {
+    const media = fakeMedia();
+    const map = new PlayerSourceIDMap(media)
+
+    const player = map.get(undefined);
+
+    expect(player.play).toBeDefined();
+    expect(media.getPlayer).not.toHaveBeenCalled();
+  });
+
+  it('returns null players if undefined sources have been stored', () => {
+    const media = fakeMedia();
+    const map = new PlayerSourceIDMap(media)
+
+    map.mapSources(5, undefined);
+    const player = map.get(5);
+
+    expect(player.play).toBeDefined();
+    expect(media.getPlayer).not.toHaveBeenCalled();
   });
 
   function fakeMedia() {

--- a/package/src/frontend/media/PlayerSourceIDMap.js
+++ b/package/src/frontend/media/PlayerSourceIDMap.js
@@ -1,3 +1,5 @@
+import {AudioPlayer} from '../AudioPlayer';
+
 export const PlayerSourceIDMap = function (media, {playerOptions} = {}) {
   return {
     current: undefined,
@@ -6,6 +8,13 @@ export const PlayerSourceIDMap = function (media, {playerOptions} = {}) {
       this[id] = sources;
     },
     get: function (sourceID) {
+      if (!this[sourceID]) {
+        return new AudioPlayer.Null();
+      }
+
+      if (this.current && this.current.playerId === sourceID) {
+        return this.current;
+      }
       if (this.previous && this.previous.playerId === sourceID) {
         let holder = this.current;
         this.current = this.previous;


### PR DESCRIPTION
Before, changing to a section without atmo only paused the atmo multi
player without changing its current file id. When a media content
element in a section without atmo was then set to turn down atmo
during playback, pausing the media element resumed the atmo that had
been playing for a previous section.

To work around this issue, we always fade the multiplayer on section
change - even to an undefined audio file perma id if non is given. We
change the `PlayerSourceIDMap` to return a `Null` player if no sources
can be found for the passed id. When moving back and forth between a
section with atmo and an adjacent section without atmo, this will now
cause players for the same audio file to be requested whenever we
enter the section with atmo. To prevent creating multiple players in
this case, we change the map to return the current player if it
matches the passed audio file id.

Now that undefined sources are a handled case, we can also fix another
issue. So far, sources were only ever added to the
`PlayerSourceIDMap`. When deleting an audio file that was previously
used as atmo, the sources would remain in the map, causing the atmo to
contnue playing every time the section is encountered, even though the
file is no longer visible in the atmo input view.  After reloading the
entry, players for undefined sources were requested.

We therefore update `SectionAtmo` to update the sources mapping also
when no sources are found. That way atmo continues playing, when the
file is deleted. But once the section is left and entered again the
mapping will be updated and no atmo will be played.

REDMINE-18017