### PR TITLE
Never hide audio controls

### DIFF
--- a/entry_types/scrolled/package/src/frontend/MediaPlayerControls.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayerControls.js
@@ -33,7 +33,8 @@ export function MediaPlayerControls(props) {
                     isPlaying={playerState.shouldPlay}
                     unplayed={playerState.unplayed}
                     lastControlledVia={playerState.lastControlledVia}
-                    inactive={(playerState.userIdle || !playerState.userHovering) &&
+                    inactive={props.autoHide &&
+                              (playerState.userIdle || !playerState.userHovering) &&
                               (!focusOutlineVisible || !playerState.focusInsideControls) &&
                               !playerState.userHoveringControls}
 

--- a/entry_types/scrolled/package/src/frontend/VideoPlayerControls.js
+++ b/entry_types/scrolled/package/src/frontend/VideoPlayerControls.js
@@ -13,6 +13,7 @@ export function VideoPlayerControls({videoFile, ...props}) {
   return (
     <MediaPlayerControls {...props}
                          file={videoFile}
+                         autoHide={true}
                          qualityMenuItems={getQualityMenuItems(availableQualities, activeQuality, t)}
                          onQualityMenuItemClick={setActiveQuality}/>
   );


### PR DESCRIPTION
Recent change caused audio controls to be hidden when not hovering.

REDMINE-17746