### PR TITLE
Allow passing model to configuration editor tab

### DIFF
--- a/package/spec/ui/views/ConfigurationEditorView-spec.js
+++ b/package/spec/ui/views/ConfigurationEditorView-spec.js
@@ -1,9 +1,51 @@
 import {ConfigurationEditorView} from 'pageflow/ui';
 
+import Marionette from 'backbone.marionette';
+import Backbone from 'backbone';
+
 import * as support from '$support';
 import {Tabs} from '$support/dominos/ui'
 
 describe('ConfigurationEditorView', () => {
+  it('passes model to inputs', () => {
+    let inputView;
+    const InputView = Marionette.View.extend({
+      initialize() {
+        inputView = this;
+      }
+    });
+    const model = new Backbone.Model();
+    const configurationEditorView = new ConfigurationEditorView({model});
+
+    configurationEditorView.tab('one', function() {
+      this.input('name', InputView);
+    });
+
+    configurationEditorView.render();
+
+    expect(inputView.model).toBe(model);
+  });
+
+  it('allows overriding model per tab', () => {
+    let inputView;
+    const InputView = Marionette.View.extend({
+      initialize() {
+        inputView = this;
+      }
+    });
+    const model = new Backbone.Model();
+    const tabModel = new Backbone.Model();
+    const configurationEditorView = new ConfigurationEditorView({model});
+
+    configurationEditorView.tab('one', {model: tabModel}, function() {
+      this.input('name', InputView);
+    });
+
+    configurationEditorView.render();
+
+    expect(inputView.model).toBe(tabModel);
+  });
+
   describe('without tab translation key option', () => {
     support.useFakeTranslations({
       'pageflow.ui.configuration_editor.tabs.one': 'Tab one',

--- a/package/src/ui/views/ConfigurationEditorView.js
+++ b/package/src/ui/views/ConfigurationEditorView.js
@@ -44,10 +44,13 @@ export const ConfigurationEditorView = Marionette.View.extend({
 
   configure: function() {},
 
-  tab: function(name, callback) {
+  tab: function(name, callbackOrOptions, callback) {
+    callback = callback || callbackOrOptions;
+    const options = callback ? callbackOrOptions : {};
+
     this.tabsView.tab(name, _.bind(function() {
       var tabView = new ConfigurationEditorTabView({
-        model: this.model,
+        model: options.model || this.model,
         placeholderModel: this.options.placeholderModel,
         tab: name,
         attributeTranslationKeyPrefixes: this.options.attributeTranslationKeyPrefixes


### PR DESCRIPTION
Shorthand to let all views/inputs on a tab use a common model.

REDMINE-18761