### PR TITLE
Allow overriding text block heading margins in typography rules

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/textBlock/TextBlock.module.css
+++ b/entry_types/scrolled/package/src/contentElements/textBlock/TextBlock.module.css
@@ -1,4 +1,3 @@
-.text h2,
 .text li,
 .text p {
   margin: 1em 0 0 0;

--- a/entry_types/scrolled/package/src/frontend/Text.module.css
+++ b/entry_types/scrolled/package/src/frontend/Text.module.css
@@ -27,6 +27,8 @@
 
 .heading-xs {
   composes: typography-heading from global;
+  margin-top: 1em;
+  margin-bottom: 0;
 }
 
 .body {


### PR DESCRIPTION
So far, the text block content element specified the margin of its
heading via a rule of the form `.text h2`, which has higher
specificity than the typography rules generated from theme options.

Move margin to `heading-xs` text size rule, which is only used by the
text block content element at the moment and has lower specificity.

REDMINE-19573