### PR TITLE
Don't remove media tag when unallocating player in IE 11

### DIFF
--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/PlayerContainer.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/PlayerContainer.js
@@ -27,16 +27,16 @@ function PlayerContainer({
         mediaEventsContextData,
         altText
       });
+      playerWrapper.appendChild(player.el());
 
-      let playerElement = player.el();
-      playerWrapper.appendChild(playerElement);
       if (onSetup) {
         onSetup(player);
       }
 
       return () => {
         media.releasePlayer(player);
-        playerWrapper.innerHTML = '';
+        playerWrapper.removeChild(player.el());
+
         if (onDispose) {
           onDispose();
         }


### PR DESCRIPTION
Setting `innerHTML` of the `PlayerContainer` to an empty string
apparently also removes all children from the player div that is
stored in the media pool. Removing the child explicitly instead.

REDMINE-18118