### PR TITLE
Fix scrolling classic page content on Windows 10 with touch screen

### DIFF
--- a/vendor/assets/javascripts/iscroll.js
+++ b/vendor/assets/javascripts/iscroll.js
@@ -101,7 +101,6 @@ var utils = (function () {
 	me.extend(me, {
 		hasTransform: _transform !== false,
 		hasPerspective: _prefixStyle('perspective') in _elementStyle,
-		hasTouch: 'ontouchstart' in window,
 		hasPointer: navigator.msPointerEnabled,
 		hasTransition: _prefixStyle('transition') in _elementStyle
 	});
@@ -862,12 +861,10 @@ IScroll.prototype = {
 			eventType(target, 'MSPointerUp', this);
 		}
 
-		if ( utils.hasTouch ) {
-			eventType(startEventTarget, 'touchstart', this);
-			eventType(target, 'touchmove', this);
-			eventType(target, 'touchcancel', this);
-			eventType(target, 'touchend', this);
-		}
+		eventType(startEventTarget, 'touchstart', this);
+		eventType(target, 'touchmove', this);
+		eventType(target, 'touchcancel', this);
+		eventType(target, 'touchend', this);
 
 		eventType(this.scroller, 'transitionend', this);
 		eventType(this.scroller, 'webkitTransitionEnd', this);


### PR DESCRIPTION
Both Edge 107 and Chrome 109 on Microsoft Surface Laptio 1 with
Windows 10 Pro did not react to touch events. This is caused by
iScrolls detecting touch as disabled on these platforms (via
`'ontouchstart' in window`) even though touch events are fired when
the user interacts with the touch screen.

On Android and iOS (where touch already is detected correctly) iScroll
registers both mouse and touch event handlers and tracks which kind of
event initiated the scroll to ignore the others. We therefore remove
touch feature detection altogether and always register touch event
handlers.

On platforms that really do not have touch events, those events should
then just never fire.

REDMINE-20117
