### PR TITLE
Validate user locale

### DIFF
--- a/lib/pageflow/user_mixin.rb
+++ b/lib/pageflow/user_mixin.rb
@@ -24,6 +24,7 @@ module Pageflow
       has_many :revisions, class_name: 'Pageflow::Revision', foreign_key: :creator_id
 
       validates :first_name, :last_name, presence: true
+      validates_inclusion_of :locale, in: Pageflow.config.available_locales.map(&:to_s)
 
       scope :admins, -> { where(admin: true) }
     end
@@ -41,7 +42,7 @@ module Pageflow
     end
 
     def locale
-      super.presence || I18n.default_locale
+      super.presence || I18n.default_locale.to_s
     end
 
     def update_with_password(attributes)

--- a/spec/models/pageflow/user_spec.rb
+++ b/spec/models/pageflow/user_spec.rb
@@ -69,13 +69,19 @@ module Pageflow
       it 'falls back to default_locale' do
         user = build(:user, locale: '')
 
-        expect(user.locale).to eq(I18n.default_locale)
+        expect(user.locale).to eq(I18n.default_locale.to_s)
       end
 
       it 'returns present attribute' do
         user = build(:user, locale: 'fr')
 
         expect(user.locale).to eq('fr')
+      end
+
+      it 'ensures folder belongs to same account' do
+        user = build(:user, locale: 'not-a-locale')
+
+        expect(user).to have(1).error_on(:locale)
       end
     end
   end


### PR DESCRIPTION
Prevent storing invalid locales which will then cause an exception
when `I18n.locale` is set for user.

REDMINE-18256