### PR TITLE
Allow skipping encoding confirmation

### DIFF
--- a/app/assets/stylesheets/pageflow/editor/confirm_encoding.scss
+++ b/app/assets/stylesheets/pageflow/editor/confirm_encoding.scss
@@ -13,6 +13,12 @@
     }
   }
 
+  .intro {
+    p {
+      margin-top: space(3);
+    }
+  }
+
   ul.confirmable_files {
     margin-bottom: 15px;
 

--- a/app/state_machines/pageflow/media_encoding_state_machine.rb
+++ b/app/state_machines/pageflow/media_encoding_state_machine.rb
@@ -58,6 +58,10 @@ module Pageflow
           Pageflow.config.hooks.invoke(:file_encoding_confirmed, file: file)
         end
 
+        after_transition any => 'waiting_for_encoding' do |file|
+          Pageflow.config.hooks.invoke(:file_encoding, file: file)
+        end
+
         job SubmitFileToZencoderJob do
           on_enter 'waiting_for_encoding'
           result ok: 'encoding'

--- a/app/views/pageflow/editor/encoding_confirmations/check.json.jbuilder
+++ b/app/views/pageflow/editor/encoding_confirmations/check.json.jbuilder
@@ -1,3 +1,15 @@
 json.exceeding(@encoding_confirmation.exceeding?)
-json.summary_html(render_html_partial('pageflow/editor/encoding_confirmations/summary',
-                                      encoding_confirmation: @encoding_confirmation))
+
+json.intro_html(
+  render_html_partial(
+    'pageflow/editor/encoding_confirmations/intro',
+    encoding_confirmation: @encoding_confirmation
+  )
+)
+
+json.summary_html(
+  render_html_partial(
+    'pageflow/editor/encoding_confirmations/summary',
+    encoding_confirmation: @encoding_confirmation
+  )
+)

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -227,7 +227,9 @@ module Pageflow
     attr_accessor :transform_theme_customization_files
 
     # Submit video/audio encoding jobs only after the user has
-    # explicitly confirmed in the editor. Defaults to false.
+    # explicitly confirmed in the editor. Can either be set to a
+    # boolean or a lambda that is passed the file and returns a
+    # boolean. Defaults to false.
     attr_accessor :confirm_encoding_jobs
 
     # Used by Pageflow extensions to provide new tabs to be displayed
@@ -501,6 +503,15 @@ module Pageflow
     # @api private
     def lint!
       @features.lint!
+    end
+
+    # @api private
+    def confirm_encoding_jobs?(file)
+      if confirm_encoding_jobs.respond_to?(:call)
+        confirm_encoding_jobs.call(file)
+      else
+        confirm_encoding_jobs
+      end
     end
 
     # @api private

--- a/package/src/editor/controllers/SidebarController.js
+++ b/package/src/editor/controllers/SidebarController.js
@@ -40,11 +40,15 @@ export const SidebarController = Marionette.Controller.extend({
   },
 
   confirmableFiles: function(preselectedFileType, preselectedFileId) {
+    const model = EncodingConfirmation.createWithPreselection({
+      fileType: preselectedFileType,
+      fileId: preselectedFileId
+    });
+
+    model.check();
+
     this.region.show(ConfirmEncodingView.create({
-      model: EncodingConfirmation.createWithPreselection({
-        fileType: preselectedFileType,
-        fileId: preselectedFileId
-      })
+      model
     }));
   },
 

--- a/package/src/editor/templates/confirmEncoding.jst
+++ b/package/src/editor/templates/confirmEncoding.jst
@@ -9,6 +9,9 @@
   </p>
 </div>
 
+<div class="intro">
+</div>
+
 <div class="video_files_panel">
   <h2><%= I18n.t('pageflow.editor.templates.confirm_encoding.videos_tab') %></h2>
 </div>

--- a/package/src/editor/views/ConfirmEncodingView.js
+++ b/package/src/editor/views/ConfirmEncodingView.js
@@ -19,6 +19,7 @@ export const ConfirmEncodingView = Marionette.ItemView.extend({
     audioFilesPanel: '.audio_files_panel',
 
     summary: '.summary',
+    intro: '.intro',
     confirmButton: 'button'
   },
 
@@ -68,12 +69,17 @@ export const ConfirmEncodingView = Marionette.ItemView.extend({
   },
 
   updateBlankSlate: function() {
-    this.ui.blankSlate.toggle(!this.confirmableVideoFiles.length && !this.confirmableAudioFiles.length);
+    this.ui.blankSlate.toggle(!this.confirmableVideoFiles.length &&
+                              !this.confirmableAudioFiles.length);
+    this.ui.intro.toggle(!!this.confirmableVideoFiles.length ||
+                         !!this.confirmableAudioFiles.length);
     this.ui.videoFilesPanel.toggle(!!this.confirmableVideoFiles.length);
     this.ui.audioFilesPanel.toggle(!!this.confirmableAudioFiles.length);
+
   },
 
   updateSummary: function(enabled) {
+    this.ui.intro.html(this.model.get('intro_html'));
     this.ui.summary.html(this.model.get('summary_html'));
     this.ui.confirmButton.toggleClass('checking', !!this.model.get('checking'));
 

--- a/spec/controllers/pageflow/editor/encoding_confirmations_controller_spec.rb
+++ b/spec/controllers/pageflow/editor/encoding_confirmations_controller_spec.rb
@@ -198,6 +198,47 @@ module Pageflow
           expect(response.status).to eq(401)
         end
       end
+
+      it 'renders summary partial' do
+        user = create(:user)
+        entry = create(:entry, with_editor: user)
+        video_file = create(:video_file, :waiting_for_confirmation, used_in: entry.draft)
+
+        stub_template('pageflow/editor/encoding_confirmations/_summary.html.erb' => <<-ERB)
+          Summary for <%= encoding_confirmation.files.size %> file
+        ERB
+
+        sign_in(user, scope: :user)
+        post(:check,
+             params: {
+               entry_id: entry.id,
+               encoding_confirmation: {video_file_ids: [video_file.id]}
+             },
+             format: 'json')
+
+        expect(json_response(path: :summary_html).strip).to eq('Summary for 1 file')
+      end
+
+      it 'renders intro partial' do
+        user = create(:user)
+        account = create(:account, name: 'some-account', with_member: user)
+        entry = create(:entry, with_editor: user, account: account)
+        video_file = create(:video_file, :waiting_for_confirmation, used_in: entry.draft)
+
+        stub_template('pageflow/editor/encoding_confirmations/_intro.html.erb' => <<-ERB)
+          Intro for <%= encoding_confirmation.account.name %>
+        ERB
+
+        sign_in(user, scope: :user)
+        post(:check,
+             params: {
+               entry_id: entry.id,
+               encoding_confirmation: {video_file_ids: [video_file.id]}
+             },
+             format: 'json')
+
+        expect(json_response(path: :intro_html).strip).to eq('Intro for some-account')
+      end
     end
   end
 end

--- a/spec/pageflow/configuration_spec.rb
+++ b/spec/pageflow/configuration_spec.rb
@@ -103,5 +103,56 @@ module Pageflow
         expect(configuration.available_public_locales).to eq([:fr])
       end
     end
+
+    describe 'confirm_encoding_jobs?' do
+      it 'returns true if confirm_encoding_jobs is set to true' do
+        configuration = Configuration.new
+        file = build(:video_file)
+
+        configuration.confirm_encoding_jobs = true
+
+        expect(configuration.confirm_encoding_jobs?(file)).to eq(true)
+      end
+
+      it 'returns false if confirm_encoding_jobs is set to false' do
+        configuration = Configuration.new
+        file = build(:video_file)
+
+        configuration.confirm_encoding_jobs = false
+
+        expect(configuration.confirm_encoding_jobs?(file)).to eq(false)
+      end
+
+      it 'passes file if confirm_encoding_jobs is callable' do
+        configuration = Configuration.new
+        file = build(:video_file)
+        callable = double(call: true)
+
+        configuration.confirm_encoding_jobs = callable
+        configuration.confirm_encoding_jobs?(file)
+
+        expect(callable).to have_received(:call).with(file)
+      end
+
+      it 'returns true if callable returns true' do
+        configuration = Configuration.new
+        file = build(:video_file)
+
+        configuration.confirm_encoding_jobs = double(call: true)
+        result = configuration.confirm_encoding_jobs?(file)
+
+        expect(result).to eq(true)
+      end
+
+      it 'returns false if callable returns false' do
+        configuration = Configuration.new
+        file = build(:video_file)
+
+        configuration.confirm_encoding_jobs = double(call: false)
+        result = configuration.confirm_encoding_jobs?(file)
+
+        expect(result).to eq(false)
+      end
+    end
   end
 end

--- a/spec/support/helpers/zencoder_api_double.rb
+++ b/spec/support/helpers/zencoder_api_double.rb
@@ -9,12 +9,12 @@ module ZencoderApiDouble
     api
   end
 
-  def finished
+  def finished(file_details: {})
     api = double
 
     allow(api).to receive(:create_job).and_return(1)
     allow(api).to receive(:get_info).and_return(finished_info_result)
-    allow(api).to receive(:get_details).and_return(details)
+    allow(api).to receive(:get_details).and_return(details(**file_details))
 
     api
   end
@@ -88,11 +88,11 @@ module ZencoderApiDouble
      finished: false}
   end
 
-  def details
+  def details(duration_in_ms: 5000)
     {format: 'ogg',
      width: 200,
      height: 100,
-     duration_in_ms: 5000,
+     duration_in_ms: duration_in_ms,
      output_presences: {avi: 'finished', gif: 'skipped'}}
   end
 end


### PR DESCRIPTION
Let host application decide on a per-file basis whether encoding needs
to be confirmed by the user.

REDMINE-19483