### PR TITLE
Fix "SourceBuffer removed from parent media source" error

### DIFF
--- a/package/spec/frontend/media/MediaPool_spec.js
+++ b/package/spec/frontend/media/MediaPool_spec.js
@@ -111,7 +111,7 @@ describe('MediaPool', function() {
       expect(player.getMediaElement().hasAttribute('src')).toBe(true);
 
       pool.unAllocatePlayer(player);
-      expect(player.getMediaElement().getAttribute('src')).toBe(blankSources[MediaType.VIDEO]);
+      expect(player.currentSource()).toBe(blankSources[MediaType.VIDEO]);
     });
 
   });

--- a/package/src/frontend/media/MediaPool.js
+++ b/package/src/frontend/media/MediaPool.js
@@ -18,7 +18,7 @@ export class MediaPool {
     this.playerCount = options.playerCount;
     this.allocatedPlayers = {};
     this.unAllocatedPlayers = {};
-    
+
     this.mediaFactory_ = {
       [MediaType.AUDIO]: () => {
         const audioEl = document.createElement('audio');
@@ -53,11 +53,11 @@ export class MediaPool {
       player.poster(poster);
       player.controls(controls)
       if (playsInline) {
-        player.playsinline(true); 
+        player.playsinline(true);
       }
       player.updateHooks(hooks || {});
       player.updateMediaEventsContext(mediaEventsContextData);
-      
+
       this.allocatedPlayers[playerType].push(player);
       player.playerId = playerId || this.allocatedPlayers[playerType].length
       return player;
@@ -71,13 +71,13 @@ export class MediaPool {
   }
   unAllocatePlayer(player){
     if (player) {
-      let type = this.getMediaTypeFromEl(player.el());    
+      let type = this.getMediaTypeFromEl(player.el());
       this.allocatedPlayers[type] = this.allocatedPlayers[type].filter(p=>p!=player);
-      
+
       player.controls(false);
       player.getMediaElement().loop = false;
       player.playsinline(false);
-      player.getMediaElement().setAttribute('src', blankSources[type]);
+      player.src(blankSources[type]);
       player.poster('');
 
       clearTextTracks(player);
@@ -97,7 +97,7 @@ export class MediaPool {
   }
   allPlayersForType(type){
     if (this.unAllocatedPlayers[type]) {
-     return [...this.unAllocatedPlayers[type], ...this.allocatedPlayers[type]] 
+     return [...this.unAllocatedPlayers[type], ...this.allocatedPlayers[type]]
     }
     return [];
   }
@@ -129,7 +129,7 @@ export class MediaPool {
       mediaElement: mediaEl,
       tagName: type
     });
-    mediaEl.setAttribute('src', blankSources[type]);
+    mediaEl.setAttribute('src', blankSources[type].src);
     this.unAllocatedPlayers[type].push(player);
     return player;
   }

--- a/package/src/frontend/media/blankSources.js
+++ b/package/src/frontend/media/blankSources.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-export const BLANK_AUDIO_SRC =
+const BLANK_AUDIO_SRC =
   'data:audio/wav;base64,UklGRjIAAABXQVZFZm10IBA' +
   'AAAABAAEAIlYAAESsAAACABAAZGF0YRAAAAAAAAAAAAAAAAAAAAAAAA==';
 
-export const BLANK_VIDEO_SRC =
+const BLANK_VIDEO_SRC =
   'data:video/mp4;base64,AAAAHGZ0eXBNNFYgAAACAG' +
   'lzb21pc28yYXZjMQAAAAhmcmVlAAAGF21kYXTeBAAAbGliZmFhYyAxLjI4AABCAJMgBDIARw' +
   'AAArEGBf//rdxF6b3m2Ui3lizYINkj7u94MjY0IC0gY29yZSAxNDIgcjIgOTU2YzhkOCAtIE' +
@@ -91,7 +91,7 @@ export const BLANK_VIDEO_SRC =
   'AAAG1kaXJhcHBsAAAAAAAAAAAAAAAALWlsc3QAAAAlqXRvbwAAAB1kYXRhAAAAAQAAAABMYX' +
   'ZmNTUuMzMuMTAw';
 
-  export const blankSources = {
-    'audio': BLANK_AUDIO_SRC,
-    'video': BLANK_VIDEO_SRC
-  }
+export const blankSources = {
+  audio: {src: BLANK_AUDIO_SRC, type: 'audio/wav'},
+  video: {src: BLANK_VIDEO_SRC, type: 'video/mp4'}
+}


### PR DESCRIPTION
Use VideoJS `src` method to reset sources to blank sources instead of
setting sources of the media element directly. This ensures the DASH
media player is disposed correctly, preventing it from trying to
access the source buffer after it has already been removed.

We need to pass object with `src`/`type` instead of string to make
sure VideoJS recognizes the data url as supported source.

REDMINE-17807