### PR TITLE
Disable automatic hyphenation in text block headings

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/textBlock/TextBlock.module.css
+++ b/entry_types/scrolled/package/src/contentElements/textBlock/TextBlock.module.css
@@ -5,11 +5,6 @@
   margin: 1.375rem 0 0 0;
 }
 
-.text h2 {
-  hyphens: auto;
-  word-wrap: break-word;
-}
-
 .text a {
   color: var(--theme-text-block-dark-link-color,
              var(--theme-text-block-link-color, currentColor));


### PR DESCRIPTION
Causes also short words to be hyphenated which looks weird. We now support manual hyphenation in text blocks to deal with really long words.

REDMINE-19992, REDMINE-19967