### PR TITLE
Remove entry template from account form

### DIFF
--- a/app/views/admin/accounts/_form.html.erb
+++ b/app/views/admin/accounts/_form.html.erb
@@ -16,10 +16,6 @@
     <% end %>
   <% end  %>
 
-  <p>
-      <%= t('pageflow.admin.accounts.entry_template_hint') %>
-  </p>
-
   <%= f.actions do %>
     <%= f.action(:submit) %>
     <%= f.action(:cancel, :wrapper_html => {:class => 'cancel'}) %>

--- a/config/locales/new/multiple_sites.de.yml
+++ b/config/locales/new/multiple_sites.de.yml
@@ -4,3 +4,5 @@ de:
       sites:
         add: "Site hinzufügen"
         default_name: "(Standard)"
+      accounts:
+        entry_template_hint: DELETED

--- a/config/locales/new/multiple_sites.en.yml
+++ b/config/locales/new/multiple_sites.en.yml
@@ -4,3 +4,5 @@ en:
       sites:
         default_name: "(Default)"
         add: "Add site"
+      accounts:
+        entry_template_hint: DELETED


### PR DESCRIPTION
Extracted fields have moved again to site admin. The original move is
long enough ago now to no longer warrant the hint.

REDMINE-20103, REDMINE-20090
