### PR TITLE
Preserve scroll position when toggling phone preview

### DIFF
--- a/entry_types/scrolled/package/spec/editor/views/EntryPreviewView-spec.js
+++ b/entry_types/scrolled/package/spec/editor/views/EntryPreviewView-spec.js
@@ -10,6 +10,8 @@ describe('EntryPreviewView', () => {
   afterEach(() => {
     // Remove post message event listener
     view.onClose();
+
+    jest.restoreAllMocks();
   });
 
   setupGlobals({
@@ -85,6 +87,9 @@ describe('EntryPreviewView', () => {
     view.render();
     document.body.appendChild(view.el);
     view.onShow();
+
+    jest.spyOn(view.messageController, 'preserveScrollPoint')
+        .mockImplementation(callback => callback());
 
     entry.set('emulation_mode', 'phone');
     expect(view.el.classList).toContain(styles.phoneEmulationMode);

--- a/entry_types/scrolled/package/spec/frontend/features/scrollPointMessages-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/features/scrollPointMessages-spec.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import {frontend} from 'frontend';
+
+import {renderEntry, useInlineEditingPageObjects} from 'support/pageObjects';
+import {fakeParentWindow} from 'support';
+
+import {asyncHandlingOf} from 'support/asyncHandlingOf';
+
+jest.mock('frontend/useScrollTarget');
+
+describe('scroll point messages', () => {
+  useInlineEditingPageObjects();
+
+  beforeEach(() => {
+    fakeParentWindow();
+    window.parent.postMessage = jest.fn();
+    window.scrollTo = jest.fn();
+  });
+
+  it('responds with SAVED_SCROLL_POINT message to SAVE_SCROLL_POINT message', async () => {
+    renderEntry();
+
+    await asyncHandlingOf(() => {
+      window.postMessage({type: 'SAVE_SCROLL_POINT'}, '*');
+    });
+
+    expect(window.parent.postMessage).toHaveBeenCalledWith({
+      type: 'SAVED_SCROLL_POINT'
+    }, expect.anything());
+  });
+
+  it('scrolls to first content element with positive viewport y coordinate', async () => {
+    const {fakeContentElementBoundingClientRectsByTestId} = renderEntry({
+      seed: {
+        contentElements: [
+          {typeName: 'withTestId', configuration: {testId: 1}},
+          {typeName: 'withTestId', configuration: {testId: 2}},
+          {typeName: 'withTestId', configuration: {testId: 3}}
+        ]
+      }
+    });
+
+    window.scrollY = 1000;
+    fakeContentElementBoundingClientRectsByTestId({
+      1: {top: -100},
+      2: {top: 30},
+      3: {top: 900},
+    });
+
+    await asyncHandlingOf(() => {
+      window.postMessage({type: 'SAVE_SCROLL_POINT'}, '*');
+    });
+    await asyncHandlingOf(() => {
+      window.postMessage({type: 'RESTORE_SCROLL_POINT'}, '*');
+    });
+
+    const offset = 100;
+    expect(window.scrollTo).toHaveBeenCalledWith(expect.objectContaining({
+      top: 30 + window.scrollY - offset
+    }));
+  });
+
+  it('scrolls to selected content element if present', async () => {
+    const {getContentElementByTestId, fakeContentElementBoundingClientRectsByTestId} = renderEntry({
+      seed: {
+        contentElements: [
+          {typeName: 'withTestId', configuration: {testId: 1}},
+          {typeName: 'withTestId', configuration: {testId: 2}},
+          {typeName: 'withTestId', configuration: {testId: 3}}
+        ]
+      }
+    });
+
+    window.scrollY = 1000;
+    fakeContentElementBoundingClientRectsByTestId({
+      1: {top: -100},
+      2: {top: 30},
+      3: {top: 900},
+    });
+    getContentElementByTestId(3).select();
+
+    await asyncHandlingOf(() => {
+      window.postMessage({type: 'SAVE_SCROLL_POINT'}, '*');
+    });
+    await asyncHandlingOf(() => {
+      window.postMessage({type: 'RESTORE_SCROLL_POINT'}, '*');
+    });
+
+    const offset = 100;
+    expect(window.scrollTo).toHaveBeenCalledWith(expect.objectContaining({
+      top: 900 + window.scrollY - offset
+    }));
+  });
+});

--- a/entry_types/scrolled/package/spec/support/pageObjects.js
+++ b/entry_types/scrolled/package/spec/support/pageObjects.js
@@ -10,7 +10,7 @@ import {act, fireEvent, queryHelpers, queries, within} from '@testing-library/re
 import {useFakeTranslations} from 'pageflow/testHelpers';
 import {simulateScrollingIntoView} from './fakeIntersectionObserver';
 
-export function renderEntry({seed}) {
+export function renderEntry({seed} = {}) {
   return renderInEntry(<Entry />, {
     seed,
     queries: {...queries, ...pageObjectQueries}
@@ -37,6 +37,8 @@ export function useInlineEditingPageObjects() {
 
 export function usePageObjects() {
   beforeEach(() => {
+    jest.restoreAllMocks();
+
     api.contentElementTypes.register('withTestId', {
       component: function WithTestId({configuration}) {
         return (
@@ -76,6 +78,23 @@ const pageObjectQueries = {
     }
 
     return createContentElementPageObject(el);
+  },
+
+  fakeContentElementBoundingClientRectsByTestId(container, rectsByTestId) {
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function() {
+      const testIdAttribute = this.querySelector('[data-testid]')?.getAttribute('data-testid');
+      const testId = testIdAttribute?.split('-')[1];
+
+      return {
+        top: 0,
+        left: 0,
+        width: 0,
+        height: 0,
+        bottom: 0,
+        right: 0,
+        ...(testId ? rectsByTestId[testId] : {})
+      };
+    });
   }
 }
 

--- a/entry_types/scrolled/package/src/editor/views/EntryPreviewView.js
+++ b/entry_types/scrolled/package/src/editor/views/EntryPreviewView.js
@@ -39,13 +39,15 @@ export const EntryPreviewView = Marionette.ItemView.extend({
   },
 
   updateEmulationMode: function() {
-    if (this.model.previous('emulation_mode')) {
-      this.$el.removeClass(styles[this.emulationModeClassName(this.model.previous('emulation_mode'))]);
-    }
+    this.messageController.preserveScrollPoint(() => {
+      if (this.model.previous('emulation_mode')) {
+        this.$el.removeClass(styles[this.emulationModeClassName(this.model.previous('emulation_mode'))]);
+      }
 
-    if (this.model.get('emulation_mode')) {
-      this.$el.addClass(styles[this.emulationModeClassName(this.model.get('emulation_mode'))]);
-    }
+      if (this.model.get('emulation_mode')) {
+        this.$el.addClass(styles[this.emulationModeClassName(this.model.get('emulation_mode'))]);
+      }
+    });
   },
 
   emulationModeClassName: function(mode) {

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/ContentElementDecorator.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/ContentElementDecorator.js
@@ -13,7 +13,7 @@ import {ContentElementEditorStateProvider} from './ContentElementEditorStateProv
 
 export function ContentElementDecorator(props) {
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} data-scrollpoint={props.id}>
       <ContentElementEditorStateProvider id={props.id}>
         <OptionalSelectionRect {...props}>
           <ContentElementConfigurationUpdateProvider id={props.id} permaId={props.permaId}>
@@ -46,6 +46,7 @@ function DefaultSelectionRect(props) {
 
   return (
     <SelectionRect selected={isSelected}
+                   scrollPoint={isSelected}
                    full={props.position === 'full'}
                    ariaLabel={t('pageflow_scrolled.inline_editing.select_content_element')}
                    insertButtonTitles={t('pageflow_scrolled.inline_editing.insert_content_element')}

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/EditableText/Selection.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/EditableText/Selection.js
@@ -70,6 +70,7 @@ export function Selection(props) {
     <div ref={outerRef}>
       <div ref={ref} className={styles.selection}>
         <SelectionRect selected={true}
+                       scrollPoint={isContentElementSelected}
                        insertButtonTitles={t('pageflow_scrolled.inline_editing.insert_content_element')}
                        onInsertButtonClick={at => {
                            if ((at === 'before' &&boundsRef.current.start === 0) ||

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/EntryDecorator.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/EntryDecorator.js
@@ -7,6 +7,7 @@ import {
   useContentElementEditorCommandEmitter,
   ContentElementEditorCommandSubscriptionProvider
 } from './ContentElementEditorCommandSubscriptionProvider';
+import {ScrollPointMessageHandler} from './scrollPoints';
 
 export function EntryDecorator(props) {
   const contentElementEditorCommandEmitter = useContentElementEditorCommandEmitter();
@@ -14,6 +15,7 @@ export function EntryDecorator(props) {
   return (
     <EditorStateProvider>
       <MessageHandler contentElementEditorCommandEmitter={contentElementEditorCommandEmitter} />
+      <ScrollPointMessageHandler />
       <ContentElementEditorCommandSubscriptionProvider emitter={contentElementEditorCommandEmitter}>
         {props.children}
       </ContentElementEditorCommandSubscriptionProvider>

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/SelectionRect.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/SelectionRect.js
@@ -15,6 +15,7 @@ export function SelectionRect(props) {
                                 [styles.start]: props.selected && props.start,
                                 [styles.end]: props.selected && props.end})}
          aria-label={props.ariaLabel}
+         data-scrollpoint={props.scrollPoint ? 'selection' : undefined}
          onClick={props.onClick}>
       {renderToolbar(props)}
 

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/scrollPoints.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/scrollPoints.js
@@ -1,0 +1,86 @@
+import {useRef, useCallback} from 'react';
+import {usePostMessageListener} from '../usePostMessageListener';
+
+// Scroll points are used to preserve scroll position when toggling
+// the editor phone preview. Each ContentElementDecorator renders a
+// `data-scrollpoint` attribute with a unique value on its wrapper
+// div. Before toggling the phone preview mode, the `EntryPreviewView`
+// sends a `SAVE_SCROLL_POINT` message. `getCurrentScrollPoint` looks
+// through all DOM elements with `data-scrollpoint` attributes and
+// stores the unique id of the element with the smallest non-negative
+// y coordinate in the viewport (i.e. the first content element inside
+// the viewport). `ScrollPointMessageHandler` responds with a
+// `SAVED_SCROLL_POINT` message which makes `EntryPreviewView` toggle
+// the preview mode. Once the preview has been resized,
+// `EntryPreviewView` sends a `RESTORE_SCROLL_POINT`
+// message. `restoreScrollPoint` looks up the new position of the
+// element with the saved scroll point and scrolls it into view.
+//
+// When a content element is selected, we want to keep that element
+// in the viewport instead. The `SelectionRect` therefore renders a
+// `data-scrollpoint=selection` attribute. If an element with such an
+// attribute is present, `getCurrentScrollPoint` prefers it over all
+// other scroll points. Since text block elements render a selection
+// rect around the current paragraph, scroll position is also
+// preserved correctly inside long text blocks.
+
+export function ScrollPointMessageHandler() {
+  const scrollPoint = useRef();
+
+  const receiveMessage = useCallback(data => {
+    if (data.type === 'SAVE_SCROLL_POINT') {
+      scrollPoint.current = getCurrentScrollPoint();
+      window.parent.postMessage({type: 'SAVED_SCROLL_POINT'}, window.location.origin);
+    }
+    else if (data.type === 'RESTORE_SCROLL_POINT') {
+      if (scrollPoint.current) {
+        restoreScrollPoint(scrollPoint.current);
+      }
+    }
+  }, []);
+
+  usePostMessageListener(receiveMessage);
+
+  return null;
+}
+
+function getCurrentScrollPoint() {
+  let scrollPointElement =
+    getSelectionScrollPointElement() ||
+    getScrollPointElementWithMinimumTopPositionInViewport();
+
+  return scrollPointElement?.getAttribute('data-scrollpoint');
+}
+
+function getSelectionScrollPointElement() {
+  return document.querySelector('[data-scrollpoint=selection]');
+}
+
+function getScrollPointElementWithMinimumTopPositionInViewport() {
+  let minTop = Infinity;
+  let scrollPointElement;
+
+  const scrollPoints = document.querySelectorAll('[data-scrollpoint]');
+
+  for (let i = 0; i < scrollPoints.length; i++) {
+    const rect = scrollPoints[i].getBoundingClientRect();
+
+    if (rect.top > 0 && rect.top < minTop) {
+      minTop = rect.top;
+      scrollPointElement = scrollPoints[i];
+    }
+  }
+
+  return scrollPointElement
+}
+
+function restoreScrollPoint(name) {
+  let element = document.querySelector(`[data-scrollpoint="${name}"]`);
+
+  if (element) {
+    window.scrollTo({
+      top: element.getBoundingClientRect().top + window.scrollY - 100,
+      behavior: 'smooth'
+    });
+  }
+}


### PR DESCRIPTION
If a content element is selected, make sure that it is still visibile
in the viewport after toggling the emulation mode. If no content
element is selected, keep the first content element with positive y
coordinate in the viewport.

REDMINE-17964