### PR TITLE
Make heading text size configurable

### DIFF
--- a/entry_types/scrolled/config/locales/new/header_size.de.yml
+++ b/entry_types/scrolled/config/locales/new/header_size.de.yml
@@ -1,0 +1,17 @@
+de:
+  pageflow_scrolled:
+    editor:
+      content_elements:
+        heading:
+          attributes:
+            textSize:
+              label: "Schriftgröße"
+              values:
+                auto: "(Automatisch)"
+                large: "Groß"
+                medium: "Mittel"
+                small: "Klein"
+              inline_help: |
+                Standardmäßig haben Überschriften im ersten Abschnitt
+                des Beitrags große Schrift. Überschriften in späteren
+                Abschnitten verwenden Schriftgröße "Klein".

--- a/entry_types/scrolled/config/locales/new/header_size.en.yml
+++ b/entry_types/scrolled/config/locales/new/header_size.en.yml
@@ -1,0 +1,17 @@
+en:
+  pageflow_scrolled:
+    editor:
+      content_elements:
+        heading:
+          attributes:
+            textSize:
+              label: "Text size"
+              values:
+                auto: "(Auto)"
+                large: "Large"
+                medium: "Medium"
+                small: "Small"
+              inline_help: |
+                By default, a heading in the first section of the
+                entry is large. Headings in later sections have small
+                text size.

--- a/entry_types/scrolled/package/src/contentElements/heading/Heading.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/Heading.js
@@ -5,7 +5,8 @@ import {
   Text,
   EditableInlineText,
   useContentElementConfigurationUpdate,
-  useI18n
+  useI18n,
+  useIsStaticPreview
 } from 'pageflow-scrolled/frontend';
 
 import styles from './Heading.module.css';
@@ -15,15 +16,21 @@ export function Heading({configuration, sectionProps}) {
   const firstSectionInEntry = level === 0;
   const updateConfiguration = useContentElementConfigurationUpdate();
   const {t} = useI18n({locale: 'ui'});
+  const isStaticPreview = useIsStaticPreview();
 
   const legacyValue = configuration.children;
 
+  // Prevent collision with legacy editor rules for h2 elements. We do
+  // not care about header structure in the static preview thumbnails.
+  const Tag = firstSectionInEntry || isStaticPreview ? 'h1' : 'h2';
+
   return (
-    <h1 className={classNames(styles.root,
-                              {[styles.first]: firstSectionInEntry},
-                              {[styles[sectionProps.layout]]: configuration.position === 'wide'},
-                              {[withShadowClassName]: !sectionProps.invert})}>
-      <Text scaleCategory={firstSectionInEntry ? 'h1' : 'h2'} inline={true}>
+    <Tag className={classNames(styles.root,
+                               {[styles.first]: firstSectionInEntry},
+                               {[styles[sectionProps.layout]]: configuration.position === 'wide'},
+                               {[withShadowClassName]: !sectionProps.invert})}>
+      <Text scaleCategory={getScaleCategory(configuration, firstSectionInEntry)}
+            inline={true}>
         <EditableInlineText value={configuration.value}
                             defaultValue={legacyValue}
                             placeholder={firstSectionInEntry ?
@@ -31,6 +38,19 @@ export function Heading({configuration, sectionProps}) {
                                          t('pageflow_scrolled.inline_editing.type_heading')}
                             onChange={value => updateConfiguration({value})} />
       </Text>
-    </h1>
+    </Tag>
   );
+}
+
+function getScaleCategory(configuration, firstSectionInEntry) {
+  switch (configuration.textSize) {
+    case 'large':
+      return 'h1';
+    case 'medium':
+      return 'h1-medium';
+    case 'small':
+      return 'h2';
+    default:
+      return firstSectionInEntry ? 'h1' : 'h2';
+  }
 }

--- a/entry_types/scrolled/package/src/contentElements/heading/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/editor.js
@@ -1,4 +1,5 @@
 import {editor} from 'pageflow-scrolled/editor';
+import {SelectInputView} from 'pageflow/ui';
 
 editor.contentElementTypes.register('heading', {
   supportedPositions: ['inline', 'wide'],
@@ -7,6 +8,9 @@ editor.contentElementTypes.register('heading', {
 
   configurationEditor() {
     this.tab('general', function() {
+      this.input('textSize', SelectInputView, {
+        values: ['auto', 'large', 'medium', 'small']
+      });
       this.group('ContentElementPosition');
     });
   }

--- a/entry_types/scrolled/package/src/contentElements/heading/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/stories.js
@@ -4,7 +4,7 @@ import {storiesOfContentElement} from 'pageflow-scrolled/spec/support/stories';
 storiesOfContentElement(module, {
   typeName: 'heading',
   baseConfiguration: {
-    children: 'Some Text',
+    children: 'Some Heading Text',
     level: 1
   },
   variants: [
@@ -12,6 +12,24 @@ storiesOfContentElement(module, {
       name: 'First headline in entry',
       configuration: {
         level: 0
+      }
+    },
+    {
+      name: 'Large',
+      configuration: {
+        textSize: 'large'
+      }
+    },
+    {
+      name: 'Medium',
+      configuration: {
+        textSize: 'medium'
+      }
+    },
+    {
+      name: 'Small',
+      configuration: {
+        textSize: 'small'
       }
     }
   ]

--- a/entry_types/scrolled/package/src/frontend/Text.js
+++ b/entry_types/scrolled/package/src/frontend/Text.js
@@ -7,7 +7,8 @@ import styles from './Text.module.css';
  * Render some text using the default typography scale.
  *
  * @param {Object} props
- * @param {string} props.scaleCategory - One of the styles `'h1'`, `'h2'`, `'body'`, `'caption'`.
+ * @param {string} props.scaleCategory -
+ *   One of the styles `'h1'`, `'h1-medium'`, `'h2'`, `'h3'`, `'body'`, `'caption'`.
  * @param {string} [props.inline] - Render a span instread of a div.
  * @param {string} props.children - Nodes to render with specified typography.
  */
@@ -20,5 +21,5 @@ export function Text({inline, scaleCategory, children}) {
 Text.propTypes = {
   children: PropTypes.node.isRequired,
   inline: PropTypes.bool,
-  scaleCategory: PropTypes.oneOf(['h1', 'h2', 'body', 'caption']),
+  scaleCategory: PropTypes.oneOf(['h1', 'h1-medium', 'h2', 'body', 'caption']),
 }

--- a/entry_types/scrolled/package/src/frontend/Text.module.css
+++ b/entry_types/scrolled/package/src/frontend/Text.module.css
@@ -1,16 +1,24 @@
 @value text-s: 20px;
 @value text-base: 22px;
 @value text-l: 40px;
+@value text-2l: 50px;
 @value text-xl: 66px;
-@value text-2xl: 110px;
+@value text-2xl: 88px;
+@value text-3xl: 110px;
 
 .h2 {
   font-size: text-xl;
   font-weight: 700;
+  line-height: 1;
+}
+
+.h1-medium {
+  font-size: text-2xl;
+  line-height: 1;
 }
 
 .h1 {
-  font-size: text-2xl;
+  font-size: text-3xl;
   line-height: 1;
 }
 
@@ -29,7 +37,13 @@
     font-size: text-l;
   }
 
+  .h1-medium {
+    font-size: text-2l;
+    line-height: 1.1;
+  }
+
   .h1 {
     font-size: text-xl;
+    line-height: 1.1;
   }
 }


### PR DESCRIPTION
So far headings in the first section were large, others
small. Introduce medium text size and allow overriding default.

REDMINE-19007