### PR TITLE
Also set Webpack public path for editor JS.

### DIFF
--- a/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
@@ -6,4 +6,6 @@
 
 <%= javascript_include_tag 'pageflow/vendor' %>
 <%= javascript_include_tag 'pageflow/editor/vendor' %>
+
+<%= scrolled_webpack_public_path_script_tag %>
 <%= scrolled_editor_javascript_packs_tag(entry) %>


### PR DESCRIPTION
Otherwise importing images from editor js results in paths that are missing the `/packs` prefix.

REDMINE-19985