### PR TITLE
Improve Datawrapper chart display

### DIFF
--- a/entry_types/scrolled/config/locales/new/de.yml
+++ b/entry_types/scrolled/config/locales/new/de.yml
@@ -178,6 +178,8 @@ de:
         help_text: >
           Dieser Artikel wirkt am besten mit eingeschaltetem Ton.<br/>
           Klicken Sie einmal in dieses Feld, um den Ton für die gesamte Geschichte zu aktivieren.
+      chart:
+        default_title: Interaktives Diagramm
       player_controls:
         play: Wiedergeben
         pause: Pausieren
@@ -300,6 +302,16 @@ de:
                 URL zu einem bei Datawrapper publizierten Diagramm. Datawrapper bietet in den
                 Diagramm Optionen ein spezielles "Pageflow"-Design für eine optimale Darstellung
                 innerhalb des Beitrags.
+            title:
+              label: Titel
+              inline_help: >
+                Dieser Titel wird von Screenreadern verwendet, um das Diagramm als Ganzes zu beschreiben.
+            backgroundColor:
+              label: Hintegrund-Farbe
+              inline_help: >
+                Farbe der Box, die das Diagramm enthält. Insbesondere für Diagramme mit transparentem
+                Hintergrund kann über die Lesbarkeit durch Wahl einer passenden Hintergrundfarbe
+                verbessert werden.
         heading:
           name: Überschrift
           tabs:

--- a/entry_types/scrolled/config/locales/new/en.yml
+++ b/entry_types/scrolled/config/locales/new/en.yml
@@ -92,6 +92,8 @@ en:
         help_text: >
           This article works best with the sound turned on. <br/>
           Click once in this field to activate the sound for the entire story.
+      chart:
+        default_title: Interactive chart
       player_controls:
         play: Play
         pause: Pause
@@ -213,6 +215,15 @@ en:
               inline_help: >
                 URL of a chart published via Datawrapper. Datawrapper offers a special 'Pageflow'
                 layout selectable on the 'Design' tab for optimal display inside Pageflow.
+            title:
+              label: Title
+              inline_help: >
+                Used by screen readers to describe the chart as a whole.
+            backgroundColor:
+              label: Background Color
+              inline_help: >
+                Color of box containing the diagram. Especially for charts with transparent background,
+                readability can be improved by choosing an appropriate background.
         heading:
           name: Heading
           tabs:

--- a/entry_types/scrolled/package/src/contentElements/dataWrapperChart/DataWrapperChart.js
+++ b/entry_types/scrolled/package/src/contentElements/dataWrapperChart/DataWrapperChart.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   useContentElementLifecycle,
   useContentElementEditorState,
+  useI18n,
   Figure
 } from 'pageflow-scrolled/frontend';
 import {useIframeHeight} from './useIframeHeight';
@@ -10,6 +11,7 @@ import {useIframeHeight} from './useIframeHeight';
 import styles from './DataWrapperChart.module.css';
 
 export function DataWrapperChart({configuration}) {
+  const {t} = useI18n();
   const {isPrepared} = useContentElementLifecycle();
   const {isEditable, isSelected} = useContentElementEditorState();
   const height = useIframeHeight(configuration.url);
@@ -24,24 +26,24 @@ export function DataWrapperChart({configuration}) {
     <Figure caption={configuration.caption}>
       <div className={styles.container}
            style={{pointerEvents: isEditable && !isSelected ? 'none' : undefined,
+                   backgroundColor: configuration.backgroundColor || '#323d4d',
                    height: height}}
            data-percy="hide">
-        {renderIframe(srcURL)}
+        {renderIframe(srcURL,
+                      configuration.title || t('pageflow_scrolled.public.chart.default_title'))}
       </div>
     </Figure>
   );
 }
 
-function renderIframe(url) {
+function renderIframe(url, title) {
   if (!url) {
     return null;
   }
 
   return (
     <iframe src={url}
-            scrolling='auto'
-            frameBorder='0'
-            align='aus'
+            title={title}
             allowFullScreen={true}
             mozallowfullscreen='true'
             webkitallowfullscreen='true' />

--- a/entry_types/scrolled/package/src/contentElements/dataWrapperChart/DataWrapperChart.module.css
+++ b/entry_types/scrolled/package/src/contentElements/dataWrapperChart/DataWrapperChart.module.css
@@ -1,6 +1,6 @@
 .container {
   min-height: 200px;
-  background-color: rgba(0, 0, 0, 0.5);
+  padding: 20px 5%;
 }
 
 .container > iframe {
@@ -8,4 +8,6 @@
   height: 100%;
   position: relative;
   top: 0;
+  border: 0;
+  overflow: hidden;
 }

--- a/entry_types/scrolled/package/src/contentElements/dataWrapperChart/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/dataWrapperChart/editor.js
@@ -1,5 +1,6 @@
+import I18n from 'i18n-js';
 import {editor} from 'pageflow-scrolled/editor';
-import {UrlInputView} from 'pageflow/ui';
+import {UrlInputView, TextInputView, ColorInputView} from 'pageflow/ui';
 import {DatawrapperAdView} from './editor/DataWrapperAdView';
 
 editor.contentElementTypes.register('dataWrapperChart', {
@@ -21,6 +22,12 @@ editor.contentElementTypes.register('dataWrapperChart', {
         permitHttps: true
       });
       this.view(DatawrapperAdView);
+      this.input('title', TextInputView, {
+        placeholder: I18n.t('pageflow_scrolled.public.chart.default_title')
+      });
+      this.input('backgroundColor', ColorInputView,{
+        defaultValue: '#323d4d'
+      });
 
       this.group('ContentElementCaption');
       this.group('ContentElementPosition');


### PR DESCRIPTION
* Never show scroll bars on iframe. Before, scroll bars sometimes
  flashed during resizing.

* Add padding to prevent displaying charts too close to the viewport
  edge.

* Make background color configurable. Use background color of default
  Datawrapper as default to give padding the same color as chart
  itself. This allows choosing a good color for charts with
  transparent backgrounds.

* Make iframe title configurable to improve accessibility.

REDMINE-18082