### PR TITLE
Cascade model removal through ForeignKeySubsetCollection

### DIFF
--- a/entry_types/scrolled/package/src/editor/models/Chapter.js
+++ b/entry_types/scrolled/package/src/editor/models/Chapter.js
@@ -24,7 +24,8 @@ export const Chapter = Backbone.Model.extend({
       parent: options.sections,
       parentModel: this,
       foreignKeyAttribute: 'chapterId',
-      parentReferenceAttribute: 'chapter'
+      parentReferenceAttribute: 'chapter',
+      autoConsolidatePositions: false
     });
     this.entry = options.entry;
   },

--- a/package/src/editor/collections/ForeignKeySubsetCollection.js
+++ b/package/src/editor/collections/ForeignKeySubsetCollection.js
@@ -49,7 +49,8 @@ export const ForeignKeySubsetCollection = SubsetCollection.extend({
       model.set(options.foreignKeyAttribute, parentModel.id);
     });
 
-    this.listenTo(parentModel, 'destroy', function() {
+    this.listenTo(parentModel, 'destroy dependentDestroy', function() {
+      this.invoke('trigger', 'dependentDestroy');
       this.clear();
     });
 


### PR DESCRIPTION
Ensure content elements are removed from `entry.contentElements` Backbone
collection when a chapter is deleted. Before, deleting a chapter already
removed sections and removing a section already removed content elements,
but removal did not cascade across multiple levels.

When new content elements were created afterwards, those received the same
perma ids as the left over content elements causing duplicates to show up
in the preview.

REDMINE-18272