### PR TITLE
Add widget slot to default navigation

### DIFF
--- a/entry_types/scrolled/package/src/frontend/Widget.js
+++ b/entry_types/scrolled/package/src/frontend/Widget.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {api} from './api';
 import {useWidget} from '../entryState';
 
-export function Widget({role}) {
+export function Widget({role, props}) {
   const widget = useWidget({role});
 
   if (!widget) {
@@ -13,6 +13,6 @@ export function Widget({role}) {
   const Component = api.widgetTypes.getComponent(widget.typeName);
 
   return (
-    <Component configuration={widget.configuration} />
+    <Component configuration={widget.configuration} {...props} />
   );
 }

--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/DefaultNavigation.js
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/DefaultNavigation.js
@@ -2,6 +2,7 @@ import React, {useState, useCallback} from 'react';
 import classNames from 'classnames';
 
 import {
+  Widget,
   useScrollPosition,
   useChapters,
   useCurrentChapter,
@@ -113,6 +114,7 @@ export function DefaultNavigation({configuration}) {
                             !shareProviders.length;
 
   return (
+    <>
     <header className={classNames(styles.navigationBar, {
       [styles.navigationBarExpanded]: (
         navExpanded ||
@@ -141,5 +143,9 @@ export function DefaultNavigation({configuration}) {
         <span className={styles.progressIndicator} style={{width: readingProgress + '%'}}/>
       </div>
     </header>
+    <Widget role="defaultNavigationExtra"
+            props={{navigationExpanded: navExpanded,
+                    mobileNavigationVisible: !mobileNavHidden}} />
+    </>
   );
 }


### PR DESCRIPTION
Pass props whether navigation is expanded or mobile menu is open. Can
be used to build custom footers.

REDMINE-20108
