### PR TITLE
Always use relative paths for custom icons

### DIFF
--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/themes_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/themes_helper.rb
@@ -1,9 +1,16 @@
 module PageflowScrolled
   # @api private
   module ThemesHelper
-    def scrolled_theme_asset_path(theme, path, theme_file_role: nil)
-      theme.files.dig(theme_file_role, :resized) ||
+    def scrolled_theme_asset_path(theme, path, theme_file_role: nil, relative_url: false)
+      path =
+        theme.files.dig(theme_file_role, :resized) ||
         asset_pack_path("media/pageflow-scrolled/themes/#{theme.name}/#{path}")
+
+      if relative_url
+        URI.parse(path).path
+      else
+        path
+      end
     end
 
     def scrolled_theme_stylesheet_pack_tags(theme)

--- a/entry_types/scrolled/app/views/pageflow_scrolled/entry_json_seed/_theme.json.jbuilder
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entry_json_seed/_theme.json.jbuilder
@@ -10,7 +10,8 @@ json.theme do
     json.icons do
       theme.options.fetch(:custom_icons, []).each do |icon_name|
         json.set!(icon_name,
-                  scrolled_theme_asset_path(theme, "icons/#{icon_name}.svg"))
+                  scrolled_theme_asset_path(theme, "icons/#{icon_name}.svg",
+                                            relative_url: true))
       end
     end
   end

--- a/entry_types/scrolled/spec/helpers/pageflow_scrolled/entry_json_seed_helper_spec.rb
+++ b/entry_types/scrolled/spec/helpers/pageflow_scrolled/entry_json_seed_helper_spec.rb
@@ -402,6 +402,25 @@ module PageflowScrolled
                                        })
       end
 
+      it 'does not use asset host in icon paths to allow xlink:href usage' do
+        controller.config.asset_host = 'some-asset-host'
+        pageflow_configure do |config|
+          config.themes.register(:default, custom_icons: [:share])
+        end
+        entry = create(:published_entry)
+        result = render(helper, entry)
+
+        expect(result).to include_json(config: {
+                                         theme: {
+                                           assets: {
+                                             icons: {
+                                               share: %r{^/packs.*share.*svg$}
+                                             }
+                                           }
+                                         }
+                                       })
+      end
+
       it 'renders empty icons object if theme has no custom icons' do
         pageflow_configure do |config|
           config.themes.register(:default, custom_icons: [])


### PR DESCRIPTION
`<use xlink:href>` in SVG elements only works with same origin.

REDMINE-19535