### PR TITLE
Do not display disabled transition option as active

### DIFF
--- a/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.js
+++ b/entry_types/scrolled/package/src/editor/views/EditSectionTransitionEffectView.js
@@ -88,12 +88,12 @@ export const EditSectionTransitionEffectView = Marionette.ItemView.extend({
     const value = model.get(propertyName);
 
     let input = this.ui.container.find(
-      `input[name="${name}"][value="${value}"]`
+      `input[name="${name}"][value="${value}"]:enabled`
     );
 
     if (!input.length) {
       input = this.ui.container.find(
-        `input[name="${name}"]`
+        `input[name="${name}"]:enabled`
       ).first();
     }
 


### PR DESCRIPTION
Now that the default transition is `fadeBg`, when creating a new
section next to a non-full-height section, we want to prevent
displaying the "fade" option as selected. Instead, we want to
highlight the first enabled option "scroll", which acts as a fallback
in this case.

REDMINE-19303