### PR TITLE
Fix unmute icon color in Safari

### DIFF
--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/ToggleMuteButton.module.css
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/ToggleMuteButton.module.css
@@ -1,4 +1,4 @@
-.button svg {
+.button {
   color: var(--theme-widget-primary-color);
 }
 


### PR DESCRIPTION
`fill: currentColor` is set on the button. Safari evaluates
`currentColor` on the element itself. We thus need to also override
color there.