### PR TITLE
Do not use import/export keywords in vendored deps

### DIFF
--- a/package/src/vendor/backbone.babysitter.js
+++ b/package/src/vendor/backbone.babysitter.js
@@ -1,5 +1,5 @@
-import Backbone from 'backbone';
-import _ from 'underscore';
+const Backbone = require('backbone');
+const _ = require('underscore');
 
 /*!
  * Includes BabySitter
@@ -24,8 +24,8 @@ import _ from 'underscore';
 // Provide a container to store, retrieve and
 // shut down child views.
 
-export default (function(Backbone, _){
-  
+module.exports = (function(Backbone, _){
+
   // Container Constructor
   // ---------------------
 

--- a/package/src/vendor/backbone.js
+++ b/package/src/vendor/backbone.js
@@ -1,6 +1,6 @@
-import $ from 'jquery';
-import _ from 'underscore';
-import Cocktail from 'cocktail';
+const $ = require('jquery');
+const _ = require('underscore');
+const Cocktail = require('cocktail');
 
 //     Backbone.js 1.0.0
 
@@ -1571,4 +1571,4 @@ import Cocktail from 'cocktail';
   Cocktail.patch(Backbone);
 }).call(window);
 
-export default Backbone;
+module.exports = Backbone;

--- a/package/src/vendor/backbone.marionette.js
+++ b/package/src/vendor/backbone.marionette.js
@@ -1,6 +1,6 @@
-import $ from 'jquery';
-import Backbone from 'backbone';
-import _ from 'underscore';
+const $ = require('jquery');
+const Backbone = require('backbone');
+const _ = require('underscore');
 
 // MarionetteJS (Marionette)
 // ----------------------------------
@@ -2366,4 +2366,4 @@ _.extend(Marionette.Module, {
   return Marionette;
 })(window, Backbone, _);
 
-export default Marionette;
+module.exports = Marionette;

--- a/package/src/vendor/cocktail.js
+++ b/package/src/vendor/cocktail.js
@@ -1,4 +1,4 @@
-import _ from 'underscore';
+const _ = require('underscore');
 
 //     Cocktail.js 0.3.0
 //     (c) 2012 Onsi Fakhouri
@@ -78,4 +78,4 @@ import _ from 'underscore';
         });
     };
 
-export default Cocktail;
+module.exports = Cocktail;

--- a/package/src/vendor/i18n.js
+++ b/package/src/vendor/i18n.js
@@ -450,4 +450,4 @@ I18n.t = I18n.translate;
 I18n.l = I18n.localize;
 I18n.p = I18n.pluralize;
 
-export default I18n;
+module.exports = I18n;

--- a/package/src/vendor/iscroll.js
+++ b/package/src/vendor/iscroll.js
@@ -1831,4 +1831,4 @@ return IScroll;
 
 })(window, document, Math);
 
-export default IScroll;
+module.exports = IScroll;

--- a/package/src/vendor/jquery-ui/index.js
+++ b/package/src/vendor/jquery-ui/index.js
@@ -1,4 +1,4 @@
-import './core';
-import './widget';
-import './menu';
-import './selectmenu';
+require('./core');
+require('./widget');
+require('./menu');
+require('./selectmenu');


### PR DESCRIPTION
Let external packages re-use the vendored legacy JS libraries without
needing to enable Babel for the node module. Use
`require`/`module.exports` instead.

REDMINE-18761