### PR TITLE
Ensure inline editing help texts/prompts use user locale

### DIFF
--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/editor/seed_html_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/editor/seed_html_helper.rb
@@ -11,25 +11,23 @@ module PageflowScrolled
       include WebpackPublicPathHelper
 
       def scrolled_editor_iframe_seed_html_script_tag(entry)
-        I18n.with_locale(entry.locale) do
-          html = render(template: 'pageflow_scrolled/entries/show',
-                        locals: {
-                          :@entry => entry,
-                          :@widget_scope => :editor,
-                          :@skip_ssr => true,
-                          :@skip_structured_data => true,
-                          :@seed_options => {
-                            skip_collections: true,
-                            include_unused_additional_seed_data: true,
-                            translations: {include_inline_editing: true}
-                          }
-                        })
+        html = render(template: 'pageflow_scrolled/entries/show',
+                      locals: {
+                        :@entry => entry,
+                        :@widget_scope => :editor,
+                        :@skip_ssr => true,
+                        :@skip_structured_data => true,
+                        :@seed_options => {
+                          skip_collections: true,
+                          include_unused_additional_seed_data: true,
+                          translations: {include_inline_editing: true}
+                        }
+                      })
 
-          content_tag(:script,
-                      html.gsub('</', '<\/').html_safe,
-                      type: 'text/html',
-                      data: {template: 'iframe_seed'})
-        end
+        content_tag(:script,
+                    html.gsub('</', '<\/').html_safe,
+                    type: 'text/html',
+                    data: {template: 'iframe_seed'})
       end
     end
   end

--- a/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<%= content_tag(:html, lang: I18n.locale) do %>
+<%= content_tag(:html, lang: @entry.locale) do %>
   <head>
     <title><%= pretty_entry_title(@entry) %></title>
 


### PR DESCRIPTION
In #1867 we ensured that the `lang` attribute on the `html` tag is set based on the entry's locale in the editor. By switching the locale for the whole seed template, we also made inline editing help texts and prompts use the entry locale. Only set `lang` attribute based on entry locale instead.

REDMINE-19967