### PR TITLE
Prevent foreground shadow from overlaying next section

### DIFF
--- a/entry_types/scrolled/package/src/frontend/Section.js
+++ b/entry_types/scrolled/package/src/frontend/Section.js
@@ -82,10 +82,17 @@ function SectionContents({
     sectionIndex: section.sectionIndex
   }), [section.layout, section.invert, section.sectionIndex]);
 
+  const transitions = getEnterAndExitTransitions(
+    section,
+    section.previousSection,
+    section.nextSection
+  );
+  const [, exitTransition] = transitions;
+
   const [motifAreaState, setMotifAreaRef, setContentAreaRef] = useMotifAreaState({
     updateOnScrollAndResize: shouldPrepare,
     exposeMotifArea: section.exposeMotifArea,
-    transitions: getEnterAndExitTransitions(section, section.previousSection, section.nextSection),
+    transitions,
     empty: !contentElements.length,
     sectionTransition: section.transition,
     fullHeight: section.fullHeight
@@ -124,7 +131,7 @@ function SectionContents({
                   paddingBottom={!endsWithFullWidthElement(contentElements)}
                   heightMode={heightMode(section)}>
         <Box inverted={section.invert}
-             coverInvisibleNextSection={section.nextSection && section.nextSection.transition.startsWith('fade')}
+             coverInvisibleNextSection={exitTransition.startsWith('fade')}
              transitionStyles={transitionStyles}
              state={state}
              motifAreaState={motifAreaState}


### PR DESCRIPTION
For sections that exit with a fade transition we extend the height of the foreground shadow to make sure the shadow does not end too early before the section is finally faded out.

When the "use full viewport" setting is disabled for such a section, we fall back to the "scroll" transition. In this case we still made the shadow longer causing it cover parts of the following section.