### PR TITLE
Do not request new player when object position changes

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/MediaPlayer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/MediaPlayer-spec.js
@@ -149,6 +149,29 @@ describe('MediaPlayer', () => {
     );
   });
 
+  it('applies object position to player', () => {
+    const {getPlayer} = render(<MediaPlayer {...requiredProps()}
+                                            type="video"
+                                            objectPosition={{x: 50, y: 0}}
+                                            sources={getVideoSources()} />);
+
+    expect(getPlayer().getMediaElement()).toHaveStyle('object-position: 50% 0%');
+  });
+
+  it('updates object position on player when props change', () => {
+    const {getPlayer, rerender} =
+      render(<MediaPlayer {...requiredProps()}
+                          type="video"
+                          objectPosition={{x: 100, y: 100}}
+                          sources={getVideoSources()} />);
+    rerender(<MediaPlayer {...requiredProps()}
+                          type="video"
+                          objectPosition={{x: 50, y: 0}}
+                          sources={getVideoSources()} />);
+
+    expect(getPlayer().getMediaElement()).toHaveStyle('object-position: 50% 0%');
+  });
+
   it('it passes data from EventContext to getPlayer as media events context data', () => {
     const eventContextData = {some: 'data'};
 

--- a/entry_types/scrolled/package/spec/frontend/PlayerContainer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/PlayerContainer-spec.js
@@ -97,37 +97,4 @@ describe('PlayerContainer', () => {
       expect.objectContaining({loop: true, controls: true, playsInline: true})
     );
   });
-
-  it('calls media.getPlayer again, when object position changes', () => {
-    const spyMedia = jest.spyOn(media, 'getPlayer');
-    let sources = getVideoSources();
-    const {rerender} = render(<PlayerContainer type={'video'} sources={sources} />);
-    expect(spyMedia).toHaveBeenCalledTimes(1);
-
-    rerender(<PlayerContainer type={'video'} sources={sources} objectPosition={{x: 100, y: 50}} />);
-    expect(spyMedia).toHaveBeenCalledTimes(2);
-    expect(spyMedia).toHaveBeenCalledWith(
-      sources,
-      expect.objectContaining({objectPosition: {x: 100, y: 50}})
-    );
-
-    rerender(<PlayerContainer type={'video'} sources={sources} objectPosition={{x: 0, y: 50}} />);
-    expect(spyMedia).toHaveBeenCalledTimes(3);
-    expect(spyMedia).toHaveBeenCalledWith(
-      sources,
-      expect.objectContaining({objectPosition: {x: 0, y: 50}})
-    );
-  });
-
-  it('does not call media.getPlayer again, when object position stays deeply equal', () => {
-    const spyMedia = jest.spyOn(media, 'getPlayer');
-    let sources = getVideoSources();
-    const {rerender} = render(<PlayerContainer type={'video'}
-                                               sources={sources}
-                                               objectPosition={{x: 100, y: 50}} />);
-    expect(spyMedia).toHaveBeenCalledTimes(1);
-
-    rerender(<PlayerContainer type={'video'} sources={sources} objectPosition={{x: 100, y: 50}} />);
-    expect(spyMedia).toHaveBeenCalledTimes(1);
-  });
 });

--- a/entry_types/scrolled/package/spec/frontend/VideoPlayer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/VideoPlayer-spec.js
@@ -191,10 +191,8 @@ describe('VideoPlayer', () => {
     expect(result.container.querySelector('video').hasAttribute('alt')).toBe(true);
   });
 
