### PR TITLE
Improve supported host handling in url input

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/dataWrapperChart/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/dataWrapperChart/editor.js
@@ -10,14 +10,10 @@ editor.contentElementTypes.register('dataWrapperChart', {
     this.tab('general', function() {
       this.input('url', UrlInputView, {
          supportedHosts: [
-          'http://cf.datawrapper.de',
-          'https://cf.datawrapper.de',
-          'http://datawrapper.dwcdn.de',
-          'https://datawrapper.dwcdn.de',
-          'http://datawrapper.dwcdn.net',
-          'https://datawrapper.dwcdn.net',
-          'http://charts.datawrapper.de',
-          'https://charts.datawrapper.de',
+          'cf.datawrapper.de',
+          'charts.datawrapper.de',
+          'datawrapper.dwcdn.de',
+          'datawrapper.dwcdn.net'
         ],
         displayPropertyName: 'displayUrl',
         required: true,

--- a/package/spec/ui/views/inputs/UrlInputView-spec.js
+++ b/package/spec/ui/views/inputs/UrlInputView-spec.js
@@ -1,5 +1,7 @@
 import Backbone from 'backbone';
 
+import '@testing-library/jest-dom/extend-expect';
+
 import {UrlInputView} from 'pageflow/ui';
 
 describe('UrlInputView', () => {
@@ -130,7 +132,7 @@ describe('UrlInputView', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
-  it('triggers single model change event if valid', () => {
+  it('triggers single model change event if invalid', () => {
     var model = new Backbone.Model({
       url: 'http://example.com/some',
       displayUrl: 'http://example.com/some'
@@ -150,5 +152,144 @@ describe('UrlInputView', () => {
     input.trigger('change');
 
     expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be invalid if not a URL', () => {
+    var model = new Backbone.Model();
+    var view = new UrlInputView({
+      model: model,
+      propertyName: 'url',
+      displayPropertyName: 'displayUrl',
+      supportedHosts: ['example.com']
+    });
+
+    view.render();
+    var input = view.$el.find('input');
+    input.val('not-a-url');
+    input.trigger('change');
+
+    expect(input[0]).toBeInvalid();
+  });
+
+  it('should be invalid if URL has unsupported host', () => {
+    var model = new Backbone.Model();
+    var view = new UrlInputView({
+      model: model,
+      propertyName: 'url',
+      displayPropertyName: 'displayUrl',
+      supportedHosts: ['example.com']
+    });
+
+    view.render();
+    var input = view.$el.find('input');
+    input.val('http://other.com');
+    input.trigger('change');
+
+    expect(input[0]).toBeInvalid();
+  });
+
+  it('should be valid if URL with supported host', () => {
+    var model = new Backbone.Model();
+    var view = new UrlInputView({
+      model: model,
+      propertyName: 'url',
+      displayPropertyName: 'displayUrl',
+      supportedHosts: ['example.com']
+    });
+
+    view.render();
+    var input = view.$el.find('input');
+    input.val('http://example.com/foo');
+    input.trigger('change');
+
+    expect(input[0]).toBeValid();
+  });
+
+  it('should ignore http protocol in supported hosts', () => {
+    var model = new Backbone.Model();
+    var view = new UrlInputView({
+      model: model,
+      propertyName: 'url',
+      displayPropertyName: 'displayUrl',
+      supportedHosts: ['http://example.com']
+    });
+
+    view.render();
+    var input = view.$el.find('input');
+    input.val('http://example.com');
+    input.trigger('change');
+
+    expect(input[0]).toBeValid();
+  });
+
+  it('should ignore https protocol in supported hosts', () => {
+    var model = new Backbone.Model();
+    var view = new UrlInputView({
+      model: model,
+      propertyName: 'url',
+      displayPropertyName: 'displayUrl',
+      permitHttps: true,
+      supportedHosts: ['https://example.com']
+    });
+
+    view.render();
+    var input = view.$el.find('input');
+    input.val('https://example.com');
+    input.trigger('change');
+
+    expect(input[0]).toBeValid();
+  });
+
+  it('should be invalid if URL uses https', () => {
+    var model = new Backbone.Model();
+    var view = new UrlInputView({
+      model: model,
+      propertyName: 'url',
+      displayPropertyName: 'displayUrl',
+      supportedHosts: ['example.com']
+    });
+
+    view.render();
+    var input = view.$el.find('input');
+    input.val('https://example.com');
+    input.trigger('change');
+
+    expect(input[0]).toBeInvalid();
+  });
+
+  it('should be valid if https is permitted and URL uses https', () => {
+    var model = new Backbone.Model();
+    var view = new UrlInputView({
+      model: model,
+      propertyName: 'url',
+      displayPropertyName: 'displayUrl',
+      permitHttps: true,
+      supportedHosts: ['example.com']
+    });
+
+    view.render();
+    var input = view.$el.find('input');
+    input.val('https://example.com');
+    input.trigger('change');
+
+    expect(input[0]).toBeValid();
+  });
+
+  it('should ignore protocol of supported Hosts if https permitted', () => {
+    var model = new Backbone.Model();
+    var view = new UrlInputView({
+      model: model,
+      propertyName: 'url',
+      displayPropertyName: 'displayUrl',
+      permitHttps: true,
+      supportedHosts: ['http://example.com']
+    });
+
+    view.render();
+    var input = view.$el.find('input');
+    input.val('https://example.com');
+    input.trigger('change');
+
+    expect(input[0]).toBeValid();
   });
 });

--- a/package/src/ui/views/inputs/UrlInputView.js
+++ b/package/src/ui/views/inputs/UrlInputView.js
@@ -106,6 +106,16 @@ export const UrlInputView = Marionette.Layout.extend(
     return this.options.supportedHosts;
   },
 
+  // Host names used to be expected to include protocols. Remove
+  // protocols for backwards compatilbity. Since supportedHosts
+  // is supposed to be overridden in subclasses, we do it in a
+  // separate method.
+  supportedHostsWithoutLegacyProtocols: function() {
+    return _.map(this.supportedHosts(), function(host) {
+      return host.replace(/^https?:\/\//, '');
+    });
+  },
+
   validate: function(success) {
     var view = this;
     var options = this.options;
@@ -149,13 +159,14 @@ export const UrlInputView = Marionette.Layout.extend(
     }
 
     function hasSupportedHost(url) {
-      return _.any(view.supportedHosts(), function(host) {
-        return url.match(new RegExp('^' + host));
+      return _.any(view.supportedHostsWithoutLegacyProtocols(), function(host) {
+        return url.match(new RegExp('^https?://' + host));
       });
     }
 
     function displayValidationError(message) {
       view.$el.addClass('invalid');
+      view.ui.input.attr('aria-invalid', 'true');
       view.ui.validation
         .removeClass('pending')
         .addClass('failed')
@@ -165,6 +176,7 @@ export const UrlInputView = Marionette.Layout.extend(
 
     function displayValidationPending(message) {
       view.$el.removeClass('invalid');
+      view.ui.input.removeAttr('aria-invalid');
       view.ui.validation
         .removeClass('failed')
         .addClass('pending')
@@ -174,6 +186,7 @@ export const UrlInputView = Marionette.Layout.extend(
 
     function resetValidationError(message) {
       view.$el.removeClass('invalid');
+      view.ui.input.attr('aria-invalid', 'false');
       view.ui.validation.hide();
     }
   }


### PR DESCRIPTION
Do not expect protocols in host strings. This prevents having to
include both http and https versions of a supported host if
`permitHttps` is set to true. Ignore protocols in host names for
backwards compatibility.

REDMINE-19000