### PR TITLE
Add reusable GitHub workflow to run RSpec tests

### DIFF
--- a/.github/workflows/reusable-workflow-rspec.yml
+++ b/.github/workflows/reusable-workflow-rspec.yml
@@ -1,0 +1,65 @@
+name: tests
+on: workflow_call
+
+env:
+  RAILS_ENV: test
+  PAGEFLOW_DB_HOST: 127.0.0.1
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        ports:
+          - 3306:3306
+        # Set health checks to wait until mysql has started
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries 5
+
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Caching
+
+    - name: Set up cache for Bundler
+      uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/*.gemspec') }}-${{ hashFiles('**/Gemfile') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
+    # Ruby/Node
+
+    - name: Set up Ruby 2.6
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+
+    # Dependencies
+
+    - name: Bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+
+    # Test
+
+    - name: Run tests
+      run: bin/rspec


### PR DESCRIPTION
Can be used in plugin repositories to limit duplication.

REDMINE-20103