### PR TITLE
Load DASH on Android if hls-playlist host contains an underscore

### DIFF
--- a/entry_types/scrolled/package/spec/entryState/getFileUrlTemplateHost-spec.js
+++ b/entry_types/scrolled/package/spec/entryState/getFileUrlTemplateHost-spec.js
@@ -1,0 +1,35 @@
+import {getFileUrlTemplateHost} from 'entryState';
+
+import {normalizeSeed} from 'support';
+
+describe('getFileUrlTemplateHost', () => {
+  it('extracts host from seed', () => {
+    const seed =  normalizeSeed({
+      fileUrlTemplates: {
+        videoFiles: {
+          'hls-playlist': `//some-cdn.com/v1/main/pageflow/video_files` +
+                          '/:id_partition/hls-playlist.m3u8'
+        }
+      }
+    });
+
+    const result = getFileUrlTemplateHost(seed, 'videoFiles', 'hls-playlist');
+
+    expect(result).toEqual('some-cdn.com');
+  });
+
+  it('handles url with protocol', () => {
+    const seed =  normalizeSeed({
+      fileUrlTemplates: {
+        videoFiles: {
+          'hls-playlist': `https://some-cdn.com/v1/main/pageflow/video_files` +
+                          '/:id_partition/hls-playlist.m3u8'
+        }
+      }
+    });
+
+    const result = getFileUrlTemplateHost(seed, 'videoFiles', 'hls-playlist');
+
+    expect(result).toEqual('some-cdn.com');
+  });
+});

--- a/entry_types/scrolled/package/spec/frontend/dash-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/dash-spec.js
@@ -1,0 +1,59 @@
+import {hasHlsSupport} from 'frontend/dash';
+
+import {fakeBrowserAgent} from 'pageflow/testHelpers';
+import {normalizeSeed} from 'support';
+
+describe('hasHlsSupport', () => {
+  it('returns true on Desktop Safari', () => {
+    const agent = fakeBrowserAgent('Safari on macOS')
+    const seed = createSeed({hlsHost: 'some-cdn.com'})
+
+    expect(hasHlsSupport({seed, agent})).toEqual(true);
+  });
+
+  it('returns true on mobile Safari', () => {
+    const agent = fakeBrowserAgent('Safari on iPhone')
+    const seed = createSeed({hlsHost: 'some-cdn.com'})
+
+    expect(hasHlsSupport({seed, agent})).toEqual(true);
+  });
+
+  it('returns true on Android with supported HLS host', () => {
+    const agent = fakeBrowserAgent('Chrome on Android')
+    const seed = createSeed({hlsHost: 'some-cdn.com'})
+
+    expect(hasHlsSupport({seed, agent})).toEqual(true);
+  });
+
+  it('returns false on Android if underscore in HLS host', () => {
+    const agent = fakeBrowserAgent('Chrome on Android')
+    const seed = createSeed({hlsHost: 'hls_multimedia.some-cdn.com'})
+
+    expect(hasHlsSupport({seed, agent})).toEqual(false);
+  });
+
+  it('returns true on iOS even with underscore in HLS host', () => {
+    const agent = fakeBrowserAgent('Safari on iPhone')
+    const seed = createSeed({hlsHost: 'hls_multimedia.some-cdn.com'})
+
+    expect(hasHlsSupport({seed, agent})).toEqual(true);
+  });
+
+  it('returns false on Desktop Chrome', () => {
+    const agent = fakeBrowserAgent('Chrome on Windows')
+    const seed = createSeed({hlsHost: 'some-cdn.com'})
+
+    expect(hasHlsSupport({seed, agent})).toEqual(false);
+  });
+
+  function createSeed({hlsHost}) {
+    return normalizeSeed({
+      fileUrlTemplates: {
+        videoFiles: {
+          'hls-playlist': `//${hlsHost}/v1/main/pageflow/video_files` +
+                          '/:id_partition/hls-playlist.m3u8'
+        }
+      }
+    });
+  }
+});

--- a/entry_types/scrolled/package/src/entryState/getFileUrlTemplateHost.js
+++ b/entry_types/scrolled/package/src/entryState/getFileUrlTemplateHost.js
@@ -1,0 +1,4 @@
+export function getFileUrlTemplateHost(seed, collectionName, variant) {
+  const hlsUrlTemplate = seed.config.fileUrlTemplates[collectionName][variant];
+  return hlsUrlTemplate.split('//')[1].split('/')[0];
+}

