### PR TITLE
Handle player unallocated by empty pool

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/MediaPlayer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/MediaPlayer-spec.js
@@ -211,6 +211,28 @@ describe('MediaPlayer', () => {
     expect(media.getPlayer).toHaveBeenCalledTimes(2);
   });
 
+  it('releases player on unmount', () => {
+    const {getPlayer, unmount} =
+      render(<MediaPlayer {...requiredProps()}
+                          sources={getVideoSources({basename: 'example'})} />);
+
+    const player = getPlayer();
+    unmount();
+
+    expect(media.releasePlayer).toHaveBeenCalledWith(player);
+  });
+
+  it('does release player on unmount if it has been released by pool already', () => {
+    const {getPlayer, unmount} =
+      render(<MediaPlayer {...requiredProps()}
+                          sources={getVideoSources({basename: 'example'})} />);
+
+    getPlayer().releaseCallback();
+    unmount();
+
+    expect(media.releasePlayer).not.toHaveBeenCalled();
+  });
+
   it('calls play on player when shouldPlay is true in initial playerState', () => {
     let state = {
       ...getInitialPlayerState(),

--- a/entry_types/scrolled/package/spec/support/fakeMedia.js
+++ b/entry_types/scrolled/package/spec/support/fakeMedia.js
@@ -52,13 +52,20 @@ export const fakeMediaRenderQueries = {
 
 export function useFakeMedia() {
   beforeEach(() => {
-    jest.spyOn(media, 'getPlayer').mockImplementation((sources, {filePermaId, textTrackSources}) =>
-      createFakePlayer({filePermaId, textTrackSources})
-    );
-    media.releasePlayer = (player) => {}
-  });
+    jest.restoreAllMocks();
 
-  afterEach(() => jest.restoreAllMocks());
+    jest.spyOn(media, 'releasePlayer').mockImplementation(player => {
+      if (player.releaseCallback) {
+        player.releaseCallback();
+      }
+    });
+
+    jest.spyOn(media, 'getPlayer').mockImplementation((sources, {filePermaId, textTrackSources, onRelease}) => {
+      const player = createFakePlayer({filePermaId, textTrackSources});
+      player.releaseCallback = onRelease;
+      return player;
+    });
+  });
 }
 
 function createFakePlayer({filePermaId, textTrackSources}) {

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/PlayerContainer.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/PlayerContainer.js
@@ -25,7 +25,16 @@ function PlayerContainer({
         controls: controls,
         hooks: atmoDuringPlayback ? atmo.createMediaPlayerHooks(atmoDuringPlayback) : {}, //create hooks only for inline media players
         mediaEventsContextData,
-        altText
+        altText,
+
+        onRelease() {
+          playerWrapper.removeChild(player.el());
+          player = null;
+
+          if (onDispose) {
+            onDispose();
+          }
+        }
       });
       playerWrapper.appendChild(player.el());
 
@@ -34,11 +43,10 @@ function PlayerContainer({
       }
 
       return () => {
-        media.releasePlayer(player);
-        playerWrapper.removeChild(player.el());
-
-        if (onDispose) {
-          onDispose();
+        // onRelease might already have been called by the pool when
+        // it needed to re-use a player.
+        if (player) {
+          media.releasePlayer(player);
         }
       }
     }

--- a/package/spec/frontend/media/MediaPool_spec.js
+++ b/package/spec/frontend/media/MediaPool_spec.js
@@ -46,24 +46,25 @@ describe('MediaPool', function() {
     });
 
     it('reallocates the first allocated player if there is no more available player', function () {
-      let pool = new MediaPool();
-      for(let i = 0; i < pool.playerCount; i++){
-        pool.allocatePlayer({
-          playerType: MediaType.VIDEO
-        });
-      }
+      const pool = new MediaPool({playerCount: 2});
 
-      expect(pool.unAllocatedPlayers[MediaType.VIDEO].length).toBe(0);
-
-      let firstPlayer = pool.allocatedPlayers[MediaType.VIDEO][0];
-      let player = pool.allocatePlayer({
-        playerType: MediaType.VIDEO
-      });
-
-      expect(pool.unAllocatedPlayers[MediaType.VIDEO].length).toBe(0);
+      const firstPlayer = pool.allocatePlayer({playerType: MediaType.VIDEO});
+      pool.allocatePlayer({playerType: MediaType.VIDEO});
+      const player = pool.allocatePlayer({playerType: MediaType.VIDEO});
 
       expect(player).toBeDefined();
       expect(player).toBe(firstPlayer);
+    });
+
+    it('calls onRelease callback for reallocated player if there is are no more available player', () => {
+      const pool = new MediaPool({playerCount: 2});
+      const callback = jest.fn();
+
+      pool.allocatePlayer({playerType: MediaType.VIDEO, onRelease: callback});
+      pool.allocatePlayer({playerType: MediaType.VIDEO});
+      pool.allocatePlayer({playerType: MediaType.VIDEO});
+
+      expect(callback).toHaveBeenCalled();
     });
 
     it('resets text tracks when player is reused', () => {
@@ -114,6 +115,18 @@ describe('MediaPool', function() {
       expect(player.currentSource()).toStrictEqual(blankSources[MediaType.VIDEO]);
     });
 
+    it('calls onRelease callback passed to allocatePlayer', () => {
+      const pool = new MediaPool();
+      const callback = jest.fn();
+      const player = pool.allocatePlayer({
+        playerType: MediaType.VIDEO,
+        onRelease: callback
+      });
+
+      pool.unAllocatePlayer(player);
+
+      expect(callback).toHaveBeenCalled();
+    });
   });
 
   describe('#blessAll', function() {

--- a/package/src/frontend/media/MediaPool.js
+++ b/package/src/frontend/media/MediaPool.js
@@ -32,8 +32,12 @@ export class MediaPool {
       }
     }
   }
-  allocatePlayer({playerType, playerId, playsInline, mediaEventsContextData,
-                  hooks, poster, loop = false, controls = false, altText}){
+
+  allocatePlayer({
+    playerType, playerId, playsInline, mediaEventsContextData,
+    hooks, poster, loop = false, controls = false, altText,
+    onRelease
+  }) {
     let player = undefined;
     if (!this.unAllocatedPlayers[playerType]) {
       this.populateMediaPool_();
@@ -43,8 +47,8 @@ export class MediaPool {
     }
 
     player = this.unAllocatedPlayers[playerType].pop();
-    if (player) {
 
+    if (player) {
       player.pause();
       player.getMediaElement().loop = loop;
       player.getMediaElement().setAttribute('alt', altText);
@@ -57,7 +61,10 @@ export class MediaPool {
       player.updateMediaEventsContext(mediaEventsContextData);
 
       this.allocatedPlayers[playerType].push(player);
+
       player.playerId = playerId || this.allocatedPlayers[playerType].length
+      player.releaseCallback = onRelease;
+
       return player;
     }
     else{
@@ -81,6 +88,11 @@ export class MediaPool {
       clearTextTracks(player);
 
       this.unAllocatedPlayers[type].push(player);
+
+      if (player.releaseCallback) {
+        player.releaseCallback();
+        player.releaseCallback = null;
+      }
     }
   }
   blessAll(value){


### PR DESCRIPTION
Do not try to remove a media element from the DOM that has already
been allocated by another player. Instead, detach and unwatch player
in `onRelease` callback that can be also invoked by the pool when it
decides to unallocate a player early.

REDMINE-18426