### PR TITLE
Improve file rights

### DIFF
--- a/entry_types/scrolled/config/locales/new/image_rights.de.yml
+++ b/entry_types/scrolled/config/locales/new/image_rights.de.yml
@@ -1,0 +1,4 @@
+de:
+  pageflow_scrolled:
+    public:
+      image_rights: "Bildrechte"

--- a/entry_types/scrolled/config/locales/new/image_rights.en.yml
+++ b/entry_types/scrolled/config/locales/new/image_rights.en.yml
@@ -1,0 +1,4 @@
+en:
+  pageflow_scrolled:
+    public:
+      image_rights: "Image rights"

--- a/entry_types/scrolled/package/spec/entryState/legalInfo-spec.js
+++ b/entry_types/scrolled/package/spec/entryState/legalInfo-spec.js
@@ -96,7 +96,7 @@ describe('useFileRights', () => {
     );
 
     const fileRights = result.current;
-    expect(fileRights).toMatch(': author');
+    expect(fileRights).toEqual('author');
   });
 
   it('returns comma separated list of file rights', () => {
@@ -112,20 +112,41 @@ describe('useFileRights', () => {
     );
 
     const fileRights = result.current;
-    expect(fileRights).toMatch(': author1, author2');
+    expect(fileRights).toEqual('author1, author2');
   });
 
   it('falls back to default file rights', () => {
     const {result} = renderHookInEntry(
       () => useFileRights(), {
         seed: {
+          imageFiles: [
+            {}
+          ],
           defaultFileRights: 'default'
         }
       }
     );
 
     const fileRights = result.current;
-    expect(fileRights).toMatch(': default');
+    expect(fileRights).toEqual('default');
+  });
+
+  it('deduplicates file rights', () => {
+    const {result} = renderHookInEntry(
+      () => useFileRights(), {
+        seed: {
+          imageFiles: [
+            {rights: 'author1'},
+            {rights: 'author2'},
+            {rights: 'author1'},
+          ],
+          defaultFileRights: 'author1'
+        }
+      }
+    );
+
+    const fileRights = result.current;
+    expect(fileRights).toEqual('author1, author2');
   });
 
   it('does not insert extra comma if a file has no rights and defaults are not configured', () => {
@@ -142,20 +163,37 @@ describe('useFileRights', () => {
     );
 
     const fileRights = result.current;
-    expect(fileRights).toMatch(': author2');
+    expect(fileRights).toEqual('author2');
   });
 
   it('returns empty string if no rights are defined', () => {
     const {result} = renderHookInEntry(
       () => useFileRights(), {
         seed: {
+          imageFiles: [
+            {},
+          ],
           defaultFileRights: ''
         }
       }
     );
 
     const fileRights = result.current;
-    expect(fileRights).toMatch('');
+    expect(fileRights).toEqual('');
+  });
+
+  it('returns empty string if no image files are present', () => {
+    const {result} = renderHookInEntry(
+      () => useFileRights(), {
+        seed: {
+          imageFiles: [],
+          defaultFileRights: 'default'
+        }
+      }
+    );
+
+    const fileRights = result.current;
+    expect(fileRights).toEqual('');
   });
 
   it('reads data from watched collection', () => {
@@ -183,6 +221,6 @@ describe('useFileRights', () => {
     );
 
     const fileRights = result.current;
-    expect(fileRights).toMatch(': author');
+    expect(fileRights).toEqual('author');
   });
 });

--- a/entry_types/scrolled/package/src/entryState/legalInfo.js
+++ b/entry_types/scrolled/package/src/entryState/legalInfo.js
@@ -17,17 +17,11 @@ export function useFileRights() {
   const config = useEntryStateConfig();
   const imageFiles = useEntryStateCollectionItems('imageFiles');
 
-  const defaultFileRights = config.defaultFileRights;
-  const imageFileRights = imageFiles.reduce(function(result, imageConfig) {
-    if(imageConfig && imageConfig.rights) {
-      result.push(imageConfig.rights.trim());
-    }
-    return result;
-  }, []).filter(Boolean).join(', ');
-  const fileRights = !!imageFileRights ? imageFileRights : defaultFileRights.trim();
-  const fileRightsString = !!fileRights ? ('Bildrechte: ' + fileRights) : '';
+  const defaultFileRights = config.defaultFileRights?.trim();
 
-  return fileRightsString;
+  return Array.from(new Set(imageFiles.map(function(imageFile) {
+    return imageFile.rights?.trim() || defaultFileRights;
+  }))).filter(Boolean).join(', ');
 }
 
 /**

--- a/entry_types/scrolled/package/src/frontend/navigation/LegalInfoMenu.js
+++ b/entry_types/scrolled/package/src/frontend/navigation/LegalInfoMenu.js
@@ -22,7 +22,7 @@ export function LegalInfoMenu(props) {
       }
 
       {fileRights &&
-       <p>{fileRights}</p>
+       <p>{t('pageflow_scrolled.public.image_rights')}: {fileRights}</p>
       }
 
       <LegalInfoLink {...legalInfo.imprint}/>

--- a/entry_types/scrolled/package/src/frontend/polyfills.js
+++ b/entry_types/scrolled/package/src/frontend/polyfills.js
@@ -1,5 +1,6 @@
 import 'core-js/features/array/fill';
 import 'core-js/features/array/find';
+import 'core-js/features/array/from'
 import 'core-js/features/object/assign';
 import 'core-js/features/promise';
 import 'core-js/features/map';


### PR DESCRIPTION
* Do not display duplicate entries if multiple images have the same
  rights strings.

* Only fall back to default rightsif there is an image with an empty
  rights string.

* Extract german "Bildrechte" string to translation.

REDMINE-18444