### PR TITLE
Do not convert SVG files uploaded as scrolled logo

### DIFF
--- a/app/models/pageflow/theme_customization_file.rb
+++ b/app/models/pageflow/theme_customization_file.rb
@@ -51,7 +51,8 @@ module Pageflow
 
     # @api private
     def attachment_styles
-      options_from_entry_type.fetch(:styles, {})
+      styles = options_from_entry_type.fetch(:styles, {})
+      styles.respond_to?(:call) ? styles.call(self) : styles
     end
   end
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -34,6 +34,9 @@ Paperclip.configure do |config|
 
   config.register_processor(:pageflow_audio_waveform,
                             Pageflow::PaperclipProcessors::AudioWaveform)
+
+  config.register_processor(:noop,
+                            Pageflow::PaperclipProcessors::Noop)
 end
 
 Paperclip::UriAdapter.register

--- a/entry_types/scrolled/lib/pageflow_scrolled.rb
+++ b/entry_types/scrolled/lib/pageflow_scrolled.rb
@@ -14,14 +14,8 @@ module PageflowScrolled
                               editor_fragment_renderer: editor_fragment_renderer,
                               editor_app: PageflowScrolled::Engine,
                               theme_files: {
-                                logo_mobile: {
-                                  content_type: %r{\Aimage/},
-                                  styles: {resized: '350x100>'}
-                                },
-                                logo_desktop: {
-                                  content_type: %r{\Aimage/},
-                                  styles: {resized: '350x100>'}
-                                }
+                                logo_mobile: LOGO_OPTIONS,
+                                logo_desktop: LOGO_OPTIONS
                               })
     end
 
@@ -31,4 +25,16 @@ module PageflowScrolled
       Pageflow::PartialEditorFragmentRenderer.new(PageflowScrolled::Editor::EntriesController)
     end
   end
+
+  LOGO_OPTIONS = {
+    content_type: %r{\Aimage/},
+
+    styles: lambda do |file|
+      if File.extname(file.file_name) == '.svg'
+        {resized: {processors: [:noop]}}
+      else
+        {resized: '350x100>'}
+      end
+    end
+  }.freeze
 end

--- a/lib/pageflow/paperclip_processors/noop.rb
+++ b/lib/pageflow/paperclip_processors/noop.rb
@@ -1,0 +1,10 @@
+module Pageflow
+  module PaperclipProcessors
+    # @api private
+    class Noop < Paperclip::Processor
+      def make
+        File.new(file.path)
+      end
+    end
+  end
+end

--- a/spec/support/helpers/test_paperclip_processor.rb
+++ b/spec/support/helpers/test_paperclip_processor.rb
@@ -5,4 +5,8 @@ class TestPaperclipProcessor < Paperclip::Processor
     invoked_with_options << options
     Tempfile.new
   end
+
+  def self.reset
+    invoked_with_options.clear
+  end
 end


### PR DESCRIPTION
Paperclip does not like an empty processors array. We therefore define
a no-op processor to still be always able to use the `resized` style.