### PR TITLE
Improve blessing media elements for iOS

### DIFF
--- a/package/src/frontend/media/MediaPool.js
+++ b/package/src/frontend/media/MediaPool.js
@@ -139,7 +139,10 @@ export class MediaPool {
       mediaElement: mediaEl,
       tagName: type
     });
+
     mediaEl.setAttribute('src', blankSources[type].src);
+    player.muted(true);
+
     this.unAllocatedPlayers[type].push(player);
     return player;
   }


### PR DESCRIPTION
Mobile browsers only allow playing videos and audios with sound, when the play call is triggered directly via a user
interaction (e.g. handling a click event). Same goes for unmuting an already playing muted video or audio element.

Once a video or audio element has been unmuted like that, we can pause and resume also outside of a user interaction (e.g. based on a firing intersection observer). Media elements stay "blessed" like this, even when we change the source.

To allow autoplaying videos and audios with sound on mobile browsers, we keep a pool of media elements that we unmute once the user clicks the unmute button. We then reuse ("allocate") those players whenever we want to play video or audio.

At least on iOS 15.4.1 and 16.3 setting `unmute` to `false` only has this blessing effect if the media element actually was muted before.

We observed the following behavior:

1. Load entry and ensure the media pool is populated (either by playing an inline audio in the first section or using a background video near the first section).

2. Unmute via the navigation bar button.

3. Scroll to another section with additional inline audios or videos.

4. Observe that all media elements that have not yet been allocated before, do not start playback when the play button is clicked. Media elements that had been allocated (and thus were explicitly muted) when the unmute button was clicked, play without problem.

5. Muting and unmuting the entry again, fixes the problem.

We can fix the issue by making sure all media elements are muted when the pool is populated initially.

REDMINE-20157