### PR TITLE
Disable top padding for new headings

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/heading/Heading.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/Heading.js
@@ -19,11 +19,13 @@ export function Heading({configuration, sectionProps}) {
   const legacyValue = configuration.children;
   const Tag = firstSectionInEntry ? 'h1' : 'h2';
 
+  const forcePaddingTop = firstSectionInEntry && !('marginTop' in configuration);
+
   return (
     <Tag className={classNames(styles.root,
                                configuration.typographyVariant &&
                                `typography-heading-${configuration.typographyVariant}`,
-                               {[styles.first]: firstSectionInEntry},
+                               {[styles.forcePaddingTop]: forcePaddingTop},
                                {[styles[sectionProps.layout]]:
                                  configuration.position === 'wide' ||
                                  sectionProps.layout === 'centerRagged'},

--- a/entry_types/scrolled/package/src/contentElements/heading/Heading.module.css
+++ b/entry_types/scrolled/package/src/contentElements/heading/Heading.module.css
@@ -16,7 +16,7 @@
 }
 
 @media (orientation: landscape) {
-  .first {
+  .forcePaddingTop {
     padding-top: var(--theme-first-heading-landscape-padding-top, 25%);
   }
 }

--- a/entry_types/scrolled/package/src/contentElements/heading/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/editor.js
@@ -9,7 +9,7 @@ editor.contentElementTypes.register('heading', {
   pictogram,
   supportedPositions: ['inline', 'wide'],
 
-  defaultConfig: {position: 'wide'},
+  defaultConfig: {position: 'wide', marginTop: 'none'},
 
   configurationEditor({entry}) {
     this.listenTo(this.model, 'change:hyphens', this.refresh);


### PR DESCRIPTION
The automatic padding for headings in first sections keeps confusing users. Still, we cannot simply remove it without risking breaking existing entries. We therefore add a new default config which turns it off for new headings. Since we expect to add some sort of margin settings for all content element types at some point, we try to name the property in a way that we can continue to use once we introduce this concept.

REDMINE-20084