### PR TITLE
Revert "Ensure JS errors can be reported when asset host is used"

### DIFF
--- a/entry_types/paged/app/views/pageflow_paged/editor/entries/_head.html.erb
+++ b/entry_types/paged/app/views/pageflow_paged/editor/entries/_head.html.erb
@@ -7,8 +7,8 @@
   window.PAGEFLOW_EDITOR = true;
 </script>
 
-<%= javascript_include_tag 'pageflow_paged/vendor', crossorigin: 'anonymous' %>
-<%= javascript_include_tag 'pageflow_paged/frontend', crossorigin: 'anonymous' %>
-<%= javascript_include_tag 'pageflow_paged/editor', crossorigin: 'anonymous' %>
+<%= javascript_include_tag 'pageflow_paged/vendor' %>
+<%= javascript_include_tag 'pageflow_paged/frontend' %>
+<%= javascript_include_tag 'pageflow_paged/editor' %>
 
 <%= render 'layouts/pageflow_paged/ie_include_tags' %>

--- a/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
@@ -1,6 +1,6 @@
 <%= stylesheet_link_tag 'pageflow_paged/editor', media: 'all' %>
 <%= stylesheet_pack_tag 'pageflow-scrolled-theme' %>
 
-<%= javascript_include_tag 'pageflow/vendor', crossorigin: 'anonymous' %>
-<%= javascript_include_tag 'pageflow/editor/vendor', crossorigin: 'anonymous' %>
-<%= javascript_pack_tag 'pageflow-scrolled-editor', crossorigin: 'anonymous' %>
+<%= javascript_include_tag 'pageflow/vendor' %>
+<%= javascript_include_tag 'pageflow/editor/vendor' %>
+<%= javascript_pack_tag 'pageflow-scrolled-editor' %>


### PR DESCRIPTION
Reverts codevise/pageflow#1656

Does not work if asset host does not set CORS headers. Therefore, cannot be the default.

REDMINE-18254