### PR TITLE
Fix scroll flickering on Android Chrome

### DIFF
--- a/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
@@ -9,7 +9,6 @@
   width: 100%;
   text-align: center;
   height: 0;
-  touch-action: none;
 }
 
 .navigationBarExpanded {
@@ -116,7 +115,6 @@ div:focus-within > .contextIcon,
   }
 
   .navigationChapters {
-    touch-action: none;
     display: block;
     position: fixed;
     top: 60px;
@@ -133,7 +131,16 @@ div:focus-within > .contextIcon,
   }
 
   .chapterList {
-    margin-top: 50px;
+    padding-top: 50px;
+    box-sizing: border-box;
+    /*
+      Prevent scrolling the page when mobile navigation is open, by
+      forcing overflow and setting `overscroll-behavior: contain`
+      above. Normally this should be done with `touch-action: none`.
+      But using `touch-action` causes weird rendering bugs in Chrome
+      on Android.
+    */
+    min-height: 101%;
   }
 
   .chapterListItem {


### PR DESCRIPTION
For unknown reasons, if `touch-action: none` is set on the navigation
bar, tapping somewhere inside the navigation bar, causes weird
rendering glitches when scrolling the page from then on. Especially
when scrolling the page via a flick gesture, once the scroll animation
stops, the page is sometims briefly rendered as if the viewport height
had changed: a white rect appears at the bottom of the page and
covering background images are briefly moved to an incorrect position.

The same effect is visible if scrolling is blocked by preventing
default on `touchmove` instead of applying `touch-action: none`. To
still prevent the mobile navigation from scrolling the page, we force
it to have scroll overflow and use `overscroll-behavior`.

REDMINE-18162