### PR TITLE
Remove scrolling attribute from embed iframe snippet

### DIFF
--- a/app/helpers/pageflow/embed_code_helper.rb
+++ b/app/helpers/pageflow/embed_code_helper.rb
@@ -11,7 +11,7 @@ module Pageflow
       end
 
       def call
-        %'<iframe src="#{url(entry)}" scrolling="no" allowfullscreen></iframe>'
+        %'<iframe src="#{url(entry)}" allowfullscreen></iframe>'
       end
 
       private


### PR DESCRIPTION
`scrolling` attribute is deprecated. Paged entries do not need it
since they hide scroll bars via `overflow: hidden`. For Scrolled
entries it needs to be removed to enable native scrolling.

REDMINE-19063