### PR TITLE
Set correct lang attribute on html element in editor preview iframe

### DIFF
--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/editor/seed_html_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/editor/seed_html_helper.rb
@@ -11,23 +11,25 @@ module PageflowScrolled
       include WebpackPublicPathHelper
 
       def scrolled_editor_iframe_seed_html_script_tag(entry)
-        html = render(template: 'pageflow_scrolled/entries/show',
-                      locals: {
-                        :@entry => entry,
-                        :@widget_scope => :editor,
-                        :@skip_ssr => true,
-                        :@skip_structured_data => true,
-                        :@seed_options => {
-                          skip_collections: true,
-                          include_unused_additional_seed_data: true,
-                          translations: {include_inline_editing: true}
-                        }
-                      })
+        I18n.with_locale(entry.locale) do
+          html = render(template: 'pageflow_scrolled/entries/show',
+                        locals: {
+                          :@entry => entry,
+                          :@widget_scope => :editor,
+                          :@skip_ssr => true,
+                          :@skip_structured_data => true,
+                          :@seed_options => {
+                            skip_collections: true,
+                            include_unused_additional_seed_data: true,
+                            translations: {include_inline_editing: true}
+                          }
+                        })
 
-        content_tag(:script,
-                    html.gsub('</', '<\/').html_safe,
-                    type: 'text/html',
-                    data: {template: 'iframe_seed'})
+          content_tag(:script,
+                      html.gsub('</', '<\/').html_safe,
+                      type: 'text/html',
+                      data: {template: 'iframe_seed'})
+        end
       end
     end
   end

--- a/entry_types/scrolled/spec/helpers/pageflow_scrolled/editor/seed_html_helper_spec.rb
+++ b/entry_types/scrolled/spec/helpers/pageflow_scrolled/editor/seed_html_helper_spec.rb
@@ -31,6 +31,20 @@ module PageflowScrolled
           expect(result).to have_selector('script', text: '<\/body>', visible: false)
         end
 
+        it 'sets lang attribute on head element based on entry locale' do
+          I18n.with_locale(:en) do
+            entry = create(:published_entry,
+                           type_name: 'scrolled',
+                           revision_attributes: {locale: 'de'})
+
+            result = helper.scrolled_editor_iframe_seed_html_script_tag(entry)
+
+            expect(result).to have_selector('script',
+                                            text: '<html lang="de"',
+                                            visible: false)
+          end
+        end
+
         it 'renders config seed data' do
           entry = create(:published_entry, type_name: 'scrolled')
 


### PR DESCRIPTION
Required to make browser apply correct hyphenation rules.

REDMINE-19967