### PR TITLE
Improve theme property for default navigation progress bar height

### DIFF
--- a/entry_types/scrolled/doc/creating_themes/custom_colors_and_dimensions.md
+++ b/entry_types/scrolled/doc/creating_themes/custom_colors_and_dimensions.md
@@ -198,10 +198,10 @@ System](https://material.io/design/color/the-color-system.html#color-theme-creat
 
 | Name | Description |
 | ---- | ----------- |
-| `default_navigation_bar_height` | Height of the navigation bar excluding the progress indicator. |
+| `default_navigation_bar_height` | Height of the navigation bar excluding the progress bar. |
 | `default_navigation_scroller_top` | Position of the horizontal scroller containing the chapter list. |
 | `default_navigation_scroll_button_top` | Position of the left/right scroll buttons visible when the chapter list overflows horizontally. |
 | `default_navigation_chapter_link_height` | Height of the links inside the horizontal chapter list. |
-| `default_navigation_chapter_progress_indicator_height` | Height of the progress indicator. |
+| `default_navigation_progress_bar_height` | Height of the progress indicator. By default, the progress bar is slightly taller in phone layout. Setting the property applies the same height for desktop and phone layout.|
 | `default_navigation_progress_bar_background_color` | Background color of the progress bar. |
 | `default_navigation_progress_bar_indicator_color` | Color of the progress bar indicator. Defaults to `accent_color`. |

--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/DefaultNavigation.module.css
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/DefaultNavigation.module.css
@@ -15,8 +15,8 @@
   --default-navigation-chapter-link-height:
     var(--theme-default-navigation-chapter-link-height, 50px);
 
-  --default-navigation-progress-indicator-height:
-    var(--theme-default-navigation-progress-indicator-height, 10px);
+  --default-navigation-progress-bar-height:
+    var(--theme-default-navigation-progress-bar-height, 8px);
 
   font-family: var(--theme-widget-font-family);
   position: fixed;
@@ -122,7 +122,7 @@ div:focus-within > .contextIcon,
   position: relative;
   background-color: var(--theme-default-navigation-progress-bar-background-color,
                         rgba(194,194,194,0.8));
-  height: 8px;
+  height: var(--default-navigation-progress-bar-height);
   width: 100%;
 }
 
@@ -137,6 +137,11 @@ div:focus-within > .contextIcon,
 }
 
 @media screen and breakpoint-below-md {
+  .navigationBar {
+    --default-navigation-progress-bar-height:
+      var(--theme-default-navigation-progress-bar-height, 10px);
+  }
+
   .logo {
     max-width: 30%;
   }
@@ -149,7 +154,7 @@ div:focus-within > .contextIcon,
     display: block;
     position: fixed;
     top: calc(var(--default-navigation-bar-height) +
-              var(--default-navigation-progress-indicator-height));
+              var(--default-navigation-progress-bar-height));
     left: 0px;
     background: var(--theme-widget-background-color);
     width: 100vw;
@@ -201,10 +206,6 @@ div:focus-within > .contextIcon,
 
   .chapterListItem p {
     margin-top: 0;
-  }
-
-  .progressBar {
-    height: var(--default-navigation-progress-indicator-height);
   }
 }
 


### PR DESCRIPTION
* Also apply to desktop layout.

* Rename to align naming with other progress bar related properties.

* Reference correct name in theme docs.

REDMINE-20108