--- a/entry_types/scrolled/package/src/entryState/index.js
+++ b/entry_types/scrolled/package/src/entryState/index.js
@@ -3,6 +3,7 @@ export {useEntryMetadata} from './metadata';
 export {useEntryStructure, useSection, useChapters, useSectionContentElements} from './structure';
 export {useFile} from './useFile';
 export {useNestedFiles} from './useNestedFiles';
+export {getFileUrlTemplateHost} from './getFileUrlTemplateHost';
 export {useFileRights, useLegalInfo, useCredits} from './legalInfo';
 export {useAvailableQualities} from './useAvailableQualities';
 export {useTheme} from './theme';

--- a/entry_types/scrolled/package/src/frontend/dash.js
+++ b/entry_types/scrolled/package/src/frontend/dash.js
@@ -1,7 +1,19 @@
 import {browser} from 'pageflow/frontend';
+import {getFileUrlTemplateHost} from '../entryState';
 
-export async function loadDashUnlessHlsSupported() {
-  if (!browser.has('hls support')) {
+export async function loadDashUnlessHlsSupported(seed) {
+  if (!hasHlsSupport({seed, agent: browser.agent})) {
     await import('@videojs/http-streaming')
   }
+}
+
+export function hasHlsSupport({agent, seed}) {
+  return agent.matchesSafari() ||
+         (agent.matchesMobilePlatform() &&
+          (!agent.matchesAndroid() ||
+           hlsHostSupportedByAndroid(seed)));
+}
+
+function hlsHostSupportedByAndroid(seed) {
+  return getFileUrlTemplateHost(seed, 'videoFiles', 'hls-playlist').indexOf('_') < 0;
 }

--- a/entry_types/scrolled/package/src/frontend/index.js
+++ b/entry_types/scrolled/package/src/frontend/index.js
@@ -97,7 +97,7 @@ global.pageflowScrolledRender = async function(seed) {
 
   features.enable('frontend', seed.config.enabledFeatureNames)
   await browser.detectFeatures();
-  await loadDashUnlessHlsSupported();
+  await loadDashUnlessHlsSupported(seed);
 
   if (editMode) {
     await loadInlineEditingComponents();

--- a/package/spec/frontend/browser/agent_spec.js
+++ b/package/spec/frontend/browser/agent_spec.js
@@ -2,6 +2,38 @@ import {browser} from 'pageflow/frontend';
 
 describe('pageflow.browser.Agent', function() {
   var Agent = browser.Agent;
+
+  describe ('#matchesAndroid', function() {
+    it('returns false for Safari on iOS', function() {
+      var agent = new Agent(
+       'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X)' +
+       'AppleWebKit/603.1.23 (KHTML, like Gecko) Version/10.0' +
+       'Mobile/14E5239e Safari/602.1'
+      );
+
+      expect(agent.matchesAndroid()).toBe(false);
+    });
+
+    it('returns false for Chrome on iOS', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X)' +
+        'AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75' +
+        'Mobile/14E5239e Safari/602.1'
+      );
+
+      expect(agent.matchesAndroid()).toBe(false);
+    });
+
+    it('returns true for Chrome on Android', function() {
+      var agent = new Agent(
+        'Mozilla/5.0 (Linux; Android 10) '+
+        'Mobile/14E5239e Safari/602.1'
+      );
+
+      expect(agent.matchesAndroid()).toBe(true);
+    });
+  });
+
   describe ('#matchesSafari11AndAbove', function() {
     it('returns false for Safari 10', function() {
       var agent = new Agent(

--- a/package/src/frontend/browser/Agent.js
+++ b/package/src/frontend/browser/Agent.js
@@ -17,7 +17,7 @@ export const Agent = function(userAgent) {
       else {
         return this.matchesSafari() &&
                !this.matchesMobilePlatform()
-      }     
+      }
     },
 
     matchesDesktopSafari9: function() {
@@ -71,6 +71,14 @@ export const Agent = function(userAgent) {
     },
 
     /**
+     * Returns true on Android.
+     * @return {boolean}
+     */
+    matchesAndroid: function() {
+      return matches(/Android/i);
+    },
+
+    /**
      * Returns true on iOS or Android.
      * @return {boolean}
      */
@@ -108,7 +116,7 @@ export const Agent = function(userAgent) {
       else {
         return this.matchesChrome() &&
                !this.matchesMobilePlatform()
-      }     
+      }
     },
 
     matchesDesktopFirefox: function(options) {
@@ -120,9 +128,9 @@ export const Agent = function(userAgent) {
       else {
         return this.matchesFirefox() &&
                !this.matchesMobilePlatform();
-      }      
+      }
     },
-    
+
     matchesDesktopEdge: function(options) {
       if (options) {
         return this.matchesEdge() &&
@@ -132,9 +140,9 @@ export const Agent = function(userAgent) {
       else {
         return this.matchesEdge() &&
                !this.matchesMobilePlatform();
-      }     
+      }
     },
-    
+
     /**
    * Returns true on Google Chrome.
    * @return {boolean}
@@ -144,7 +152,7 @@ export const Agent = function(userAgent) {
       return matches(/Chrome\//i) &&
               !matches(/Edg/i);
     },
-    
+
     /**
    * Returns true on Firefox.
    * @return {boolean}
@@ -153,7 +161,7 @@ export const Agent = function(userAgent) {
       return matches(/Firefox\//i) &&
             !matches(/Seamonkey/i);
     },
-    
+
     /**
    * Returns true on Microsoft Edge.
    * @return {boolean}
@@ -169,7 +177,7 @@ export const Agent = function(userAgent) {
 
   function matchesMinVersion(exp, version) {
     var match = userAgent.match(exp);
-    return match && match[1] && parseInt(match[1], 10) >= version;   
+    return match && match[1] && parseInt(match[1], 10) >= version;
   }
 
   //After ios13 update, iPad reports the same user string
@@ -180,7 +188,7 @@ export const Agent = function(userAgent) {
   function matchesiPadSafari13AndAbove() {
     return agent.matchesSafari() &&
            navigator.maxTouchPoints > 1 &&
-           navigator.platform === 'MacIntel';       
+           navigator.platform === 'MacIntel';
   }
 };
 

--- a/package/src/frontend/browser/video.js
+++ b/package/src/frontend/browser/video.js
@@ -34,10 +34,6 @@ browser.feature('mse and native hls support', function(has) {
     !agent.matchesMobilePlatform();
 });
 
-browser.feature('hls support', function(has) {
-  return agent.matchesSafari() || agent.matchesMobilePlatform();
-});
-
 browser.feature('native video player', function(has) {
   return has('iphone platform');
 });

--- a/package/src/testHelpers/fakeBrowserAgent.js
+++ b/package/src/testHelpers/fakeBrowserAgent.js
@@ -1,0 +1,26 @@
+import {browser} from 'pageflow/frontend';
+
+const userAgents = {
+  'Safari on iPhone': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_1 like Mac OS X) '+
+                      'AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0' +
+                      'Mobile/14A403 Safari/602.1',
+  'Safari on macOS': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) ' +
+                     'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 ' +
+                     'Safari/605.1.15',
+  'Chrome on Android': 'Mozilla/5.0 (Linux; Android 10) '+
+                       'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106' +
+                       'Mobile Safari/537.36',
+  'Chrome on iPhone': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X)' +
+                      'AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75' +
+                      'Mobile/14E5239e Safari/602.1',
+  'Chrome on Windows': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36' +
+                       '(KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36'
+};
+
+export function fakeBrowserAgent(name) {
+  if (!userAgents[name]) {
+    throw new Error(`Unknown browser ${name}.`);
+  }
+
+  return new browser.Agent(userAgents[name]);
+}

--- a/package/src/testHelpers/index.js
+++ b/package/src/testHelpers/index.js
@@ -1,5 +1,6 @@
 export * from './dominos/editor';
 export * from './dominos/ui';
 export * from './factories';
+export * from './fakeBrowserAgent';
 export * from './setupGlobals';
 export * from './useFakeTranslations';


### PR DESCRIPTION
Android does not play HLS videos for such host names. Since our DASH
source comes first, we can fall back to DASH in this case.

REDMINE-19543