### PR TITLE
Allow non latin characters in video embed caption

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/heading/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/editor.js
@@ -1,11 +1,11 @@
 import {editor, NoOptionsHintView} from 'pageflow-scrolled/editor';
 
 editor.contentElementTypes.register('heading', {
-  supportedPositions: ['inline'],
+  supportedPositions: ['inline', 'full'],
 
   configurationEditor() {
     this.tab('general', function() {
-      this.view(NoOptionsHintView);
+      this.group('ContentElementPosition');
     });
   }
 });

--- a/entry_types/scrolled/package/src/contentElements/videoEmbed/VideoEmbed.js
+++ b/entry_types/scrolled/package/src/contentElements/videoEmbed/VideoEmbed.js
@@ -54,10 +54,11 @@ function PreparedPlayer({contentElementId, configuration, playerState, setPlayer
     }
   });
 
-  // base64-encoded configuration
-  // => make component re-render on configuration changes
+  // React player does not re-create player when controls or config
+  // prop changes. Ensure key changes to force React to re-mount
+  // component.
   function keyFromConfiguration(config) {
-    return btoa(JSON.stringify(config))
+    return [config.hideControls, config.hideInfo].join('');
   }
 
   return (


### PR DESCRIPTION
Previously used hash function only supported limited range of
characters as input.

REDMINE-18456