### PR TITLE
Allow defining custom poster for video embeds

### DIFF
--- a/entry_types/scrolled/config/locales/new/video_embed_poster.de.yml
+++ b/entry_types/scrolled/config/locales/new/video_embed_poster.de.yml
@@ -1,0 +1,8 @@
+de:
+  pageflow_scrolled:
+    editor:
+      content_elements:
+        videoEmbed:
+          attributes:
+            posterId:
+              label: Poster

--- a/entry_types/scrolled/config/locales/new/video_embed_poster.en.yml
+++ b/entry_types/scrolled/config/locales/new/video_embed_poster.en.yml
@@ -1,0 +1,8 @@
+en:
+  pageflow_scrolled:
+    editor:
+      content_elements:
+        videoEmbed:
+          attributes:
+            posterId:
+              label: Poster

--- a/entry_types/scrolled/package/src/contentElements/videoEmbed/VideoEmbed.js
+++ b/entry_types/scrolled/package/src/contentElements/videoEmbed/VideoEmbed.js
@@ -11,7 +11,8 @@ import {
   FitViewport,
   useContentElementLifecycle,
   useContentElementEditorState,
-  useAudioFocus
+  useAudioFocus,
+  useFile
 } from 'pageflow-scrolled/frontend';
 
 const aspectRatios = {
@@ -61,6 +62,13 @@ function PreparedPlayer({
     }
   });
 
+  const posterImageFile = useFile({
+    collectionName: 'imageFiles',
+    permaId: configuration.posterId
+  });
+
+  const posterUrl = posterImageFile?.isReady && posterImageFile.urls.large;
+
   // React player does not re-create player when controls or config
   // prop changes. Ensure key changes to force React to re-mount
   // component.
@@ -78,7 +86,9 @@ function PreparedPlayer({
                      onPlay={() => setPlayerState('playing')}
                      onPause={() => setPlayerState('paused')}
                      onEnded={() => setPlayerState('paused')}
-                     light={!consentedHere && playerState === 'unplayed'}
+                     light={!consentedHere && playerState === 'unplayed' ?
+                            (posterUrl || true) :
+                            false}
                      width='100%'
                      height='100%'
                      controls={!configuration.hideControls}

--- a/entry_types/scrolled/package/src/contentElements/videoEmbed/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/videoEmbed/editor.js
@@ -1,5 +1,6 @@
 import {editor} from 'pageflow-scrolled/editor';
 import {CheckBoxInputView, SelectInputView, UrlInputView} from 'pageflow/ui';
+import {FileInputView} from 'pageflow/editor';
 
 editor.contentElementTypes.register('videoEmbed', {
   supportedPositions: ['inline', 'sticky', 'left', 'right', 'full'],
@@ -20,6 +21,11 @@ editor.contentElementTypes.register('videoEmbed', {
         displayPropertyName: 'displayVideoSource',
         required: true,
         permitHttps: true
+      });
+      this.input('posterId', FileInputView, {
+        collection: 'image_files',
+        fileSelectionHandler: 'contentElementConfiguration',
+        positioning: false
       });
       this.input('hideInfo', CheckBoxInputView);
       this.input('hideControls', CheckBoxInputView);


### PR DESCRIPTION
Facebook videos do not support displaying automatic posters. Allow
setting one manually.

REDMINE-19167