### PR TITLE
Migrate to supported setup-ruby action

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -78,7 +78,7 @@ jobs:
     # Ruby/Node
 
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
     # Ruby/Node
 
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
 


### PR DESCRIPTION
`actions/setup-ruby` started raising error:

     ------------------------
     NOTE: This action is deprecated and is no longer maintained.
     Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
     ------------------------
     Error: Version 2.6 not found