### PR TITLE
Support csmil HLS playlists

### DIFF
--- a/app/models/pageflow/video_file.rb
+++ b/app/models/pageflow/video_file.rb
@@ -114,7 +114,10 @@ module Pageflow
     def hls_playlist
       if Pageflow.config.zencoder_options[:hls_smil_suffix].present?
         ZencoderAttachment.new(self,
-                               'hls-playlist.smil',
+                               Pageflow.config.zencoder_options.fetch(
+                                 :hls_smil_file_name,
+                                 'hls-playlist.smil'
+                               ),
                                host: :hls,
                                url_suffix: Pageflow.config.zencoder_options[:hls_smil_suffix])
       else

--- a/app/models/pageflow/video_file_url_templates.rb
+++ b/app/models/pageflow/video_file_url_templates.rb
@@ -27,6 +27,7 @@ module Pageflow
     def example_file
       @example_file ||= VideoFile.new(id: 0).tap do |video_file|
         video_file.file_name = ':basename.mp4'
+        video_file.output_presences = {':pageflow_hls_qualities' => true}
         video_file.poster_file_name = video_file.zencoder_poster.original_filename
       end
     end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -20,6 +20,14 @@ Paperclip.interpolates(:pageflow_attachments_version) do |attachment, style|
   Pageflow::PaperclipInterpolations::Support.pageflow_attachments_version(attachment, style)
 end
 
+Paperclip.interpolates(:pageflow_hls_qualities) do |attachment, _style|
+  # Placeholder :pageflow_hls_qualities is included here to let
+  # VideoFileUrlTemplates preserve the palceholder in url templates.
+  %w[:pageflow_hls_qualities low medium high fullhd 4k].select { |quality|
+    attachment.instance.output_presences[quality]
+  }.join(',')
+end
+
 Paperclip.configure do |config|
   config.register_processor(:pageflow_vtt,
                             Pageflow::PaperclipProcessors::Vtt)

--- a/entry_types/paged/packages/pageflow-paged-react/src/files/__spec__/selectors-spec.js
+++ b/entry_types/paged/packages/pageflow-paged-react/src/files/__spec__/selectors-spec.js
@@ -79,6 +79,29 @@ describe('file', () => {
     expect(result).toHaveProperty('urls.high', 'http://example.com/my-video.mp4');
   });
 
+  it('interpolates hls qualities into video file url template', () => {
+    const files = {'video_files': [{
+      id: 2004,
+      perma_id: 31,
+      variants: ['low', 'medium', 'high', 'fullhd', 'hls-playlist'],
+      basename: 'my-video'
+    }]};
+    const fileUrlTemplates = {
+      'video_files': {
+        'hls-playlist': 'http://example.com/,:pageflow_hls_qualities,.mp4.csmil/master.m3u8'
+      }
+    };
+    const state = sample({files, fileUrlTemplates});
+
+    const result = file('videoFiles', {id: 31})(state);
+
+    expect(result)
+      .toHaveProperty(
+        'urls.hls-playlist',
+        'http://example.com/,low,medium,high,fullhd,.mp4.csmil/master.m3u8'
+      );
+  });
+
   it('skips url with missing template', () => {
     const files = {'video_files': [{id: 2004, perma_id: 31, variants: ['unknown']}]};
     const fileUrlTemplates = {'video_files': {}};

--- a/entry_types/paged/packages/pageflow-paged-react/src/files/expandUrls.js
+++ b/entry_types/paged/packages/pageflow-paged-react/src/files/expandUrls.js
@@ -37,7 +37,8 @@ function getFileUrl(collectionName, file, quality, urlTemplates) {
   if (template) {
     return template
       .replace(':id_partition', idPartition(file.id))
-      .replace(':basename', file.basename);
+      .replace(':basename', file.basename)
+      .replace(':pageflow_hls_qualities', () => hlsQualities(file));
   }
 }
 
@@ -53,4 +54,10 @@ function partition(string, separator) {
 
 function pad(string, size) {
   return (Array(size).fill(0).join('') + string).slice(-size);
+}
+
+function hlsQualities(file) {
+  return ['low', 'medium', 'high', 'fullhd', '4k']
+    .filter(quality => file.variants.includes(quality))
+    .join(',');
 }

--- a/entry_types/scrolled/package/spec/entryState/useFile-spec.js
+++ b/entry_types/scrolled/package/spec/entryState/useFile-spec.js
@@ -156,4 +156,40 @@ describe('useFile', () => {
       }
     });
   });
+
+  it('interpolates hls qualities into video file url templates', () => {
+    const {result} = renderHookInEntry(
+      () => useFile({collectionName: 'videoFiles', permaId: 1}),
+      {
+        seed: {
+          fileUrlTemplates: {
+            videoFiles: {
+              'hls-playlist': 'http://example.com/,:pageflow_hls_qualities,.mp4.csmil/master.m3u8'
+            }
+          },
+          fileModelTypes: {
+            videoFiles: 'Pageflow::VideoFile'
+          },
+          videoFiles: [
+            {
+              id: 100,
+              permaId: 1,
+              basename: 'video',
+              variants: ['low', 'medium', 'high', 'fullhd', 'hls-playlist'],
+            }
+          ]
+        }
+      }
+    );
+
+    const file = result.current;
+
+    expect(file).toMatchObject({
+      id: 100,
+      permaId: 1,
+      urls: {
+        'hls-playlist': 'http://example.com/,low,medium,high,fullhd,.mp4.csmil/master.m3u8'
+      }
+    });
+  });
 });

