### PR TITLE
Allow to disable page-level caching

### DIFF
--- a/app/helpers/pageflow/pages_helper.rb
+++ b/app/helpers/pageflow/pages_helper.rb
@@ -100,5 +100,15 @@ module Pageflow
       ThumbnailFileResolver.new(@entry, page.page_type.thumbnail_candidates, page.configuration)
                            .find_thumbnail
     end
+
+    def decide_caching(page, entry)
+      if entry.feature_state('page_level_caching')
+        cache [entry.locale, page] do
+          yield
+        end
+      else
+        yield
+      end
+    end
   end
 end

--- a/entry_types/paged/app/views/pageflow_paged/pages/_page.html.erb
+++ b/entry_types/paged/app/views/pageflow_paged/pages/_page.html.erb
@@ -1,4 +1,4 @@
-<%= cache [entry.locale, page] do %>
+<%= decide_caching(page, entry) do %>
   <%= content_tag(:section,
                   id: page.perma_id,
                   class: page_css_class(page),

--- a/entry_types/paged/config/initializers/features.rb
+++ b/entry_types/paged/config/initializers/features.rb
@@ -12,7 +12,9 @@ Pageflow.configure do |config|
     entry_type_config.features.register('editor_emulation_mode')
     entry_type_config.features.register('waveform_player_controls')
     entry_type_config.features.register('structured_data')
+    entry_type_config.features.register('page_level_caching')
 
     entry_type_config.features.enable_by_default('structured_data')
+    entry_type_config.features.enable_by_default('page_level_caching')
   end
 end


### PR DESCRIPTION
Depending on app usage and the caching back-end, it might be faster to
not cache pages and only cache the entries that contain them.

REDMINE-19719