### PR TITLE
Upgrade to Devise 4.7

### DIFF
--- a/admins/pageflow/user.rb
+++ b/admins/pageflow/user.rb
@@ -25,8 +25,6 @@ module Pageflow
       column :first_name
       column :last_name
       column :email
-      column :last_sign_in_at
-      column :sign_in_count
       column :suspended?
     end
 

--- a/app/views/pageflow/admin/initial_passwords/edit.html.erb
+++ b/app/views/pageflow/admin/initial_passwords/edit.html.erb
@@ -1,7 +1,8 @@
 <div id="login">
   <h2><%= render_or_call_method_or_proc_on(self, active_admin_application.site_title) %> - <%= title t('pageflow.initial_password.title') %></h2>
 
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
   <%= active_admin_form_for(resource, as: resource_name, url: admin_initial_password_path, html: { method: :put }) do |f|
     f.inputs do
       f.input :password

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -31,7 +31,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'activeadmin-searchable_select', '~> 1.0'
 
   # User authentication
-  s.add_dependency 'devise', '~> 4.4.0'
+  #
+  # Pageflow::UserMixin depends on Devise internals. We therefore use
+  # a conservative version constraint.
+  s.add_dependency 'devise', '~> 4.7.3'
 
   # Faster JSON backend
   s.add_dependency 'yajl-ruby', '~> 1.2'


### PR DESCRIPTION
`trackable` module is no longer enabled by default. Remove columns
from CSV report to stay compatible with new default.

Replace deprecated error messages helper.

REDMINE-18256