### PR TITLE
Do not fall back to file default motif area

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/MotifArea-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/MotifArea-spec.js
@@ -42,46 +42,6 @@ describe('MotifArea', () => {
     expect(container.firstChild).toHaveStyle('height: 500px');
   });
 
-  it('falls back to motif area from file configuration', () => {
-    const {container} =
-      renderInEntry(
-        () => {
-          const file = useBackgroundFile({
-            file: useFile({collectionName: 'imageFiles', permaId: 100}),
-            containerDimension: {width: 2000, height: 1000}
-          });
-
-          return (
-            <MotifArea file={file} />
-          )
-        },
-        {
-          seed: {
-            imageFiles: [
-              {
-                permaId: 100,
-                width: 200,
-                height: 100,
-                configuration: {
-                  motifArea: {
-                    top: 10,
-                    left: 10,
-                    width: 50,
-                    height: 50
-                  }
-                }
-              }
-            ]
-          }
-        }
-      );
-
-    expect(container.firstChild).toHaveStyle('top: 100px');
-    expect(container.firstChild).toHaveStyle('left: 200px');
-    expect(container.firstChild).toHaveStyle('width: 1000px');
-    expect(container.firstChild).toHaveStyle('height: 500px');
-  });
-
   it('renders nothing when file is not set', () => {
     const {container} =
       renderInEntry(
@@ -167,10 +127,11 @@ describe('MotifArea', () => {
       ]
     };
 
-    function useBackgroundFileByPermaId(permaId) {
+    function useBackgroundFileByPermaId(permaId, {motifArea} = {}) {
       return useBackgroundFile({
         file: useFile({collectionName: 'imageFiles', permaId}),
-        containerDimension: {width: 2000, height: 1000}
+        containerDimension: {width: 2000, height: 1000},
+        motifArea
       });
     }
 
@@ -204,14 +165,20 @@ describe('MotifArea', () => {
       const callback = jest.fn();
       const {container, rerender} =
         renderInEntry(
-          () => <MotifArea file={useBackgroundFileByPermaId(100)}
+          () => <MotifArea file={useBackgroundFileByPermaId(100,
+                                                            {motifArea: {
+                                                              top: 10, left: 10, width: 50, height: 50
+                                                            }})}
                            onUpdate={callback} />,
           {seed}
         );
 
       callback.mockReset();
       rerender(
-        () => <MotifArea file={useBackgroundFileByPermaId(101)}
+        () => <MotifArea file={useBackgroundFileByPermaId(101,
+                                                          {motifArea: {
+                                                            top: 20, left: 20, width: 100, height: 100
+                                                          }})}
                          onUpdate={callback} />
       );
 

--- a/entry_types/scrolled/package/spec/frontend/useBackgroundFile-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/useBackgroundFile-spec.js
@@ -34,26 +34,6 @@ describe('useBackgroundFile', () => {
     expect(result.current.motifArea).toEqual({left: 20, top: 10, width: 50, height: 60});
   });
 
-  it('falls back to motif area from file configuration if passed motif area is undefined', () => {
-    const {result} = renderHookInEntry(
-      () => useBackgroundFile({
-        file: useFile({collectionName: 'imageFiles', permaId: 10}),
-        containerDimension: {width: 200, height: 100}
-      }),
-      {
-        seed: {
-          imageFiles: [{
-            permaId: 10,
-            configuration: {
-              motifArea: {left: 30, top: 20, width: 60, height: 70}
-            }
-          }]
-        }
-      });
-
-    expect(result.current.motifArea).toEqual({left: 30, top: 20, width: 60, height: 70});
-  });
-
   describe('cropPosition property', () => {
     // The following tests assume that there is an image with size
     // 2000x1000 with a specified motif area. We want to display this
@@ -168,28 +148,5 @@ describe('useBackgroundFile', () => {
         height: 80
       });
     });
-  });
-
-  it('does not fall back to motif area from file configuration if passed motif area is null', () => {
-    const {result} = renderHookInEntry(
-      () => useBackgroundFile({
-        file: useFile({collectionName: 'imageFiles', permaId: 10}),
-        motifArea: null,
-        containerDimension: {width: 200, height: 100}
-      }),
-      {
-        seed: {
-          imageFiles: [{
-            permaId: 10,
-            configuration: {
-              motifArea: {left: 30, top: 20, width: 60, height: 70}
-            }
-          }]
-        }
-      });
-
-    expect(result.current.motifArea).toBeNull();
-    expect(result.current.cropPosition.x).toEqual(50);
-    expect(result.current.cropPosition.y).toEqual(50);
   });
 });

--- a/entry_types/scrolled/package/src/frontend/useBackgroundFile.js
+++ b/entry_types/scrolled/package/src/frontend/useBackgroundFile.js
@@ -31,12 +31,6 @@ export function useBackgroundFile({file, motifArea, containerDimension}) {
     return null ;
   }
 
-  // Motif area used to be file specific not section specific. Fall
-  // back to file configuration for backwards compatibility if no
-  // motif area has been supplied.
-
-  motifArea = motifArea !== undefined ? motifArea : file.configuration.motifArea;
-
   // Calculate scale factor required to make the file cover the container:
 
   const originalRatio = file.width / file.height;


### PR DESCRIPTION
When an image file is used as both desktop and mobile image and a
motif area is selected for the desktop variant, the mobile variant
will start using the default motif area stored in the file
configuration.

We accept the breaking change since there are no important old entries
yet.

REDMINE-18038