### PR TITLE
Do not move backdrop when navigation is scrolled out of view

### DIFF
--- a/entry_types/scrolled/package/src/frontend/Entry.module.css
+++ b/entry_types/scrolled/package/src/frontend/Entry.module.css
@@ -5,9 +5,3 @@
   background-color: #000;
   color: #fff;
 }
-
-.Entry > div:first-child {
-  /* Let content begin below navigation bar. Navigation bar has zero
-     height to let first chapter start at the very top. */
-  padding-top: 58px;
-}

--- a/entry_types/scrolled/package/src/frontend/Foreground.js
+++ b/entry_types/scrolled/package/src/frontend/Foreground.js
@@ -22,6 +22,7 @@ function className(props, forcePadding) {
     props.transitionStyles.foreground,
     props.transitionStyles[`foreground-${props.state}`],
     {[styles.paddingBottom]: props.paddingBottom || forcePadding},
+    {[styles.inFirstSection]: props.inFirstSection},
     styles[`${props.heightMode}Height`]
   )
 }

--- a/entry_types/scrolled/package/src/frontend/Foreground.module.css
+++ b/entry_types/scrolled/package/src/frontend/Foreground.module.css
@@ -17,6 +17,12 @@
   min-height: 100vh;
 }
 
+.inFirstSection {
+  /* Let content begin below navigation bar. Navigation bar has zero
+     height to let first chapter start at the very top. */
+  padding-top: 58px;
+}
+
 .paddingBottom {
   padding-bottom: 3em;
 }

--- a/entry_types/scrolled/package/src/frontend/Section.js
+++ b/entry_types/scrolled/package/src/frontend/Section.js
@@ -79,6 +79,7 @@ function SectionContents(props) {
 
       <Foreground transitionStyles={props.transitionStyles}
                   state={props.state}
+                  inFirstSection={props.sectionIndex === 0}
                   minHeight={motifAreaState.minHeight}
                   paddingBottom={!endsWithFullWidthElement(props.contentElements)}
                   contentRef={setForegroundContentRef}


### PR DESCRIPTION
Apply padding to foreground of first section to prevent pushing the
backdrop below the navigation bar. If the first section uses a fixed
backdrop, it should also be fixed when first scrolling the page.

REDMINE-18071