### PR TITLE
Prevent state update on unmounted component

### DIFF
--- a/entry_types/scrolled/package/src/frontend/MediaInteractionTracking.js
+++ b/entry_types/scrolled/package/src/frontend/MediaInteractionTracking.js
@@ -19,6 +19,10 @@ export function MediaInteractionTracking({playerState, playerActions, idleDelay,
   }, [wasPlaying, playerState.isPlaying, setHideControlsTimeout,
       playerState.focusInsideControls, focusWasInside]);
 
+  useEffect(() => {
+    return () => clearTimeout(hideControlsTimeout.current);
+  }, []);
+
   const handleInteraction = function () {
     playerActions.userInteraction();
     setHideControlsTimeout();


### PR DESCRIPTION
Prevent timeout set by `MediaInteractionTracking` from firing after
the component has been unmounted.