### PR TITLE
Allow disabling taking snapshots when acquiring an editor lock

### DIFF
--- a/app/controllers/pageflow/edit_locks_controller.rb
+++ b/app/controllers/pageflow/edit_locks_controller.rb
@@ -8,7 +8,9 @@ module Pageflow
       entry = Entry.find(params[:entry_id])
       authorize!(:edit, entry)
       entry.edit_lock.acquire(current_user, edit_lock_params)
-      entry.snapshot(:creator => current_user)
+
+      entry.snapshot(creator: current_user) unless entry.feature_state('no_edit_lock_snapshot')
+
       respond_with(entry.reload.edit_lock, :location => entry_edit_lock_url(entry))
     end
 

--- a/spec/controllers/pageflow/edit_locks_controller_spec.rb
+++ b/spec/controllers/pageflow/edit_locks_controller_spec.rb
@@ -17,6 +17,30 @@ module Pageflow
           expect(response.status).to eq(201)
         end
 
+        it 'creates snapshot' do
+          user = create(:user)
+          entry = create(:entry, with_editor: user)
+
+          sign_in(user, scope: :user)
+
+          expect {
+            post(:create, params: {entry_id: entry}, format: :json)
+          }.to(change { entry.revisions.frozen.count })
+        end
+
+        it 'snapshot can be disabled' do
+          user = create(:user)
+          entry = create(:entry,
+                         with_editor: user,
+                         with_feature: 'no_edit_lock_snapshot')
+
+          sign_in(user, scope: :user)
+
+          expect {
+            post(:create, params: {entry_id: entry}, format: :json)
+          }.not_to(change { entry.revisions.frozen.count })
+        end
+
         it 'responds with id of created edit lock' do
           user = create(:user)
           entry = create(:entry, with_editor: user)


### PR DESCRIPTION
For pathologically large entries this copying everything can take so
long that opening the editor no longer works. Add feature flag to at
least restore editor access.

REDMINE-19747