### PR TITLE
Ensure last item of mobile menu is visible on Android

### DIFF
--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/DefaultNavigation.module.css
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/DefaultNavigation.module.css
@@ -161,7 +161,7 @@ div:focus-within > .contextIcon,
     left: 0px;
     background: var(--theme-widget-background-color);
     width: 100vw;
-    height: calc(100vh - 60px);
+    bottom: 0;
     overscroll-behavior: contain;
     overflow: scroll;
   }


### PR DESCRIPTION
`100vh` represents largest viewport [1], which causes menu to exceed
viewport height when browser navigation bar is shown.

[1] https://dev.to/frehner/css-vh-dvh-lvh-svh-and-vw-units-27k4