### PR TITLE
Fix embed video opt in text color in inverted section

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/videoEmbed/VideoEmbed.module.css
+++ b/entry_types/scrolled/package/src/contentElements/videoEmbed/VideoEmbed.module.css
@@ -1,5 +1,6 @@
 .VideoEmbed {
   background-color: #000;
+  color: #fff;
 }
 
 .embedPlayer {


### PR DESCRIPTION
Since background color is set to black, we also need to set the text
color to prevent displaying black text on back backgrounds in sections
with black text color.

REDMINE-18528