-  it('passes object position based on motif area to media api when fit is cover', () => {
-    const spyMedia = jest.spyOn(media, 'getPlayer');
-
-    renderInEntry(
+  it('sets object position based on motif area to media api when fit is cover', () => {
+    const result = renderInEntry(
       () => {
         const file = useBackgroundFile({
           file: useFile({collectionName: 'videoFiles', permaId: 100}),
@@ -215,16 +213,11 @@ describe('VideoPlayer', () => {
       }
     );
 
-    expect(spyMedia).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({objectPosition: {x: 100, y: 50}})
-    );
+    expect(result.container.querySelector('video')).toHaveStyle('object-position: 100% 50%');
   });
 
-  it('does not pass object position when fit is not cover', () => {
-    const spyMedia = jest.spyOn(media, 'getPlayer');
-
-    renderInEntry(
+  it('does not set object position when fit is not cover', () => {
+    const result = renderInEntry(
       () => {
         const file = useBackgroundFile({
           file: useFile({collectionName: 'videoFiles', permaId: 100}),
@@ -244,9 +237,6 @@ describe('VideoPlayer', () => {
       }
     );
 
-    expect(spyMedia).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.not.objectContaining({objectPosition: expect.anything()})
-    );
+    expect(result.container.querySelector('video')).toHaveAttribute('style', '');
   });
 });

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/PlayerContainer.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/PlayerContainer.js
@@ -6,7 +6,7 @@ import './videojsBase.module.css';
 
 function PlayerContainer({
   filePermaId, sources, textTrackSources, type,
-  playsInline, loop, controls, objectPosition, altText,
+  playsInline, loop, controls, altText,
   mediaEventsContextData, atmoDuringPlayback, onSetup, onDispose
 }){
   const playerWrapperRef = useRef(null);
@@ -23,7 +23,6 @@ function PlayerContainer({
         playsInline: playsInline,
         loop: loop,
         controls: controls,
-        objectPosition,
         hooks: atmoDuringPlayback ? atmo.createMediaPlayerHooks(atmoDuringPlayback) : {}, //create hooks only for inline media players
         mediaEventsContextData,
         altText
@@ -87,8 +86,6 @@ function areEqual(prevProps, nextProps) {
          prevProps.playsInline === nextProps.playsInline &&
          prevProps.loop === nextProps.loop &&
          prevProps.controls === nextProps.controls &&
-         prevProps.objectPosition?.x === nextProps.objectPosition?.x &&
-         prevProps.objectPosition?.y === nextProps.objectPosition?.y &&
          prevProps.altText === nextProps.altText &&
          prevProps.atmoDuringPlayback === nextProps.atmoDuringPlayback &&
          deepEqual(prevProps.sources, nextProps.sources) &&

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/index.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/index.js
@@ -6,6 +6,7 @@ import ScrollToSectionContext from "../ScrollToSectionContext";
 import watchPlayer, {unwatchPlayer} from './watchPlayer';
 import {applyPlayerState} from './applyPlayerState';
 import {updatePlayerState} from './updatePlayerState';
+import {updateObjectPosition} from './updateObjectPosition';
 
 import {useEventContextData} from '../useEventContextData';
 import {useIsStaticPreview} from '../useScrollPositionLifecycle';
@@ -66,6 +67,7 @@ function PreparedMediaPlayer(props){
 
     watchPlayer(newPlayer, props.playerActions);
     applyPlayerState(newPlayer, props.playerState, props.playerActions)
+    updateObjectPosition(newPlayer, props.objectPosition.x, props.objectPosition.y)
   }
 
   let onDispose = ()=>{
@@ -88,6 +90,13 @@ function PreparedMediaPlayer(props){
     }
   }, [props.textTracks.activeFileId]);
 
+  useEffect(() => {
+    const player = playerRef.current;
+    if (player) {
+      updateObjectPosition(player, props.objectPosition.x, props.objectPosition.y);
+    }
+  }, [props.objectPosition.x, props.objectPosition.y]);
+
   return (
     <PlayerContainer type={props.type}
                      sources={appendSuffix(props.sources, props.sourceUrlSuffix)}
@@ -96,7 +105,6 @@ function PreparedMediaPlayer(props){
                      loop={props.loop}
                      controls={props.controls}
                      playsInline={props.playsInline}
-                     objectPosition={props.objectPosition}
                      mediaEventsContextData={eventContextData}
                      atmoDuringPlayback={props.atmoDuringPlayback}
                      onSetup={onSetup}
@@ -106,6 +114,7 @@ function PreparedMediaPlayer(props){
 };
 
 PreparedMediaPlayer.defaultProps = {
+  objectPosition: {},
   textTracks: {
     files: []
   }

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/updateObjectPosition.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/updateObjectPosition.js
@@ -1,0 +1,4 @@
+export function updateObjectPosition(player, x, y) {
+  player.getMediaElement().style.objectPosition =
+    typeof x !== 'undefined' && typeof y !== 'undefined' ? `${x}% ${y}%` : '';
+}

--- a/package/spec/frontend/media/media_spec.js
+++ b/package/spec/frontend/media/media_spec.js
@@ -63,23 +63,6 @@ describe('media', function() {
       expect(player.getMediaElement().getAttribute('alt')).toBe('audio file');
     });
 
-    it('sets passed object position style on media element', function () {
-      let player = media.getPlayer(fileSources, {
-        tagName: 'video',
-        objectPosition: {x: 100, y: 40}
-      });
-
-      expect(player.getMediaElement()).toHaveStyle('object-position: 100% 40%');
-    });
-
-    it('defaults to centered object position', function () {
-      let player = media.getPlayer(fileSources, {
-        tagName: 'video'
-      });
-
-      expect(player.getMediaElement()).toHaveStyle('object-position: 50% 50%');
-    });
-
     it('updates player\'s context data', () => {
       let context = {
         page: {

--- a/package/src/frontend/media/MediaPool.js
+++ b/package/src/frontend/media/MediaPool.js
@@ -33,8 +33,7 @@ export class MediaPool {
     }
   }
   allocatePlayer({playerType, playerId, playsInline, mediaEventsContextData,
-                  hooks, poster, loop = false, controls = false, altText,
-                  objectPosition = {x: 50, y: 50}}){
+                  hooks, poster, loop = false, controls = false, altText}){
     let player = undefined;
     if (!this.unAllocatedPlayers[playerType]) {
       this.populateMediaPool_();
@@ -48,7 +47,6 @@ export class MediaPool {
 
       player.pause();
       player.getMediaElement().loop = loop;
-      player.getMediaElement().style.objectPosition = `${objectPosition.x}% ${objectPosition.y}%`;
       player.getMediaElement().setAttribute('alt', altText);
       player.poster(poster);
       player.controls(controls)


### PR DESCRIPTION
Crop positions of background files can change when the viewport
resizes. So far player object position could only be updated by
disposing the player and requesting a new one. On mobile resize events
also sometimes happen due to browser chrome being hidden while
scrolling. Replacing the player is too heavy weight in these
cases. Change `MediaPlayer` to update object position of player in
place instead.

REDMINE-18166