### PR TITLE
Fix storybook

### DIFF
--- a/entry_types/scrolled/package/src/testHelpers/rendering.js
+++ b/entry_types/scrolled/package/src/testHelpers/rendering.js
@@ -1,6 +1,6 @@
 import React, {useEffect} from 'react';
 import {render} from '@testing-library/react';
-import {renderHook} from '@testing-library/react-hooks';
+import {renderHook} from '@testing-library/react-hooks/dom';
 
 import {Consent} from 'pageflow/frontend';
 import {useEntryStateDispatch, RootProviders} from 'pageflow-scrolled/frontend';


### PR DESCRIPTION
Exporting the test helpers from the package in #1818, caused the
storybook to raise an error of the form "Could not auto-detect a React
renderer" during rendering. The Percy related actions failed silently.