### PR TITLE
Prevent exception when reusing file from deleted entry

### DIFF
--- a/app/state_machines/pageflow/media_encoding_state_machine.rb
+++ b/app/state_machines/pageflow/media_encoding_state_machine.rb
@@ -87,7 +87,15 @@ module Pageflow
 
     # UploadableFile-overrides
     def retryable?
-      can_retry_encoding? && !encoded?
+      # Calling `can_retry_encoding?` invokes
+      # `Pageflow.config.confirm_encoding_jobs` which might depend on
+      # accessing `file.entry.account`. If the file has been reused in
+      # a different entry and the original entry has been deleted, we
+      # default to making the file not retryable to prevent
+      # exceptions.
+      entry &&
+        can_retry_encoding? &&
+        !encoded?
     end
 
     def ready?

--- a/spec/state_machines/pageflow/media_encoding_state_machine_examples.rb
+++ b/spec/state_machines/pageflow/media_encoding_state_machine_examples.rb
@@ -346,6 +346,14 @@ shared_examples 'media encoding state machine' do |model|
 
         expect(file).not_to be_retryable
       end
+
+      it 'does not invoke confirm_encoding_jobs if original entry is nil' do
+        Pageflow.config.confirm_encoding_jobs =
+          ->(file) { file.entry.duration_in_ms > 1000 }
+        file = create(model, :encoded, entry: nil)
+
+        expect(file).not_to be_retryable
+      end
     end
 
     describe '#failed?' do


### PR DESCRIPTION
Work around edge case which can cause error in editor seed, if host
application defines `confirm_encoding_jobs` lambda that depends on
`file.entry`.