### PR TITLE
Pass consistent arguments when transforming theme options

### DIFF
--- a/app/models/pageflow/customized_theme.rb
+++ b/app/models/pageflow/customized_theme.rb
@@ -26,11 +26,13 @@ module Pageflow
       new(theme,
           config.transform_theme_customization_overrides.call(
             theme_customization.overrides,
-            entry
+            entry: entry,
+            theme: theme
           ),
           config.transform_theme_customization_files.call(
             theme_customization.selected_files.transform_values(&:urls),
-            entry
+            entry: entry,
+            theme: theme
           ))
     end
   end

--- a/app/models/pageflow/entry_at_revision.rb
+++ b/app/models/pageflow/entry_at_revision.rb
@@ -42,7 +42,7 @@ module Pageflow
     end
 
     def theme
-      @theme ||= CustomizedTheme.find(entry: self, theme: revision.theme)
+      @theme ||= CustomizedTheme.find(entry: entry, theme: revision.theme)
     end
 
     def home_button

--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -230,7 +230,7 @@ module Pageflow
     end
 
     def available_themes
-      Pageflow.config_for(entry).themes
+      @available_themes ||= Pageflow.config_for(entry).themes
     end
   end
 end


### PR DESCRIPTION
So far, we passed a `PublishedEntry` when actually computing theme
options for a published entry, but only passed an `Entry` when
previewing a theme customization. We now always pass an `Entry`.

To allow having the transformation depend on the actual theme, we
change the signature of the lambda to also take a theme option. This
is safer than always passing a `PublishedEntry` since calling
`PublishedEntry.theme` in the transform leads to a stack overflow.

REDMINE-17625