### PR TITLE
Do not scale images up when creating panorama styles

### DIFF
--- a/spec/models/pageflow/image_file_spec.rb
+++ b/spec/models/pageflow/image_file_spec.rb
@@ -52,6 +52,22 @@ module Pageflow
 
         expect(styles[:panorama_large][:format]).to eq(:JPG)
       end
+
+      it 'resizes panorama if original is larger than target in both dimensions' do
+        image_file = build(:image_file, :uploading, width: 3000, height: 1500)
+        styles = image_file.attachment.styles
+
+        expect(styles[:panorama_large].processor_options[:geometry]).to eq('1920x1080^')
+        expect(styles[:panorama_medium].processor_options[:geometry]).to eq('1024x1024^')
+      end
+
+      it 'does not resize panorama if original is smaller than target in one dimensions' do
+        image_file = build(:image_file, :uploading, width: 2000, height: 1000)
+        styles = image_file.attachment.styles
+
+        expect(styles[:panorama_large].processor_options[:geometry]).to eq('100%')
+        expect(styles[:panorama_medium].processor_options[:geometry]).to eq('100%')
+      end
     end
 
     describe 'basename' do


### PR DESCRIPTION
Especially for small images with extreme aspect ratios, this can lead to images which exceed limits and cause errors of the form:

    convert-im6.q16: width or height exceeds limit

For example, a 1000x10 image scaled to cover 1024x1024 a rect leads to an image that is 102400 pixels wide.

Instead only scale panorama images if their dimensions exceed the size of the box that we want to cover in both dimensions.

To be able to use image dimensions to define style geometry, we need to detect width and height before post processing starts.

REDMINE-20147