### PR TITLE
Prevent scaled iframe element from causing horizontal overflow

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/iframeEmbed/IframeEmbed.js
+++ b/entry_types/scrolled/package/src/contentElements/iframeEmbed/IframeEmbed.js
@@ -28,7 +28,8 @@ export function IframeEmbed({configuration}) {
                       configuration.aspectRatio;
 
   return (
-    <div style={{pointerEvents: isEditable && !isSelected ? 'none' : undefined}}>
+    <div className={styles.wrapper}
+         style={{pointerEvents: isEditable && !isSelected ? 'none' : undefined}}>
       <FitViewport aspectRatio={aspectRatios[aspectRatio || 'wide']}>
         <Figure caption={configuration.caption}>
           <FitViewport.Content>

--- a/entry_types/scrolled/package/src/contentElements/iframeEmbed/IframeEmbed.module.css
+++ b/entry_types/scrolled/package/src/contentElements/iframeEmbed/IframeEmbed.module.css
@@ -1,3 +1,7 @@
+.wrapper {
+  overflow: hidden;
+}
+
 .iframe {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Transformation is not accounted for when computing overflow. So even
if the element does not overflow visually, there are still horizontal
scroll bars. Hide (invisible) overflow of element.

REDMINE-19406