### PR TITLE
Align navigation breakpoints with theme breakpoints

### DIFF
--- a/entry_types/scrolled/package/.storybook/main.js
+++ b/entry_types/scrolled/package/.storybook/main.js
@@ -26,6 +26,14 @@ module.exports = {
           'videojs': path.resolve(__dirname, '../../../../vendor/assets/javascripts/videojs'),
           'pageflow/frontend': path.resolve(__dirname, '../../../../package/src/frontend'),
           'pageflow-scrolled/frontend': path.resolve(__dirname, '../src/frontend'),
+
+          // css-loader (used by Storybook's Webpack setup) expects
+          // imports from node modules to be prefixed with a tilde,
+          // e.g. "~pageflow-scrolled/..."). This syntax is not
+          // supported by our Rollup setup, though. Without the tilde,
+          // css-loader interprets imports as relative. We use this
+          // alias as a workaround to mimic the Rollup behavior.
+          './pageflow-scrolled/values': path.resolve(__dirname, '../values'),
         }
       }
     };

--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/ChapterLink.module.css
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/ChapterLink.module.css
@@ -1,3 +1,5 @@
+@value breakpoint-md from 'pageflow-scrolled/values/breakpoints.module.css';
+
 .chapterLink {
   composes: typography-defaultNavigationChapterLink from global;
   line-height: 42px;
@@ -24,19 +26,19 @@
 }
 
 .summary {
+  color: var(--theme-widget-on-background-color);
+}
+
+.tooltipBubble {
   display: none;
 }
 
-/* mobile view */
-@media (max-width: 780px) {
+@media breakpoint-md {
   .summary {
-    display: block;
-    color: var(--theme-widget-on-background-color);
+    display: none;
   }
-}
 
-@media (max-width: 780px) {
   .tooltipBubble {
-    display: none !important;
+    display: block;
   }
 }

--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/DefaultNavigation.module.css
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/DefaultNavigation.module.css
@@ -1,3 +1,5 @@
+@value breakpoint-below-md from 'pageflow-scrolled/values/breakpoints.module.css';
+
 .navigationBar {
   composes: scope-defaultNavigation from global;
 
@@ -134,7 +136,7 @@ div:focus-within > .contextIcon,
   background-color: var(--theme-accent-color);
 }
 
-@media screen and (max-width: 780px) {
+@media screen and breakpoint-below-md {
   .logo {
     max-width: 30%;
   }

--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/HamburgerIcon.module.css
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/HamburgerIcon.module.css
@@ -1,13 +1,11 @@
-.burgerMenuIconContainer {
-  display: none;
+@value breakpoint-md from 'pageflow-scrolled/values/breakpoints.module.css';
+
+@media breakpoint-md {
+  .burgerMenuIconContainer {
+    display: none;
+  }
 }
 
 .burgerMenuIcon {
   outline: none;
-}
-
-@media screen and (max-width: 780px) {
-  .burgerMenuIconContainer {
-    display: block;
-  }
 }

--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/Scroller.module.css
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/Scroller.module.css
@@ -1,4 +1,6 @@
-@media screen and (min-width: 781px) {
+@value breakpoint-md from 'pageflow-scrolled/values/breakpoints.module.css';
+
+@media screen and breakpoint-md {
   .scroller {
     overflow: hidden;
     scroll-behavior: smooth;

--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/stories.js
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/stories.js
@@ -16,7 +16,7 @@ let getSeed = function({chapterCount}){
   ]
   return {
     widgets: [{
-      role: 'navigation',
+      role: 'header',
       typeName: 'defaultNavigation'
     }],
     chapters: Array(chapterCount).fill().map((_, index) => (

--- a/entry_types/scrolled/package/values/breakpoints.module.css
+++ b/entry_types/scrolled/package/values/breakpoints.module.css
@@ -1,0 +1,9 @@
+@value breakpoint-sm: (min-width: 640px);
+@value breakpoint-md: (min-width: 768px);
+@value breakpoint-lg: (min-width: 1024px);
+@value breakpoint-xl: (min-width: 1280px);
+
+@value breakpoint-below-sm: (max-width: 639px);
+@value breakpoint-below-md: (max-width: 767px);
+@value breakpoint-below-lg: (max-width: 1023px);
+@value breakpoint-below-xl: (max-width: 1279px);

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
                 'package/{config/**/*,editor.js,frontend.js,ui.js,testHelpers.js,package.json}',
                 'entry_types/scrolled/package/' \
                 '{config/**/*,contentElements-frontend.{js,css},frontend-server.js,' \
-                'widgets/defaultNavigation.{css,js},' \
+                'widgets/defaultNavigation.{css,js},values/*,' \
                 'contentElements-editor.js,frontend/*.{js,css},editor.js,package.json}',
                 'MIT-LICENSE', 'Rakefile', 'README.md', 'CHANGELOG.md']
 


### PR DESCRIPTION
Provide reusable breakpoints in
`pageflow-scrolled/values/breakpoints.module.css` that align with the
breakpoints that can be used in theme properties and typography
settings. Use these breakpoints in default navigation widget.

REDMINE-19429