### PR TITLE
Prevent interpreting external links as relative

### DIFF
--- a/entry_types/scrolled/package/spec/contentElements/externalLinkList/frontend/ExternalLink-spec.js
+++ b/entry_types/scrolled/package/spec/contentElements/externalLinkList/frontend/ExternalLink-spec.js
@@ -1,0 +1,32 @@
+import {ExternalLink} from 'contentElements/externalLinkList/frontend/ExternalLink';
+
+import React from 'react';
+
+import {renderInEntry} from 'support';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('ExternalLink', () => {
+  it('does not render url without protocol', () => {
+    const {getByRole} = renderInEntry(<ExternalLink url="example.com" />)
+
+    expect(getByRole('link')).toHaveAttribute('href', 'http://example.com');
+  });
+
+  it('preserves http url protocol', () => {
+    const {getByRole} = renderInEntry(<ExternalLink url="http://example.com" />)
+
+    expect(getByRole('link')).toHaveAttribute('href', 'http://example.com');
+  });
+
+  it('preserves protocol relative urls', () => {
+    const {getByRole} = renderInEntry(<ExternalLink url="//example.com" />)
+
+    expect(getByRole('link')).toHaveAttribute('href', '//example.com');
+  });
+
+  it('preserves https url protocol', () => {
+    const {getByRole} = renderInEntry(<ExternalLink url="https://example.com" />)
+
+    expect(getByRole('link')).toHaveAttribute('href', 'https://example.com');
+  });
+});

--- a/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLink.js
+++ b/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLink.js
@@ -9,6 +9,7 @@ export function ExternalLink(props) {
   const {t} = useI18n({locale: 'ui'});
   const {isEditable, isSelected} = useContentElementEditorState();
   const thumbnailImageFile = useFile({collectionName: 'imageFiles', permaId: props.thumbnail});
+  const url = ensureAbsolute(props.url);
 
   const onClick = function (event) {
     if (isEditable) {
@@ -29,7 +30,7 @@ export function ExternalLink(props) {
   function renderNewTabTooltip() {
     if (isEditable) {
       const onTooltipClick = function () {
-        window.open(props.url, '_blank');
+        window.open(url, '_blank');
         setHideTooltip(true);
       };
 
@@ -49,7 +50,7 @@ export function ExternalLink(props) {
                                [styles.invert]: props.invert,
                                [styles.layout_center]: layout === 'center'
                              })}
-       href={props.url || 'about:blank'}
+       href={url || 'about:blank'}
        onClick={onClick}
        onMouseLeave={onMouseLeave}
        target={props.open_in_new_tab ? '_blank' : '_self'}
@@ -68,4 +69,17 @@ export function ExternalLink(props) {
       {renderNewTabTooltip()}
     </a>
   );
+}
+
+ExternalLink.defaultProps = {
+  sectionProps: {}
+};
+
+function ensureAbsolute(url) {
+  if (url.match(/^(https?:)?\/\//)) {
+    return url;
+  }
+  else {
+    return `http://${url}`;
+  }
 }


### PR DESCRIPTION
Add default protocol to ensure URLs without a protocol are not
interpreted as relative paths.

REDMINE-18997