### PR TITLE
Fix lazy loading in editor for Safari

### DIFF
--- a/entry_types/scrolled/package/src/frontend/polyfills.js
+++ b/entry_types/scrolled/package/src/frontend/polyfills.js
@@ -8,8 +8,17 @@ import 'core-js/features/set';
 import 'core-js/features/symbol';
 import 'core-js/features/symbol/iterator';
 
-import 'intersection-observer';
 import 'regenerator-runtime/runtime.js';
+
+import {browser} from 'pageflow/frontend';
+
+// Safari does not handle positive root margin correctly inside
+// iframes. Use polyfill instead.
+if (browser.agent.matchesSafari() && window.parent !== window) {
+  delete window.IntersectionObserver;
+}
+
+require('intersection-observer');
 
 // Make sure we're in a Browser-like environment before importing polyfills
 // This prevents `fetch()` from being imported in a Node test environment


### PR DESCRIPTION
Passing the document `root`, which fixes positive root margin handling
in iframes for Chrome, causes `IntersectionObserver` not to trigger
callback at all in Safari. Without `root` option, Safari still ignores
positive root margins in iframes. Delete the built-in to ensure the
polyfill is loaded instead.

REDMINE-18070