### PR TITLE
Display subtitles at the bottom of the media element

### DIFF
--- a/entry_types/scrolled/package/src/frontend/MediaPlayer.module.css
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer.module.css
@@ -1,5 +1,6 @@
 .wrapper,
-.wrapper div,
+.wrapper > div,
+.wrapper > div > div,
 .wrapper img {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
MediaPlayer styles to make player use full height in content element
also applied to text track display elements managed by Video.js.

REDMINE-19196