### PR TITLE
Ensure backdrop covers viewport in iOS in-app browers

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/VhFix-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/VhFix-spec.js
@@ -1,0 +1,65 @@
+import {getHeight} from 'frontend/VhFix';
+
+describe('VhFix', () => {
+  describe('getHeight', () => {
+    it('returns undefined if probe height matches window height', () => {
+      const result = getHeight({
+        windowHeight: 2000,
+        probeHeight: 2000,
+        previousHeight: undefined
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined if probe height is greater than window height', () => {
+      const result = getHeight({
+        windowHeight: 1800,
+        probeHeight: 2000,
+        previousHeight: undefined
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns window height if probe height is lower than window height', () => {
+      const result = getHeight({
+        windowHeight: 2100,
+        probeHeight: 2000,
+        previousHeight: undefined
+      });
+
+      expect(result).toEqual(2100);
+    });
+
+    it('returns window height if it increases to no longer match probe height', () => {
+      const result = getHeight({
+        windowHeight: 2100,
+        probeHeight: 2000,
+        previousHeight: 2000
+      });
+
+      expect(result).toEqual(2100);
+    });
+
+    it('returns previous height if window height decreases again', () => {
+      const result = getHeight({
+        windowHeight: 2000,
+        probeHeight: 2000,
+        previousHeight: 2100
+      });
+
+      expect(result).toEqual(2100);
+    });
+
+    it('returns window height if it decreases drastically (orientation change)', () => {
+      const result = getHeight({
+        windowHeight: 1000,
+        probeHeight: 1000,
+        previousHeight: 2100
+      });
+
+      expect(result).toEqual(1000);
+    });
+  });
+});

--- a/entry_types/scrolled/package/src/frontend/Content.js
+++ b/entry_types/scrolled/package/src/frontend/Content.js
@@ -2,6 +2,7 @@ import React, {useState, useCallback} from 'react';
 
 import Chapter from "./Chapter";
 import ScrollToSectionContext from './ScrollToSectionContext';
+import {VhFix} from './VhFix';
 import {useCurrentSectionIndexState} from './useCurrentChapter';
 import {useEntryStructure} from '../entryState';
 import {withInlineEditingDecorator} from './inlineEditing';
@@ -56,15 +57,17 @@ export const Content = withInlineEditingDecorator('ContentDecorator', function C
 
   return (
     <div className={styles.Content} id='goToContent'>
-      <AtmoProvider>
-        <ScrollToSectionContext.Provider value={scrollToSection}>
-          {renderChapters(entryStructure,
-                          currentSectionIndex,
-                          setCurrentSection,
-                          scrollTargetSectionIndex,
-                          setScrollTargetSectionIndex)}
-        </ScrollToSectionContext.Provider>
-      </AtmoProvider>
+      <VhFix>
+        <AtmoProvider>
+          <ScrollToSectionContext.Provider value={scrollToSection}>
+            {renderChapters(entryStructure,
+                            currentSectionIndex,
+                            setCurrentSection,
+                            scrollTargetSectionIndex,
+                            setScrollTargetSectionIndex)}
+          </ScrollToSectionContext.Provider>
+        </AtmoProvider>
+      </VhFix>
     </div>
   );
 })

--- a/entry_types/scrolled/package/src/frontend/Fullscreen.module.css
+++ b/entry_types/scrolled/package/src/frontend/Fullscreen.module.css
@@ -1,6 +1,6 @@
 .root {
   width: 100%;
-  height: 100vh;
+  height: calc(100 * var(--vh));
   position: relative;
   overflow: hidden;
 }

--- a/entry_types/scrolled/package/src/frontend/VhFix.js
+++ b/entry_types/scrolled/package/src/frontend/VhFix.js
@@ -1,0 +1,63 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {browser} from 'pageflow/frontend';
+
+// InApp browsers on iOS (e.g. Twitter) report the height of the
+// initial viewport as 100vh. Once the page is scrolled, browser
+// toolbars are hidden, the viewport becomes larger and elements with
+// height 100vh no longer cover the viewport.
+//
+// To detect this situation, this component compares the height of a
+// 100vh div with the inner height of the window on resize. Once those
+// window height exceeds probe heights the component sets the `--vh`
+// custom property (which default to 1vh) to a pixel value such that
+// `calc(100 * var(--vh))` equals the inner height of the window.
+//
+// To prevent changing element sizes once the browser toolbars are
+// shown again (when the user scrolls back up), `--vh` is not updated
+// when the inner height of the window decreases slightly.
+//
+// On orientation change, we do want to update `--vh`, though. We
+// therefore do update it when the inner height of the window
+// decreases by more than 30%.
+export function VhFix({children}) {
+  const probeRef = useRef();
+  const [height, setHeight] = useState();
+
+  useEffect(() => {
+    if (!browser.has('ios platform')) {
+      return;
+    }
+
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+
+    function update() {
+      setHeight(previousHeight => getHeight({
+        windowHeight: window.innerHeight,
+        probeHeight: probeRef.current.clientHeight,
+        previousHeight
+      }));
+    }
+  }, []);
+
+  return (
+    <div style={height && {'--vh': `${height / 100}px`}}>
+      <div style={{height: '100vh', position: 'absolute'}}
+           ref={probeRef} />
+      {children}
+    </div>
+  );
+}
+
+export function getHeight({windowHeight, probeHeight, previousHeight}) {
+  if (probeHeight < windowHeight || previousHeight) {
+    if (!previousHeight ||
+        windowHeight > previousHeight ||
+        windowHeight < previousHeight * 0.7) {
+      return windowHeight
+    }
+    else {
+      return previousHeight;
+    }
+  }
+}


### PR DESCRIPTION
Prevent backdrop from staying to small once in-app browsers (e.g. Twitter browser) hides its toolbars on scroll.

REDMINE-20011