### PR TITLE
Add feature flag to use ultra image variant for paged backgrounds

### DIFF
--- a/app/helpers/pageflow/file_background_images_helper.rb
+++ b/app/helpers/pageflow/file_background_images_helper.rb
@@ -37,7 +37,7 @@ module Pageflow
       end
 
       def rules_for_file(file_type, file)
-        file_type.css_background_image_urls.call(file).map do |name, url|
+        file_type.css_background_image_urls_for(file, entry: entry).map do |name, url|
           {
             prefix: rule_prefix(file_type, name),
             file: file,

--- a/app/models/pageflow/entry_at_revision.rb
+++ b/app/models/pageflow/entry_at_revision.rb
@@ -16,7 +16,7 @@ module Pageflow
     delegate(:id, :slug,
              :entry_type,
              :account, :theming,
-             :enabled_feature_names,
+             :feature_state, :enabled_feature_names,
              :edit_lock,
              :password_digest,
              :to_model, :to_key, :to_param, :persisted?, :to_json,

--- a/app/models/pageflow/image_file_css_background_image_urls.rb
+++ b/app/models/pageflow/image_file_css_background_image_urls.rb
@@ -1,10 +1,10 @@
 module Pageflow
   # @api private
   class ImageFileCssBackgroundImageUrls
-    def call(image_file)
+    def call(image_file, entry:)
       {
         default: {
-          desktop: image_file.ready? ? image_file.attachment.url(:large) : '',
+          desktop: image_file.ready? ? image_file.attachment.url(desktop_style(entry)) : '',
           mobile: image_file.ready? ? image_file.attachment.url(:medium) : ''
         },
         panorama: {
@@ -12,6 +12,12 @@ module Pageflow
           mobile: image_file.ready? ? image_file.attachment.url(:panorama_medium) : ''
         }
       }
+    end
+
+    private
+
+    def desktop_style(entry)
+      entry.feature_state('highdef_background_images') ? :ultra : :large
     end
   end
 end

--- a/config/locales/new/highdef_background_images.de.yml
+++ b/config/locales/new/highdef_background_images.de.yml
@@ -1,0 +1,4 @@
+de:
+  pageflow:
+    highdef_background_images:
+      feature_name: "Hochaufgelöste Hintergrundbilder"

--- a/config/locales/new/highdef_background_images.en.yml
+++ b/config/locales/new/highdef_background_images.en.yml
@@ -1,0 +1,4 @@
+de:
+  pageflow:
+    highdef_background_images:
+      feature_name: "High resolution background images"

--- a/entry_types/paged/config/initializers/features.rb
+++ b/entry_types/paged/config/initializers/features.rb
@@ -1,5 +1,7 @@
 Pageflow.configure do |config|
   config.for_entry_type(PageflowPaged.entry_type) do |entry_type_config|
+    entry_type_config.features.register('highdef_background_images')
+
     entry_type_config.features.register('auto_change_page')
     entry_type_config.features.register('delayed_text_fade_in')
 

--- a/lib/pageflow/file_type.rb
+++ b/lib/pageflow/file_type.rb
@@ -123,6 +123,14 @@ module Pageflow
       @css_background_image_class_prefix || model.model_name.singular
     end
 
+    def css_background_image_urls_for(file, options)
+      if call_arity(css_background_image_urls) == 1
+        css_background_image_urls.call(file)
+      else
+        css_background_image_urls.call(file, options)
+      end
+    end
+
     # @api private
     def param_key
       model.model_name.param_key.to_sym
@@ -153,6 +161,22 @@ module Pageflow
       else
         {}
       end
+    end
+
+    def call_arity(callable)
+      # lambda's #call method always claims to have no required
+      # parameters:
+      #
+      #   lambda { |file| }.method(:call).arity # => -1
+      #   lambda { |file, entry:| }.method(:call).arity # => -1
+      #
+      # Use arity of lambda itself instead:
+      #
+      #   lambda { |file| }.arity # => 1
+      #   lambda { |file, entry:| }.arity # => 1
+      return callable.arity if callable.respond_to?(:arity)
+
+      callable.method(:call).arity
     end
   end
 end

--- a/spec/helpers/pageflow/file_background_images_helper_spec.rb
+++ b/spec/helpers/pageflow/file_background_images_helper_spec.rb
@@ -140,6 +140,27 @@ module Pageflow
 
         expect(result).to include(".custom_poster_#{uploadable_file.perma_id}")
       end
+
+      it 'supports taking entry keyword argument' do
+        pageflow_configure do |config|
+          TestFileType.register(
+            config,
+            model: TestUploadableFile,
+            css_background_image_urls: lambda do |_file, entry:|
+              {
+                poster: entry.feature_state('highdef_background_images') ? 'high' : 'low'
+              }
+            end
+          )
+        end
+
+        entry = PublishedEntry.new(create(:entry, :published))
+        create_used_file(:uploadable_file, entry: entry)
+
+        result = helper.file_background_images_css(entry, :desktop)
+
+        expect(result).to include("background-image: url('low')")
+      end
     end
   end
 end

--- a/spec/support/pageflow/lint/file_type.rb
+++ b/spec/support/pageflow/lint/file_type.rb
@@ -57,7 +57,8 @@ module Pageflow
 
           it 'provides css_background_image_urls that returns hash if present' do
             if file_type.css_background_image_urls
-              result = file_type.css_background_image_urls.call(file)
+              entry = create(:entry)
+              result = file_type.css_background_image_urls_for(file, entry: entry)
 
               expect(result).to be_a(Hash)
             end


### PR DESCRIPTION
When using text in images the current compression settings for the
`large` variant lead to sub-optimal results. The higher resolution
images happen to use higher values for the quality parameter.

REDMINE-19692