### PR TITLE
Ensure scroller content is accessible via OS X Spoken Content

### DIFF
--- a/app/assets/stylesheets/pageflow/page.scss
+++ b/app/assets/stylesheets/pageflow/page.scss
@@ -39,7 +39,6 @@
   }
 
   .scroller > div {
-    pointer-events: none;
     width: 75%;
 
     @include mobile {
@@ -70,7 +69,6 @@
   }
 
   .scroller > div {
-    pointer-events: none;
     width: 100%;
 
     @include mobile {


### PR DESCRIPTION
Addition of `pointer-events: none` dates back to very early commit that claims to improve non-js functionality of video page. Since lazy loading has been added since then, video pages do not work without js anyway.

Enabling pointer events makes content accessible without otherwise altering behavior of the pages in any noticeable way.

REDMINE-19986