### PR TITLE
Make Webpack load chunks via asset host

### DIFF
--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/editor/seed_html_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/editor/seed_html_helper.rb
@@ -8,6 +8,7 @@ module PageflowScrolled
       include Pageflow::StructuredDataHelper
       include FaviconHelper
       include PacksHelper
+      include WebpackPublicPathHelper
 
       def scrolled_editor_iframe_seed_html_script_tag(entry)
         html = render(template: 'pageflow_scrolled/entries/show',

--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/react_server_side_rendering_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/react_server_side_rendering_helper.rb
@@ -65,7 +65,10 @@ module PageflowScrolled
       ReactRenderer
         .new(files: ['pageflow-scrolled-server'],
              # Define required external globals.
-             code: 'function videojs() {};')
+             code: <<-JS)
+                #{WebpackPublicPathHelper.js_snippet}
+                function videojs() {};
+             JS
     end
   end
 end

--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/webpack_public_path_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/webpack_public_path_helper.rb
@@ -1,0 +1,15 @@
+module PageflowScrolled
+  # @api private
+  module WebpackPublicPathHelper
+    def scrolled_webpack_public_path_script_tag
+      content_tag(:script, WebpackPublicPathHelper.js_snippet.html_safe)
+    end
+
+    def self.js_snippet
+      asset_host = Rails.configuration.action_controller.asset_host
+      packs_dir = Webpacker.config.public_output_path.basename
+
+      "var __webpack_public_path__ = '#{asset_host}/#{packs_dir}/';"
+    end
+  end
+end

--- a/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
@@ -44,6 +44,7 @@
       <%= render_widgets(@entry, scope: @widget_scope, insert_point: :bottom_of_entry) %>
     </div>
 
+    <%= scrolled_webpack_public_path_script_tag %>
     <%= scrolled_frontend_javascript_packs_tag(@entry, widget_scope: @widget_scope) %>
 
     <%= scrolled_entry_json_seed_script_tag(@entry, @seed_options || {}) %>

--- a/entry_types/scrolled/package/jest.config.js
+++ b/entry_types/scrolled/package/jest.config.js
@@ -8,7 +8,10 @@ module.exports = {
 
   testEnvironment: 'jsdom',
   testMatch: ["<rootDir>/spec/**/*-spec.js"],
-  globals,
+  globals: {
+    ...globals,
+    __webpack_public_path__: ''
+  },
   setupFiles: ['<rootDir>/spec/support/matchMediaStub.js'],
   setupFilesAfterEnv: ['<rootDir>/spec/support/fakeBrowserFeatures.js'],
   modulePaths: ['<rootDir>/src', '<rootDir>/spec'],

--- a/entry_types/scrolled/package/src/frontend/index.js
+++ b/entry_types/scrolled/package/src/frontend/index.js
@@ -1,3 +1,4 @@
+import './webpackPublicPath';
 import './polyfills';
 import './globalNotices.module.css';
 

--- a/entry_types/scrolled/package/src/frontend/webpackPublicPath.js
+++ b/entry_types/scrolled/package/src/frontend/webpackPublicPath.js
@@ -1,0 +1,8 @@
+// Make sure Webpack loads chunks via asset host.
+// Free variable assignment will be rewritten during Webpack compilation.
+// See https://v4.webpack.js.org/guides/public-path/#on-the-fly
+// PageflowScrolled::WebpackPublicPathHelper generates js snippet
+// that defines the global. For Storybook, we set it to an empty default.
+
+// eslint-disable-next-line no-undef
+__webpack_public_path__ = global.__webpack_public_path__ || '';

--- a/entry_types/scrolled/spec/helpers/pageflow_scrolled/webpack_public_path_helper_spec.rb
+++ b/entry_types/scrolled/spec/helpers/pageflow_scrolled/webpack_public_path_helper_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+module PageflowScrolled
+  RSpec.describe WebpackPublicPathHelper, type: :helper do
+    describe 'scrolled_webpack_public_path_script_tag' do
+      it 'sets global variable' do
+        html = helper.scrolled_webpack_public_path_script_tag
+
+        expect(html)
+          .to have_selector('script',
+                            visible: false,
+                            text: "var __webpack_public_path__ = '/packs-test/';")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dynamically set `__webpack_public_path__` in server and client side
rendering.

REDMINE-19272