### PR TITLE
Apply consist max-width to wide elements

### DIFF
--- a/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.module.css
+++ b/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.module.css
@@ -17,12 +17,11 @@
 }
 
 .sticky,
-.inline,
-.wide {
+.inline {
   max-width: var(--two-column-inline-content-max-width, 500px);
 }
 
-.wideViewport .wide {
+.wide {
   max-width: var(--two-column-wide-content-max-width, 1200px);
 }
 


### PR DESCRIPTION
Do not apply inline content max width below wide viewport. This
prevents awkward intermediate states on tablets.

REDMINE-19482