### PR TITLE
Ensure muted inline media pauses on deactivation

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/MediaPlayer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/MediaPlayer-spec.js
@@ -288,6 +288,56 @@ describe('MediaPlayer', () => {
     expect(player.pause).toHaveBeenCalledTimes(1);
   });
 
+  it('calls fadeOutAndPause on player when isPlaying, shouldPlay changes to false and fadeDuration is present', () => {
+    let state = {
+      ...getInitialPlayerState(),
+      isPlaying: true,
+      shouldPlay: true
+    };
+    const {rerender, getPlayer} =
+      render(<MediaPlayer {...requiredProps()}
+                          sources={getVideoSources()}
+                          playerState={state} />);
+    const player = getPlayer();
+
+    state = {
+      ...state,
+      fadeDuration: 100,
+      shouldPlay: false
+    };
+    rerender(<MediaPlayer {...requiredProps()}
+                          sources={getVideoSources()}
+                          playerState={state} />);
+
+    expect(player.fadeOutAndPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls pause instead of fadeOutAndPause if player is muted', () => {
+    let state = {
+      ...getInitialPlayerState(),
+      isPlaying: true,
+      shouldPlay: true
+    };
+    const {rerender, getPlayer} =
+      render(<MediaPlayer {...requiredProps()}
+                          sources={getVideoSources()}
+                          playerState={state} />);
+    const player = getPlayer();
+    player.muted.mockReturnValue(true);
+
+    state = {
+      ...state,
+      fadeDuration: 100,
+      shouldPlay: false
+    };
+    rerender(<MediaPlayer {...requiredProps()}
+                          sources={getVideoSources()}
+                          playerState={state} />);
+
+    expect(player.fadeOutAndPause).not.toHaveBeenCalled();
+    expect(player.pause).toHaveBeenCalledTimes(1);
+  });
+
   it('sets initial volume factor accoring to playerState', () => {
     let state = {
       ...getInitialPlayerState(),

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/updatePlayerState.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/updatePlayerState.js
@@ -12,7 +12,7 @@ export function updatePlayerState(player, prevPlayerState, playerState, playerAc
     }
   }
   else if (prevPlayerState.shouldPlay && !playerState.shouldPlay && playerState.isPlaying) {
-    if (playerState.fadeDuration) {
+    if (playerState.fadeDuration && !player.muted()) {
       player.fadeOutAndPause(playerState.fadeDuration);
     }
     else {


### PR DESCRIPTION
When scrolling away from a media element that is playing without sound
while the audio context has not yet been resumed (i.e. auto play is
still forbidden by the browser), the controls switch to paused state,
but the element keeps playing. This can be observed in Chrome before
the first user interaction with the document.

The problem is caused by the fact that `AudioContext#resume` returns a
promise that stays pending when auto play is forbidden.
[`tryResumeIfSuspended`](https://github.com/codevise/pageflow/blob/62b7c1a8304c97d8fef9d5cdcfdeb143ed6159e1/package/src/frontend/mediaPlayer/volumeFading/webAudio.js#L23) in the `volumeFading/webAudio` module
therefore also stays pending. This causes `fadeVolume` to not
resolve. [`fadeOutAndPause`](https://github.com/codevise/pageflow/blob/62b7c1a8304c97d8fef9d5cdcfdeb143ed6159e1/package/src/frontend/mediaPlayer/volumeBinding.js#L48), which is [called on deactivation](https://github.com/codevise/pageflow/blob/62b7c1a8304c97d8fef9d5cdcfdeb143ed6159e1/entry_types/scrolled/package/src/contentElements/inlineVideo/InlineVideo.js#L31),
thus does not pause in this case. At least in Scrolled, players will
always be muted in this situation. In the general case it is not
clear, though, whether for a muted player `fadeOutAndPause` should
still wait for the delay to pass before resolving. Also in Paged,
`fadeOutAndPause` can be called on `audio5js` players which do not
implemented a `muted` method.

For the Scrolled MediaPlayer, it makes sense to immediately pause on
`fadeOutAndPause` if the player is muted. So this looks like a safe
place to work around the problem.

REDMINE-18168
