### PR TITLE
Display opt-out vendors as accepted by default on privacy page

### DIFF
--- a/package/src/frontend/Consent/index.js
+++ b/package/src/frontend/Consent/index.js
@@ -79,7 +79,8 @@ export class Consent {
           vendor.paradigm === 'external opt-out' ||
           (vendor.paradigm === 'lazy opt-in' &&
            this.persistence.read(vendor) !== 'undecided');
-      })
+      }),
+      {applyDefaults: true}
     );
   }
 
@@ -190,10 +191,23 @@ export class Consent {
     return vendor;
   }
 
-  withState(vendors) {
+  withState(vendors, {applyDefaults} = {}) {
     return vendors.map((vendor) => {
-      return {...vendor, state: this.persistence.read(vendor)};
+      const state = this.persistence.read(vendor);
+
+      return {
+        ...vendor,
+        state: state === 'undecided' && applyDefaults ? this.getDefaultState(vendor) : state
+      };
     });
+  }
+
+  getDefaultState(vendor) {
+    if (vendor.paradigm === 'external opt-out') {
+      return 'accepted';
+    }
+
+    return 'undecided';
   }
 }
 


### PR DESCRIPTION
Using this paradigm causes vendors to be accepted unless the opt-out cookie is present.

REDMINE-19544