### PR TITLE
Fix compatibility with JBuilder 2.11.3

### DIFF
--- a/app/helpers/pageflow/page_types_helper.rb
+++ b/app/helpers/pageflow/page_types_helper.rb
@@ -4,7 +4,7 @@ module Pageflow
 
     def page_type_json_seeds(config)
       render_json_partial('pageflow/page_types/page_type',
-                          collection: config.page_types,
+                          collection: config.page_types.to_a,
                           as: :page_type)
     end
 

--- a/app/helpers/pageflow/themes_helper.rb
+++ b/app/helpers/pageflow/themes_helper.rb
@@ -10,7 +10,7 @@ module Pageflow
 
     def theme_json_seeds(config)
       render_json_partial('pageflow/themes/theme',
-                          collection: config.themes,
+                          collection: config.themes.to_a,
                           as: :theme)
     end
   end


### PR DESCRIPTION
Turn page_types into array since JBuilder
2.11.3 (https://github.com/rails/jbuilder/pull/501) requires
collection to respond to `empty?`, which `Enumerable` does not
provide. See also https://github.com/rails/jbuilder/issues/514

REDMINE-19357