### PR TITLE
Missing semicolon in themes/default/page.scss

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -78,7 +78,7 @@ jobs:
     # Ruby/Node
 
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
     # Ruby/Node
 
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
 

--- a/app/assets/stylesheets/pageflow/themes/default/page.scss
+++ b/app/assets/stylesheets/pageflow/themes/default/page.scss
@@ -9,7 +9,7 @@ $page-typography: () !default;
 $page-content-text-typography: () !default;
 
 /// Typography for content text in phone layout.
-$page-content-text-phone-typography: () !default
+$page-content-text-phone-typography: () !default;
 
 /// Base font size for page content
 $page-content-font-size: 1em !default;


### PR DESCRIPTION
assets:precompile returned an error:
** Execute assets:precompile
rake aborted!
Sass::SyntaxError: Invalid CSS after "...or page content": expected selector or at-rule, was "$page-content-f..."
/usr/local/bundle/gems/pageflow-15.7.1/app/assets/stylesheets/pageflow/themes/default/page.scss:15
/usr/local/bundle/gems/pageflow-15.7.1/app/assets/stylesheets/pageflow/themes/default/base.scss:22
/usr/local/bundle/gems/pageflow-15.7.1/app/assets/stylesheets/pageflow/themes/default.scss:1
/usr/local/bundle/gems/sass-3.7.4/lib/sass/scss/parser.rb:1308:in `expected'

After investigation i found that a missing semicolon caused the issue.