### PR TITLE
Do not trigger multiple save requests for backdrop updates

### DIFF
--- a/entry_types/scrolled/package/spec/editor/models/SectionConfiguration-spec.js
+++ b/entry_types/scrolled/package/spec/editor/models/SectionConfiguration-spec.js
@@ -67,6 +67,18 @@ describe('SectionConfiguration', () => {
     });
   });
 
+  describe('set backdrop*', () => {
+    it('does not raise multiple change events', () => {
+      const sectionConfiguration = new SectionConfiguration();
+      const listener = jest.fn();
+
+      sectionConfiguration.on('change', listener);
+      sectionConfiguration.set('backdropImage', 1);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('set backdropImage', () => {
     it('sets backdrop image to value', () => {
       const sectionConfiguration = new SectionConfiguration();

--- a/entry_types/scrolled/package/src/editor/models/SectionConfiguration.js
+++ b/entry_types/scrolled/package/src/editor/models/SectionConfiguration.js
@@ -13,12 +13,12 @@ export const SectionConfiguration = Configuration.extend({
     Configuration.prototype.initialize.apply(this, arguments);
 
     this.attributes = {
-      ...this.getBackdropAttributes(),
+      ...this.getAttributesFromBackdropAttribute(),
       ...this.attributes
     }
   },
 
-  getBackdropAttributes() {
+  getAttributesFromBackdropAttribute() {
     const backdrop = this.attributes.backdrop || {};
 
     if (backdrop.image && backdrop.image.toString().startsWith('#')) {
@@ -49,33 +49,38 @@ export const SectionConfiguration = Configuration.extend({
   },
 
   set: function(name, value) {
-    Configuration.prototype.set.apply(this, arguments);
-
-    if (name !== 'backdrop' &&
-        name.startsWith &&
-        name.startsWith('backdrop')) {
-      this.updateBackdropAttribute();
+    if (name !== 'backdrop' && name.startsWith && name.startsWith('backdrop')) {
+      Configuration.prototype.set.call(this, {
+        backdrop: this.getBackdropAttribute({
+          ...this.attributes,
+          [name]: value
+        }),
+        [name]: value
+      });
+    }
+    else {
+      Configuration.prototype.set.apply(this, arguments);
     }
   },
 
-  updateBackdropAttribute() {
-    switch (this.get('backdropType')) {
+  getBackdropAttribute(nextAttributes) {
+    switch (nextAttributes.backdropType) {
     case 'color':
-      return this.set('backdrop', {
-        color: this.get('backdropColor')
-      });
+      return {
+        color: nextAttributes.backdropColor
+      };
     case 'video':
-      return this.set('backdrop', {
-        video: this.get('backdropVideo'),
-        videoMotifArea: this.get('backdropVideoMotifArea')
-      });
+      return {
+        video: nextAttributes.backdropVideo,
+        videoMotifArea: nextAttributes.backdropVideoMotifArea
+      };
     default:
-      return this.set('backdrop', {
-        image: this.get('backdropImage'),
-        imageMotifArea: this.get('backdropImageMotifArea'),
-        imageMobile: this.get('backdropImageMobile'),
-        imageMobileMotifArea: this.get('backdropImageMobileMotifArea')
-      });
+      return {
+        image: nextAttributes.backdropImage,
+        imageMotifArea: nextAttributes.backdropImageMotifArea,
+        imageMobile: nextAttributes.backdropImageMobile,
+        imageMobileMotifArea: nextAttributes.backdropImageMobileMotifArea
+      };
     }
   }
 });


### PR DESCRIPTION
Setting section configuration attributes like `backdropType` or
`backdropImage` also updates the `backdrop` attribute which is read in
frontend code. So far these updates each triggered a save request,
which could lead to race conditions when different Passenger processes
handled these requests concurrently since the first request still
contained an old value for the `backdrop` attribute.

Perform both updates in a single `set` call. It would probably be
better to not store `backdrop` at all and compute it in the structure
hooks. For now, we went with the smaller change, though.

REDMINE-18462