### PR TITLE
Fix classic loading spinner preview in editor

### DIFF
--- a/app/assets/stylesheets/pageflow/loading_spinner.scss
+++ b/app/assets/stylesheets/pageflow/loading_spinner.scss
@@ -1,4 +1,7 @@
 .loading_spinner {
+  // Ensure loading spinner does not cover page if JS is
+  // disabled. Will be overridden by
+  // layouts/pageflow_paged/_loading_spinner_inline_script.html.erb
   display: none;
 
   position: absolute;

--- a/entry_types/paged/app/views/layouts/pageflow_paged/_loading_spinner_inline_script.html.erb
+++ b/entry_types/paged/app/views/layouts/pageflow_paged/_loading_spinner_inline_script.html.erb
@@ -1,3 +1,4 @@
+<%# Ensure loading spinner is visible if JavaScript is enabled. %>
 <script>
   document.write(
     '<style>' +

--- a/entry_types/paged/app/views/layouts/pageflow_paged/application.html.erb
+++ b/entry_types/paged/app/views/layouts/pageflow_paged/application.html.erb
@@ -9,7 +9,7 @@
 
   <%= javascript_include_tag 'pageflow_paged/vendor', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'pageflow_paged/frontend', 'data-turbolinks-track' => true %>
-  
+
   <meta charset="utf-8" />
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, minimum-scale=1, maximum-scale=1" />

--- a/entry_types/paged/app/views/pageflow_paged/editor/entries/_head.html.erb
+++ b/entry_types/paged/app/views/pageflow_paged/editor/entries/_head.html.erb
@@ -1,6 +1,8 @@
 <%= stylesheet_link_tag 'pageflow/application_with_simulated_media_queries', media: 'all' %>
 <%= stylesheet_link_tag 'pageflow_paged/editor', media: 'all' %>
 
+<%= render 'layouts/pageflow_paged/loading_spinner_inline_script' %>
+
 <script>
   window.PAGEFLOW_EDITOR = true;
 </script>


### PR DESCRIPTION
Before the paged entry type was extracted, the editor used the same
layout as the published entries. Once the paged entries used their own
layout [1], the editor got a separate layout [2] and everything
related to Paged was removed [3]. We missed that the loading spinner
inline script was also needed inside the editor to ensure the preview
could be displayed. Add it back to the paged head editor partial.

We also could have added the rule to an editor stylesheet, but that
would have meant introducing a third place where loading spinner
display is controlled. This way editor and published entry work the
same way.

REDMINE-17738

[1] https://github.com/codevise/pageflow/commit/b0762674c999140021dc725f4445d21b3e72a417#diff-d6c740536eb9bfa6732ef7dfa73df647cae865b6d4a0f7d48ea309ded4c745aa
[2] https://github.com/codevise/pageflow/commit/1ee34a99ca0ae79aa6d700a19a21b3b26839ded2#diff-bf899f40e327b5be0b920c45d6a8602eddfbd0bdbf90e1cdd312c696cec13ec9
[3] https://github.com/codevise/pageflow/commit/e83409db124ead25864ce9def998e781809b0065#diff-bf899f40e327b5be0b920c45d6a8602eddfbd0bdbf90e1cdd312c696cec13ec9