### PR TITLE
Display notices for unsupported browser or non-js

### DIFF
--- a/entry_types/scrolled/app/views/pageflow_scrolled/entries/_global_notices.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entries/_global_notices.html.erb
@@ -1,0 +1,10 @@
+<div class="globalNotices">
+  <div class="unsupported">
+    <%= t('pageflow_scrolled.public.unsupported_browser') %>
+  </div>
+  <noscript>
+    <div>
+      <%= t('pageflow_scrolled.public.js_required') %>
+    </div>
+  </noscript>
+</div>

--- a/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
@@ -34,7 +34,8 @@
   <body>
     <%= structured_data_for_entry(@entry) unless @skip_structured_data %>
 
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <%= render 'pageflow_scrolled/entries/global_notices' %>
+
     <div id="root"><%= render_scrolled_entry(@entry) unless @skip_ssr %></div>
 
     <div id='template-widget-container'>

--- a/entry_types/scrolled/config/locales/new/global_notices.de.yml
+++ b/entry_types/scrolled/config/locales/new/global_notices.de.yml
@@ -1,0 +1,5 @@
+de:
+  pageflow_scrolled:
+    public:
+      js_required: "Bitte aktivieren Sie JavaScript, um diese Website korrekt anzuzeigen."
+      unsupported_browser: "Diese Website verwendet Funktionen, die Ihr Browser nicht unterstützt. Bitte aktualisieren Sie Ihren Browser auf eine aktuelle Version."

--- a/entry_types/scrolled/config/locales/new/global_notices.en.yml
+++ b/entry_types/scrolled/config/locales/new/global_notices.en.yml
@@ -1,0 +1,5 @@
+en:
+  pageflow_scrolled:
+    public:
+      js_required: "Please activate JavaScript to make this website display correctly."
+      unsupported_browser: "This website uses features that your browser doesn't support. Please upgrade to a recent version of your browser."

--- a/entry_types/scrolled/package/src/frontend/globalNotices.module.css
+++ b/entry_types/scrolled/package/src/frontend/globalNotices.module.css
@@ -1,0 +1,24 @@
+:global .globalNotices {
+  z-index: 100000000;
+  position: fixed;
+  bottom: 10px;
+  left: 10px;
+}
+
+/* IE <= 11 does not know @supports and thus ignores this rule. In all
+   other browsers the condition evaluates to true. */
+@supports not (old: ie) {
+  :global .unsupported {
+    display: none;
+  }
+}
+
+:global .globalNotices div {
+  background: #fff;
+  padding: 20px;
+  max-width: 240px;
+  box-shadow: 0 3px 3px -2px rgba(0,0,0,.2), 0 3px 4px 0 rgba(0,0,0,.14), 0 1px 8px 0 rgba(0,0,0,.12);
+  font-family: 'Source Sans Pro';
+  border-top: solid 2px #a50e0e;
+  margin-top: 10px;
+}

--- a/entry_types/scrolled/package/src/frontend/index.js
+++ b/entry_types/scrolled/package/src/frontend/index.js
@@ -1,4 +1,5 @@
 import './polyfills';
+import './globalNotices.module.css';
 
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
IE 11 currently renders the entry, but does not scale backdrop assets
correctly (due to missing `object-fit` support) and renders section
transition incorrectly (due to missing `position sticky` support).

REDMINE-18283