--- a/entry_types/scrolled/package/src/entryState/extendFile.js
+++ b/entry_types/scrolled/package/src/entryState/extendFile.js
@@ -64,7 +64,8 @@ function getFileUrl(collectionName, file, quality, urlTemplates) {
   if (template) {
     return template
       .replace(':id_partition', idPartition(file.id))
-      .replace(':basename', file.basename);
+      .replace(':basename', file.basename)
+      .replace(':pageflow_hls_qualities', () => hlsQualities(file));
   }
 }
 
@@ -80,4 +81,10 @@ function partition(string, separator) {
 
 function pad(string, size) {
   return (Array(size).fill(0).join('') + string).slice(-size);
+}
+
+function hlsQualities(file) {
+  return ['low', 'medium', 'high', 'fullhd', '4k']
+    .filter(quality => file.variants.includes(quality))
+    .join(',');
 }

--- a/spec/models/pageflow/video_file_url_templates_spec.rb
+++ b/spec/models/pageflow/video_file_url_templates_spec.rb
@@ -21,5 +21,46 @@ module Pageflow
       expect(result[:poster_ultra])
         .to include('pageflow/video_files/posters/:id_partition/ultra/poster-0.JPG')
     end
+
+    it 'returns template for hls playlist' do
+      result = VideoFileUrlTemplates.new.call
+
+      expect(result[:'hls-playlist'])
+        .to include('pageflow/video_files/:id_partition/hls-playlist.m3u8')
+    end
+
+    it 'returns template for hls playlist with smil suffix' do
+      Pageflow.config.zencoder_options[:hls_smil_suffix] = '/master.m3u8'
+
+      result = VideoFileUrlTemplates.new.call
+
+      expect(result[:'hls-playlist'])
+        .to include('pageflow/video_files/:id_partition/hls-playlist.smil/master.m3u8')
+    end
+
+    it 'supports custom smil playlist name' do
+      Pageflow.config.zencoder_options.merge!(
+        hls_smil_suffix: '/master.m3u8',
+        hls_smil_file_name: 'playlist.csmil'
+      )
+
+      result = VideoFileUrlTemplates.new.call
+
+      expect(result[:'hls-playlist'])
+        .to include('pageflow/video_files/:id_partition/playlist.csmil/master.m3u8')
+    end
+
+    it 'preserves hls qualities placeholder smil playlist name' do
+      Pageflow.config.zencoder_options.merge!(
+        hls_smil_suffix: '/master.m3u8',
+        hls_smil_file_name: ',:pageflow_hls_qualities,mp4.csmil'
+      )
+
+      result = VideoFileUrlTemplates.new.call
+
+      expect(result[:'hls-playlist'])
+        .to include('pageflow/video_files/:id_partition/' \
+                    ',:pageflow_hls_qualities,mp4.csmil/master.m3u8')
+    end
   end
 end

--- a/spec/models/pageflow/zencoder_attachment_spec.rb
+++ b/spec/models/pageflow/zencoder_attachment_spec.rb
@@ -18,8 +18,11 @@ module Pageflow
       zencoder_options[:attachments_version]
     end
 
-    def file_double(id:)
-      double('File', id: id, class: double(name: 'File'))
+    def file_double(id:, output_presences: [])
+      double('File',
+             id: id,
+             class: double(name: 'File'),
+             output_presences: output_presences)
     end
 
     describe '#original_filename' do
@@ -152,6 +155,24 @@ module Pageflow
 
         expect(attachment.url).to eq("#{s3_protocol}://#{s3_host_alias}/#{version}/" \
                                      'test-host/files/000/000/005/playlist.smil/master.m3u8')
+      end
+
+      it 'supports interpolations in file name pattern' do
+        file = file_double(id: 5,
+                           output_presences: {
+                             'low' => true,
+                             'medium' => true,
+                             'high' => true,
+                             'fullhd' => true,
+                             '4k' => false,
+                             'hls-playlist' => true
+                           })
+        attachment = ZencoderAttachment.new(file, ',:pageflow_hls_qualities,mp4.csmil',
+                                            url_suffix: '/master.m3u8')
+
+        expect(attachment.url)
+          .to eq("#{s3_protocol}://#{s3_host_alias}/#{version}/" \
+                 'test-host/files/000/000/005/,low,medium,high,fullhd,mp4.csmil/master.m3u8')
       end
 
       it 'can append url suffix and unique id to url' do


### PR DESCRIPTION
Make HLS-SMIL file name configurable and introduce
`:pageflow_hls_qualities` interpolation, which can be used to generate
HLS urls of the form

    .../,low,medium,high,fullhd,.mp4.csmil/master.m3u8

The listed qualities correspond to present outputs.

REDMINE-19686