### PR TITLE
Do not keep navigation open when focus is within

### DIFF
--- a/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
@@ -11,7 +11,6 @@
   height: 0;
 }
 
-.navigationBar:focus-within,
 .navigationBarExpanded {
   top: 0;
 }


### PR DESCRIPTION
Was indented to keep navigation open while tooltips are
showing. Caused navigation to remain open when scrolling after
clicking unmute button.