### PR TITLE
Ensure soft breaks are visible outside editor

### DIFF
--- a/entry_types/scrolled/package/src/frontend/EditableText.js
+++ b/entry_types/scrolled/package/src/frontend/EditableText.js
@@ -6,11 +6,15 @@ import {withInlineEditingAlternative} from './inlineEditing';
 import {Text} from './Text';
 import textStyles from './Text.module.css';
 
+import styles from './EditableText.module.css';
+
 export const EditableText = withInlineEditingAlternative('EditableText', function EditableText({value}) {
   return (
-    <Text scaleCategory="body">
-      {render(value)}
-    </Text>
+    <div className={styles.root}>
+      <Text scaleCategory="body">
+        {render(value)}
+      </Text>
+    </div>
   );
 });
 

--- a/entry_types/scrolled/package/src/frontend/EditableText.module.css
+++ b/entry_types/scrolled/package/src/frontend/EditableText.module.css
@@ -1,0 +1,3 @@
+.root {
+  white-space: pre-line;
+}


### PR DESCRIPTION
Slate sets `white-space: pre-wrap` as an inline style. Outside the editor, we need to set it ourselves to ensure line breaks take effect.

REDMINE-19967