### PR TITLE
Hide frame around inline video on iOS 12

### DIFF
--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/videojsBase.module.css
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/videojsBase.module.css
@@ -160,3 +160,7 @@
 @media print {
   :global .video-js > *:not(.vjs-tech):not(.vjs-poster) {
     visibility: hidden; } }
+
+:global .vjs-resize-manager {
+  border: none;
+}


### PR DESCRIPTION
VideoJS inserts an iframe which becomes visible due to user agent
styles.

REDMINE-18552