### PR TITLE
Use lazy opt-in consent paradigm for scrolled embeds

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/features/thirdPartyConsent-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/features/thirdPartyConsent-spec.js
@@ -88,6 +88,69 @@ describe('Third party consent', () => {
 
       expect(vendors).toMatchObject([{name: 'someService'}]);
     });
+
+    it('allows setting custom paradigm', async () => {
+      const consent = Consent.create();
+      jest.spyOn(consent, 'registerVendor');
+
+      frontend.contentElementTypes.register('test', {
+        consentVendors() {
+          return [{
+            name: 'vendor',
+            displayName: 'Vendor',
+            paradigm: 'lazy opt-in'
+          }];
+        },
+
+        component: function Component() {
+          return (<div />);
+        }
+      });
+
+      await renderEntry({
+        consent,
+        seed: {
+          themeOptions: {thirdPartyConsent: {cookieName: 'optIn'}},
+          contentElements: [{typeName: 'test', configuration: {provider: 'someService'}}]
+        }
+      });
+
+      expect(consent.registerVendor).toHaveBeenCalledWith(
+        'vendor',
+        expect.objectContaining({paradigm: 'lazy opt-in'})
+      )
+    });
+
+    it('ignores custom paradigm if no cookieName is set', async () => {
+      const consent = Consent.create();
+      jest.spyOn(consent, 'registerVendor');
+
+      frontend.contentElementTypes.register('test', {
+        consentVendors() {
+          return [{
+            name: 'vendor',
+            displayName: 'Vendor',
+            paradigm: 'lazy opt-in'
+          }];
+        },
+
+        component: function Component() {
+          return (<div />);
+        }
+      });
+
+      await renderEntry({
+        consent,
+        seed: {
+          contentElements: [{typeName: 'test', configuration: {provider: 'someService'}}]
+        }
+      });
+
+      expect(consent.registerVendor).toHaveBeenCalledWith(
+        'vendor',
+        expect.objectContaining({paradigm: 'skip'})
+      )
+    });
   });
 
   describe('opt in', () => {

--- a/entry_types/scrolled/package/src/contentElements/dataWrapperChart/frontend.js
+++ b/entry_types/scrolled/package/src/contentElements/dataWrapperChart/frontend.js
@@ -11,7 +11,8 @@ frontend.contentElementTypes.register('dataWrapperChart', {
     return [{
       name: 'datawrapper',
       displayName: t(`${prefix}.consent_vendor_name`),
-      description: t(`${prefix}.consent_vendor_description`)
+      description: t(`${prefix}.consent_vendor_description`),
+      paradigm: 'lazy opt-in'
     }];
   }
 });

--- a/entry_types/scrolled/package/src/contentElements/videoEmbed/frontend.js
+++ b/entry_types/scrolled/package/src/contentElements/videoEmbed/frontend.js
@@ -15,7 +15,8 @@ frontend.contentElementTypes.register('videoEmbed', {
       return [{
         name: provider,
         displayName: t(`${prefix}.${provider}.vendor_name`),
-        description: t(`${prefix}.${provider}.vendor_description`)
+        description: t(`${prefix}.${provider}.vendor_description`),
+        paradigm: 'lazy opt-in'
       }];
     }
 

--- a/entry_types/scrolled/package/src/frontend/thirdPartyConsent/registerVendors.js
+++ b/entry_types/scrolled/package/src/frontend/thirdPartyConsent/registerVendors.js
@@ -13,7 +13,7 @@ export function registerVendors({contentElementTypes, seed, consent}) {
       consent.registerVendor(vendor.name, {
         displayName: vendor.displayName,
         description: vendor.description,
-        paradigm: options?.cookieName ? 'opt-in' : 'skip',
+        paradigm: options?.cookieName ? (vendor.paradigm || 'opt-in') : 'skip',
         cookieName: options?.cookieName,
         cookieKey: options?.cookieProviderNameMapping?.[vendor.name],
         cookieDomain: options?.cookieDomain


### PR DESCRIPTION
Prevent showing consent UI if entry does not use analytics, only
embeds.

REDMINE-18993