### PR TITLE
Remove space before heading in cards appearance

### DIFF
--- a/entry_types/scrolled/package/src/frontend/foregroundBoxes/CardBoxWrapper.module.css
+++ b/entry_types/scrolled/package/src/frontend/foregroundBoxes/CardBoxWrapper.module.css
@@ -4,6 +4,8 @@
 ) from "pageflow-scrolled/values/colors.module.css";
 
 .card {
+  --theme-first-heading-landscape-padding-top: 0;
+
   position: relative;
   padding: 0 1.5em;
   margin-top: -1px;


### PR DESCRIPTION
We need to find a good alternative to the fixed space before headings
in the first section. Since some entries rely on the space, though, we
cannot simply remove it.

At least when the cards are used, we know that we do not want to add a
padding to the card. So we start by fixing this case as a special
case.

REDMINE-19912