### PR TITLE
Use canonical entry url prefix in pretty urls

### DIFF
--- a/app/models/pageflow/entry_at_revision.rb
+++ b/app/models/pageflow/entry_at_revision.rb
@@ -18,7 +18,7 @@ module Pageflow
              :enabled_feature_names,
              :edit_lock,
              :password_digest,
-             :to_model, :to_key, :persisted?, :to_json,
+             :to_model, :to_key, :to_param, :persisted?, :to_json,
              :first_published_at, :published_until, :published?,
              :type_name,
              to: :entry)

--- a/db/migrate/20211020085902_add_canonical_entry_url_prefix_to_themings.rb
+++ b/db/migrate/20211020085902_add_canonical_entry_url_prefix_to_themings.rb
@@ -1,0 +1,5 @@
+class AddCanonicalEntryUrlPrefixToThemings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pageflow_themings, :canonical_entry_url_prefix, :string
+  end
+end

--- a/spec/factories/draft_entries.rb
+++ b/spec/factories/draft_entries.rb
@@ -1,8 +1,26 @@
 module Pageflow
   FactoryBot.define do
     factory :draft_entry, class: DraftEntry do
+      transient do
+        title
+        account
+        theming
+        type_name { 'paged' }
+        revision_attributes { {} }
+
+        with_feature { nil }
+        without_feature { nil }
+      end
+
       initialize_with do
-        DraftEntry.new(create(:entry))
+        DraftEntry.new(create(:entry,
+                              title: title,
+                              account: account,
+                              theming: theming,
+                              type_name: type_name,
+                              draft_attributes: revision_attributes,
+                              with_feature: with_feature,
+                              without_feature: without_feature))
       end
 
       to_create { |draft_entry| draft_entry.entry.save! }

--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -21,6 +21,8 @@ module Pageflow
 
         with_feature { nil }
         without_feature { nil }
+
+        draft_attributes { nil }
       end
 
       after(:create) do |entry, evaluator|
@@ -40,6 +42,8 @@ module Pageflow
                entity: entry,
                user: evaluator.with_manager,
                role: :manager) if evaluator.with_manager
+
+        entry.draft.update!(evaluator.draft_attributes) if evaluator.draft_attributes
       end
 
       after(:build) do |entry, evaluator|

--- a/spec/factories/published_entries.rb
+++ b/spec/factories/published_entries.rb
@@ -2,6 +2,7 @@ module Pageflow
   FactoryBot.define do
     factory :published_entry, class: PublishedEntry do
       transient do
+        title
         account
         theming
         type_name { 'paged' }
@@ -14,6 +15,7 @@ module Pageflow
       initialize_with do
         PublishedEntry.new(create(:entry,
                                   :published,
+                                  title: title,
                                   account: account,
                                   theming: theming,
                                   type_name: type_name,


### PR DESCRIPTION
Allow specifying a custom prefix that is used in pretty entry
urls. This helps with cases, where entries are meant to be published
below a custom path of a third party domain using a custom proxy
setup.

REDMINE-19272