### PR TITLE
Retry js specs of pageflow engine

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
           - engine-name: pageflow
             engine-directory: .
-            rspec-command: bin/rspec --tag js
+            rspec-command: bin/rspec-with-retry --tag js
 
           - engine-name: pageflow_paged
             engine-directory: entry_types/paged

--- a/bin/rspec-with-retry
+++ b/bin/rspec-with-retry
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Used to run flaky js specs multiple times
+
+for i in {1..3}; do
+  bin/rspec $@
+  e=$?
+  [[ $e -gt 0 ]] && echo Retry || exit $e;
+done;
+
+exit 1

--- a/entry_types/scrolled/bin/rspec-with-retry-on-timeout
+++ b/entry_types/scrolled/bin/rspec-with-retry-on-timeout
@@ -5,8 +5,6 @@
 # If Chrome Driver hangs, the timeout command will exit with 137.
 # Retry or else exit with original exit status of rspec command.
 
-cd entry_types/scrolled
-
 for i in {1..10}; do
   timeout --signal=KILL 30 bin/rspec $@
   e=$?


### PR DESCRIPTION
Make overall test run less flaky. Since those specs run in a separate
job, they are quite fast to retry.

REDMINE-18078