### PR TITLE
Invisible share links should not be clickable

### DIFF
--- a/app/assets/stylesheets/pageflow/editor/drop_down_button.scss
+++ b/app/assets/stylesheets/pageflow/editor/drop_down_button.scss
@@ -31,7 +31,7 @@ $drop-down-button-menu-border-color: #aaa !default;
   &.is_visible {
     @include transition(visibility 0ms, opacity 100ms);
     visibility: visible;
-    pointer-events: all;
+    pointer-events: auto;
     opacity: 1;
   }
 }

--- a/app/assets/stylesheets/pageflow/editor/select_button.scss
+++ b/app/assets/stylesheets/pageflow/editor/select_button.scss
@@ -37,7 +37,7 @@
   &:hover .dropdown {
     @include transition(visibility 0ms, opacity 100ms, top 200ms);
     visibility: visible;
-    pointer-events: all;
+    pointer-events: auto;
 
     top: 18px;
     opacity: 1;

--- a/app/assets/stylesheets/pageflow/entries.scss
+++ b/app/assets/stylesheets/pageflow/entries.scss
@@ -73,7 +73,7 @@
     }
 
     &.visible {
-      pointer-events: all;
+      pointer-events: auto;
       visibility: visible;
     }
 

--- a/app/assets/stylesheets/pageflow/navigation_mobile.scss
+++ b/app/assets/stylesheets/pageflow/navigation_mobile.scss
@@ -75,7 +75,7 @@ body {
     background-position: -45px 0px;
     background-size: auto 100%;
     right: 10px;
-    pointer-events: all;
+    pointer-events: auto;
     cursor: pointer;
     @include transition(opacity 500ms, right 250ms);
 
@@ -99,7 +99,7 @@ body {
     @include background-icon-center($color: #ddd);
     @include fa-arrow-left-icon;
     cursor: pointer;
-    pointer-events: all;
+    pointer-events: auto;
     position: absolute;
     top: 16px;
     right: 60px;
@@ -277,7 +277,7 @@ body {
   }
 
   &.active {
-    pointer-events: all;
+    pointer-events: auto;
     visibility: visible;
 
     &:before {
@@ -293,7 +293,7 @@ body {
       right: 200px;
 
       &.sharing, &.imprint {
-        pointer-events: all;
+        pointer-events: auto;
         opacity: 1;
       }
     }

--- a/app/assets/stylesheets/pageflow/themes/default/anchors.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/anchors.scss
@@ -12,7 +12,7 @@ $anchor-external-links-icon: false !default;
   }
 
   text-decoration: none;
-  pointer-events: all;
+  pointer-events: auto;
   position: relative;
   margin-left: 6px;
   margin-right: 6px;

--- a/app/assets/stylesheets/pageflow/themes/default/logo/variant/watermark.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/logo/variant/watermark.scss
@@ -111,7 +111,7 @@ $logo-watermark-mobile-height: null !default;
   }
 
   .header.near_top .header_logo {
-    pointer-events: all;
+    pointer-events: auto;
   }
 
   @if $logo-watermark-variant-fade-in-near-top == "first-page" {

--- a/app/assets/stylesheets/pageflow/themes/default/page/anchors.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page/anchors.scss
@@ -15,7 +15,7 @@ $page-anchor-typography: () !default;
   .page_text a {
     @extend %anchor;
     color: $page-anchor-color;
-    pointer-events: all;
+    pointer-events: auto;
     margin-right: 0;
     @include typography($page-anchor-typography)
   }

--- a/app/assets/stylesheets/pageflow/themes/default/player_controls/classic/control_bar.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/player_controls/classic/control_bar.scss
@@ -61,7 +61,7 @@ $classic-player-controls-timestamp-position: "left" !default;
 
     background-color: $classic-player-controls-background-color;
     border: $classic-player-controls-border-width solid $classic-player-controls-border-color;
-    pointer-events: all;
+    pointer-events: auto;
 
     &:before {
       content: "";

--- a/app/assets/stylesheets/pageflow/themes/default/player_controls/classic/info_box.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/player_controls/classic/info_box.scss
@@ -80,7 +80,7 @@ $classic-player-controls-info-box-border-radius: 4px !default;
     pointer-events: none;
 
     a {
-      pointer-events: all;
+      pointer-events: auto;
     }
 
     margin: 0;

--- a/app/assets/stylesheets/pageflow/themes/default/player_controls/shared/menu_bar.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/player_controls/shared/menu_bar.scss
@@ -15,7 +15,7 @@ $player-controls-quality-menu-annotation-color: #ff0000 !default;
     position: absolute;
     bottom: 0;
     z-index: 10;
-    pointer-events: all;
+    pointer-events: auto;
 
     @include transition(opacity 0.5s, visibility 0.5s);
 
@@ -98,7 +98,7 @@ $player-controls-quality-menu-annotation-color: #ff0000 !default;
   &-menu_bar_button-sub_menu_visible .player_controls-menu_bar_button_sub_menu {
     visibility: visible;
     opacity: 1;
-    pointer-events: all;
+    pointer-events: auto;
     @include transition(none);
   }
 

--- a/app/assets/stylesheets/pageflow/themes/default/player_controls/slim/control_bar.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/player_controls/slim/control_bar.scss
@@ -53,7 +53,7 @@ $slim-player-controls-control-bar-text-phone-typography: () !default;
   }
 
   &-container-playing %player_controls-control_bar {
-    pointer-events: all;
+    pointer-events: auto;
   }
 
   &-control_bar_text {
@@ -248,7 +248,7 @@ $slim-player-controls-control-bar-text-phone-typography: () !default;
   &-control_bar_text,
   &-play_button,
   &-skip_button {
-    pointer-events: all;
+    pointer-events: auto;
   }
 
   &-progress_bar,

--- a/app/assets/stylesheets/pageflow/themes/default/player_controls/slim/info_box.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/player_controls/slim/info_box.scss
@@ -74,7 +74,7 @@ $slim-player-controls-info-box-header-typography: () !default;
     pointer-events: none;
 
     a {
-      pointer-events: all;
+      pointer-events: auto;
     }
 
     position: absolute;

--- a/app/assets/stylesheets/pageflow/themes/default/player_controls/slim/quality_menu.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/player_controls/slim/quality_menu.scss
@@ -12,7 +12,7 @@ $slim-player-controls-quality-menu-annotation-color: #ff0000 !default;
     bottom: 0;
     right: 10px;
     z-index: 10;
-    pointer-events: all;
+    pointer-events: auto;
 
     @include transition(opacity 0.5s, visibility 0.5s);
   }
@@ -88,7 +88,7 @@ $slim-player-controls-quality-menu-annotation-color: #ff0000 !default;
   &-menu_bar_button-sub_menu_visible .player_controls-menu_bar_button_sub_menu {
     visibility: visible;
     opacity: 1;
-    pointer-events: all;
+    pointer-events: auto;
     @include transition(none);
   }
 

--- a/app/assets/stylesheets/pageflow/themes/default/player_controls/waveform/wave.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/player_controls/waveform/wave.scss
@@ -15,7 +15,7 @@
 
     position: relative;
     z-index: 1;
-    pointer-events: all;
+    pointer-events: auto;
     height: 70px;
 
     @media (min-height: 600px) {

--- a/app/assets/stylesheets/pageflow/ui/forms.scss
+++ b/app/assets/stylesheets/pageflow/ui/forms.scss
@@ -196,7 +196,7 @@ textarea.short {
     width: 20px;
     height: 17px;
     text-align: center;
-    pointer-events: all;
+    pointer-events: auto;
   }
 
   position: absolute;

--- a/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLinkList.module.css
+++ b/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLinkList.module.css
@@ -6,7 +6,7 @@
   min-height: 240px;
   width: auto;
   height: auto;
-  pointer-events: all;
+  pointer-events: auto;
   position: relative;
   -webkit-transition: opacity 0.5s;
   -moz-transition: opacity 0.5s;

--- a/entry_types/scrolled/package/src/frontend/PlayerControls/MenuBarButton.module.css
+++ b/entry_types/scrolled/package/src/frontend/PlayerControls/MenuBarButton.module.css
@@ -34,7 +34,7 @@
 .subMenuExpanded .subMenu {
   visibility: visible;
   opacity: 1;
-  pointer-events: all;
+  pointer-events: auto;
   transition: none;
 }
 

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/SelectionRect.module.css
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/SelectionRect.module.css
@@ -41,7 +41,7 @@
   top: -40px;
   right: -15px;
   z-index: 1;
-  pointer-events: all;
+  pointer-events: auto;
 }
 
 .insert {
@@ -99,7 +99,7 @@
 }
 
 .insertButton {
-  pointer-events: all;
+  pointer-events: auto;
   border: 0;
   background: none;
   color: currentColor;

--- a/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
+++ b/entry_types/scrolled/package/src/frontend/navigation/AppHeader.module.css
@@ -45,7 +45,7 @@
 }
 
 .contextIcons > * {
-  pointer-events: all;
+  pointer-events: auto;
 }
 
 .contextIcon {

--- a/entry_types/scrolled/package/src/frontend/thirdPartyConsent/OptOutInfo.module.css
+++ b/entry_types/scrolled/package/src/frontend/thirdPartyConsent/OptOutInfo.module.css
@@ -4,7 +4,7 @@
   color: #fff;
   box-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2), 0px 3px 4px 0px rgba(0,0,0,0.14), 0px 1px 8px 0px rgba(0,0,0,0.12);
   transition: opacity 0.2s ease, visibility 0.2s linear;
-  pointer-events: all;
+  pointer-events: auto;
 }
 
 .tooltip {


### PR DESCRIPTION
So far `pointer-events: all` was used to re-enable pointer events for
an element inside a `pointer-events: none` parent. The correct way to
reset pointer events is to use `auto`, though. `all` is reserved for
SVG and causes SVG elements to receive pointer events even if
`visibility` is `hidden`. This caused share icons in the hidden
tooltip to be clickable.

Replace all occurences across all CSS files.

REDMINE-18174

[1] https://developer.mozilla.org/de/docs/Web/CSS/pointer-events