### PR TITLE
Remove Theming alias for Site

### DIFF
--- a/app/models/pageflow/theming.rb
+++ b/app/models/pageflow/theming.rb
@@ -1,5 +1,0 @@
-module Pageflow
-  # Ensure polymorphic associations using this legacy class name still
-  # work.
-  Theming = Site
-end

--- a/spec/models/pageflow/widget_spec.rb
+++ b/spec/models/pageflow/widget_spec.rb
@@ -220,12 +220,5 @@ module Pageflow
         expect(subject.widgets).to include_record_with(role: 'header', type_name: 'new_widget')
       end
     end
-
-    it 'supports legacy subject type' do
-      site = create(:site)
-      widget = create(:widget, subject_id: site.id, subject_type: 'Pageflow::Theming')
-
-      expect(widget.subject).to eq(site)
-    end
   end
 end


### PR DESCRIPTION
Was meant to ensure that polymorphic associations keep working. This
only works for `belongs_to` associations, though, not for
`has_many`. Moreover, `Widget` references `EntryTemplate` anyway - not
`Theming`/`Site`. Plugins that use `Theming` will need to be migrated.

REDMINE-20103, REDMINE-20090
