### PR TITLE
Stub Paperclip by default in specs 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
           - engine-name: pageflow
             engine-directory: .
-            rspec-command: bin/rspec --tag js
+            rspec-command: bin/rspec-with-retry --tag js
 
           - engine-name: pageflow_paged
             engine-directory: entry_types/paged

--- a/bin/rspec-with-retry
+++ b/bin/rspec-with-retry
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Used to run flaky js specs multiple times
+
+for i in {1..3}; do
+  bin/rspec $@
+  e=$?
+  [[ $e -gt 0 ]] && echo Retry || exit $e;
+done;
+
+exit 1

--- a/entry_types/scrolled/bin/rspec-with-retry-on-timeout
+++ b/entry_types/scrolled/bin/rspec-with-retry-on-timeout
@@ -5,8 +5,6 @@
 # If Chrome Driver hangs, the timeout command will exit with 137.
 # Retry or else exit with original exit status of rspec command.
 
-cd entry_types/scrolled
-
 for i in {1..10}; do
   timeout --signal=KILL 30 bin/rspec $@
   e=$?

--- a/entry_types/scrolled/spec/pageflow_scrolled/seeds_spec.rb
+++ b/entry_types/scrolled/spec/pageflow_scrolled/seeds_spec.rb
@@ -128,7 +128,7 @@ module PageflowScrolled
           expect(created_content_elements.last.configuration['children']).to eq('Some content')
         end
 
-        context 'files referenced', stub_paperclip: true do
+        context 'files referenced' do
           it 'ignores non file backdrops' do
             entry = SeedsDsl.sample_scrolled_entry(attributes: {
                                                      account: create(:account),
@@ -343,7 +343,7 @@ module PageflowScrolled
         end
       end
 
-      context 'image files', stub_paperclip: true do
+      context 'image files' do
         before do
           stub_request(:get, /example.com/)
             .to_return(status: 200,
@@ -389,7 +389,7 @@ module PageflowScrolled
         end
       end
 
-      context 'video files', stub_paperclip: true do
+      context 'video files' do
         before do
           stub_request(:get, /example.com/)
             .to_return(status: 200,
@@ -486,7 +486,7 @@ module PageflowScrolled
         end
       end
 
-      context 'audio files', stub_paperclip: true do
+      context 'audio files' do
         before do
           stub_request(:get, /example.com/)
             .to_return(status: 200,

--- a/spec/controllers/pageflow/editor/file_import_controller_spec.rb
+++ b/spec/controllers/pageflow/editor/file_import_controller_spec.rb
@@ -137,7 +137,7 @@ module Pageflow
       end
     end
 
-    describe '#start_import_job', perform_jobs: true, stub_paperclip: true do
+    describe '#start_import_job', perform_jobs: true do
       include ActiveJob::TestHelper
 
       let(:zencoder_options) do

--- a/spec/helpers/pageflow/social_share_helper_spec.rb
+++ b/spec/helpers/pageflow/social_share_helper_spec.rb
@@ -130,7 +130,7 @@ module Pageflow
       end
     end
 
-    describe '#social_share_entry_image_tags', stub_paperclip: true do
+    describe '#social_share_entry_image_tags' do
       include UsedFileTestHelper
 
       it 'renders share image meta tags if share image was chosen' do

--- a/spec/models/pageflow/text_track_file_spec.rb
+++ b/spec/models/pageflow/text_track_file_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Pageflow
-  describe TextTrackFile, perform_jobs: true do
+  describe TextTrackFile, perform_jobs: true, unstub_paperclip: true do
     describe '#process' do
       it 'sets state to processed' do
         text_track_file = create(:text_track_file, :uploaded)

--- a/spec/state_machines/pageflow/image_and_text_track_processing_state_machine_spec.rb
+++ b/spec/state_machines/pageflow/image_and_text_track_processing_state_machine_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Pageflow
-  describe ImageAndTextTrackProcessingStateMachine, perform_jobs: true do
+  describe ImageAndTextTrackProcessingStateMachine, perform_jobs: true, unstub_paperclip: true do
     describe '#process event' do
       context 'for uploaded file' do
         it 'processes attachment' do

--- a/spec/state_machines/pageflow/media_encoding_state_machine_examples.rb
+++ b/spec/state_machines/pageflow/media_encoding_state_machine_examples.rb
@@ -5,7 +5,7 @@ shared_examples 'media encoding state machine' do |model|
     Pageflow.config.zencoder_options
   end
 
-  describe '#publish event', perform_jobs: true, stub_paperclip: true do
+  describe '#publish event', perform_jobs: true do
     context 'with disabled confirm_encoding_jobs option' do
       before do
         stub_request(:get, /#{zencoder_options[:s3_host_alias]}/)
@@ -106,7 +106,7 @@ shared_examples 'media encoding state machine' do |model|
     end
   end
 
-  describe '#confirm_encoding event', perform_jobs: true, stub_paperclip: true do
+  describe '#confirm_encoding event', perform_jobs: true do
     before do
       stub_request(:get, /#{zencoder_options[:s3_host_alias]}/)
         .to_return(:status => 200, :body => File.read('spec/fixtures/image.jpg'))
@@ -138,7 +138,7 @@ shared_examples 'media encoding state machine' do |model|
     end
   end
 
-  describe '#retry_encoding event', perform_jobs: true, stub_paperclip: true do
+  describe '#retry_encoding event', perform_jobs: true do
     before do
       stub_request(:get, /#{zencoder_options[:s3_host_alias]}/)
         .to_return(:status => 200, :body => File.read('spec/fixtures/image.jpg'))

--- a/spec/support/pageflow/support/config/paperclip.rb
+++ b/spec/support/pageflow/support/config/paperclip.rb
@@ -1,13 +1,21 @@
 RSpec.configure do |config|
-  config.before(:each) do
+  config.before(:all) do
     Dir.glob(Rails.root.join('public', 'system', 's3', '*')).each do |f|
       FileUtils.rm_r(f)
     end
   end
 
-  config.before(:each, stub_paperclip: true) do
-    allow_any_instance_of(Paperclip::Attachment).to receive(:post_process)
-    allow(Paperclip).to receive(:run).and_return('100x100')
+  config.after(:each, unstub_paperclip: true) do
+    Dir.glob(Rails.root.join('public', 'system', 's3', '*')).each do |f|
+      FileUtils.rm_r(f)
+    end
+  end
+
+  config.before(:each) do |example|
+    unless example.metadata[:unstub_paperclip] || example.metadata[:js]
+      allow_any_instance_of(Paperclip::Attachment).to receive(:post_process)
+      allow(Paperclip).to receive(:run).and_return('100x100')
+    end
   end
 end
 


### PR DESCRIPTION
Speed up tests by only processing attachments of factory created files
if the test actually uses the files. Also process attachments in JS
specs since the browser might request processed files for display.