### PR TITLE
Introduce palettes

### DIFF
--- a/entry_types/scrolled/config/locales/new/counter.de.yml
+++ b/entry_types/scrolled/config/locales/new/counter.de.yml
@@ -6,6 +6,9 @@ de:
     inline_editing:
       type_description: Type description
     editor:
+      common_content_element_attributes:
+        palette_color:
+          blank: "(Automatisch)"
       content_elements:
         counter:
           description: Animierte Metriken
@@ -56,3 +59,5 @@ de:
                 large: Groß
                 medium: Mittel
                 small: Klein
+            numberColor:
+              label: "Farbe"

--- a/entry_types/scrolled/config/locales/new/counter.en.yml
+++ b/entry_types/scrolled/config/locales/new/counter.en.yml
@@ -6,6 +6,9 @@ en:
     inline_editing:
       type_description: Type description
     editor:
+      common_content_element_attributes:
+        palette_color:
+          blank: "(Auto)"
       content_elements:
         counter:
           description: Animated metrics
@@ -56,3 +59,5 @@ en:
                 large: Large
                 medium: Medium
                 small: Small
+            numberColor:
+              label: Color

--- a/entry_types/scrolled/config/locales/new/quote.de.yml
+++ b/entry_types/scrolled/config/locales/new/quote.de.yml
@@ -17,3 +17,5 @@ de:
                 large: Groß
                 medium: Mittel
                 small: Klein
+            color:
+              label: Farbe

--- a/entry_types/scrolled/config/locales/new/quote.en.yml
+++ b/entry_types/scrolled/config/locales/new/quote.en.yml
@@ -17,3 +17,5 @@ en:
                 large: Large
                 medium: Medium
                 small: Small
+            color:
+              label: Color

--- a/entry_types/scrolled/doc/creating_content_element_types.md
+++ b/entry_types/scrolled/doc/creating_content_element_types.md
@@ -303,6 +303,53 @@ pageflow_scrolled:
             inline_help: "..."
 ```
 
+## Using Palette Colors
+
+[Palette
+colors](./creating_themes/custom_colors_and_dimensions.md#palette-colors)
+let users pick colors for certain content element properties using a
+predefined, theme-specific selection of colors. To define a property
+based on palette colors, you can use the `PaletteColors` input group
+in your content element's configuration editor:
+
+```javascript
+import {editor} from 'pageflow-scrolled/editor';
+import {TextInputView} from 'pageflow/ui';
+
+editor.contentElementTypes.register('myContentElement', {
+  configurationEditor({entry}) {
+    this.tab('general', function() {
+      this.input('caption', TextInputView);
+      this.group('PaletteColor', {
+        entry,
+        propertyName: 'color'
+      });
+    });
+  }
+});
+```
+
+This will let the user choose a color from the palette defined by the
+current theme and assign it to the `color` property. Just like for a
+normal input, you need to define translations for the label and inline
+help text of the property.
+
+Inside your component, you can apply the palette using the
+`paletteColor` helper:
+
+```javascript
+import React from 'react';
+import {paletteColor} from 'pageflow-scrolled/frontend';
+
+export function MyContentElement({configuration}) {
+  return (
+    <div style={{color: paletteColor(configuration.color)}}>
+      ...
+    </div>
+  );
+}
+```
+
 ## Further Steps
 
 * [Additional Frontend Seed Data](./additional_frontend_seed_data.md)

--- a/entry_types/scrolled/doc/creating_themes/custom_colors_and_dimensions.md
+++ b/entry_types/scrolled/doc/creating_themes/custom_colors_and_dimensions.md
@@ -214,3 +214,44 @@ System](https://material.io/design/color/the-color-system.html#color-theme-creat
 | `default_navigation_progress_bar_background_color` | Background color of the progress bar. |
 | `default_navigation_progress_bar_indicator_color` | Color of the progress bar indicator. Defaults to `accent_color`. |
 | `default_navigation_separator_color` | Color of separator lines between chapters. |
+
+## Palette Colors
+
+Themes can supply so called palette colors that content elements can
+use to let the user choose from a predefined set of colors matching
+the CI. For example, the counter content element the lets users choose
+a palette color for the number.
+
+Palette colors need to supplied as root properties starting with the
+prefix `palette_color_`. Assume a custom theme implements a corporate
+identity that features a certain brand specific shade of blue. We want
+to make it easy for editors to apply this brand color to certain
+elements in their stories. We can freely choose a name and call the
+palette color "brand blue":
+
+``` ruby
+entry_type_config.themes.register(:my_custom_theme,
+                                  # ...
+                                  properties: {
+                                    root: {
+                                      # ...
+                                      palette_color_brand_blue: '#15103a'
+                                    }
+                                  }
+```
+
+The following translation defines how the color will be represented in
+the editor user interface:
+
+``` yaml
+en:
+  pageflow_scrolled:
+    editor:
+      themes:
+        my_custom_theme:
+          palette_colors:
+            brand_blue: "Brand Blue"
+```
+
+Users will now be able to select "Brand Blue" as a color for quotes,
+counters and text paragraphs.

--- a/entry_types/scrolled/doc/creating_themes/custom_typography.md
+++ b/entry_types/scrolled/doc/creating_themes/custom_typography.md
@@ -127,7 +127,7 @@ en:
   pageflow_scrolled:
     editor:
       themes:
-        website:
+        my_custom_theme:
           typography_variants:
             "textBlock-blockQuote-red": "Red"
 ```

--- a/entry_types/scrolled/package/documentation.yml
+++ b/entry_types/scrolled/package/documentation.yml
@@ -46,6 +46,11 @@ toc:
       - useShareProviders
       - useShareUrl
       - useTheme
+  - name: Frontend Helpers
+    description: |
+      Helper functions that can be used in content elements.
+    children:
+      - paletteColor
   - name: Spec Support
     description: |
       Helper functions to use in specs.

--- a/entry_types/scrolled/package/spec/editor/models/ScrolledEntry-spec.js
+++ b/entry_types/scrolled/package/spec/editor/models/ScrolledEntry-spec.js
@@ -2721,4 +2721,119 @@ describe('ScrolledEntry', () => {
       expect(entry.supportsSectionWidths()).toEqual(true);
     });
   });
+
+  describe('getPaletteColors', () => {
+    it('returns empty arrays by default', () => {
+      const entry = factories.entry(
+        ScrolledEntry,
+        {},
+        {entryTypeSeed: normalizeSeed()}
+      );
+
+      const [values, translationKeys] = entry.getPaletteColors();
+
+      expect(values).toEqual([]);
+      expect(translationKeys).toEqual([]);
+    });
+
+    it('extracts palette colors names from theme properties', () => {
+      const entry = factories.entry(
+        ScrolledEntry,
+        {},
+        {
+          entryTypeSeed: normalizeSeed({
+            themeOptions: {
+              properties: {
+                root: {
+                  paletteColorBrandBlue: '#00f',
+                  paletteColorBrandGreen: '#0f0'
+                }
+              }
+            }
+          })
+        }
+      );
+
+      const [values] = entry.getPaletteColors();
+
+      expect(values).toEqual(['brand-blue', 'brand-green']);
+    });
+
+    describe('with shared translations', () => {
+      const commonPrefix = 'pageflow_scrolled.editor.palette_colors'
+
+      useFakeTranslations({
+        [`${commonPrefix}.dark_content_text`]: 'Dark Text Color',
+        [`${commonPrefix}.light_content_text`]: 'Light Text Color'
+      });
+
+      it('returns translated display names', () => {
+        editor.contentElementTypes.register('someElement', {});
+
+        const entry = factories.entry(
+          ScrolledEntry,
+          {
+            metadata: {theme_name: 'custom'}
+          },
+          {
+            entryTypeSeed: normalizeSeed({
+              themeOptions: {
+                properties: {
+                  root: {
+                    paletteColorDarkContentText: '#00f',
+                    paletteColorLightContentText: '#fff'
+                  }
+                }
+              }
+            })
+          }
+        );
+
+        const [, texts] = entry.getPaletteColors();
+
+        expect(texts).toEqual([
+          'Dark Text Color',
+          'Light Text Color'
+        ]);
+      });
+    });
+
+    describe('with theme specific translations', () => {
+      const commonPrefix = 'pageflow_scrolled.editor.palette_colors';
+      const themePrefix = `pageflow_scrolled.editor.themes.custom.palette_colors`;
+
+      useFakeTranslations({
+        [`${commonPrefix}.accent`]: 'Accent',
+        [`${themePrefix}.accent`]: 'Highlight'
+      });
+
+      it('prefers theme specific translations', () => {
+        editor.contentElementTypes.register('someElement', {});
+
+        const entry = factories.entry(
+          ScrolledEntry,
+          {
+            metadata: {theme_name: 'custom'}
+          },
+          {
+            entryTypeSeed: normalizeSeed({
+              themeOptions: {
+                properties: {
+                  root: {
+                    paletteColorAccent: '#00f'
+                  }
+                }
+              }
+            })
+          }
+        );
+
+        const [, texts] = entry.getPaletteColors();
+
+        expect(texts).toEqual([
+          'Highlight'
+        ]);
+      });
+    });
+  });
 });

--- a/entry_types/scrolled/package/spec/editor/views/inputs/ColorSelectInputView-spec.js
+++ b/entry_types/scrolled/package/spec/editor/views/inputs/ColorSelectInputView-spec.js
@@ -1,0 +1,44 @@
+import {
+  ColorSelectInputView
+} from 'editor/views/inputs/ColorSelectInputView';
+import Backbone from 'backbone';
+
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+import {useReactBasedBackboneViews} from 'support';
+import {useFakeTranslations} from 'pageflow/testHelpers';
+
+describe('ColorSelectInputView', () => {
+  const {render} = useReactBasedBackboneViews();
+
+  useFakeTranslations({
+    'pageflow_scrolled.editor.blank': 'Auto'
+  });
+
+  it('renders options for colors', async () => {
+    const model = new Backbone.Model();
+
+    const inputView = new ColorSelectInputView({
+      model,
+      blankTranslationKey: 'pageflow_scrolled.editor.blank',
+      values: ['brand-red', 'brand-green'],
+      texts: ['Red', 'Green'],
+      cssColorPropertyPrefix: '--theme-palette-color',
+      propertyName: 'color'
+    });
+
+    const user = userEvent.setup();
+    const {queryByRole, getByRole} = render(inputView);
+    await user.click(getByRole('button', {name: 'Auto'}));
+
+    expect(queryByRole('option', {name: 'Red'})).not.toBeNull();
+    expect(queryByRole('option', {name: 'Green'})).not.toBeNull();
+
+    expect(queryByRole('option', {name: 'Red'}).querySelector(
+      '[style*="var(--theme-palette-color-brand-red)"]'
+    )).not.toBeNull();
+    expect(queryByRole('option', {name: 'Green'}).querySelector(
+      '[style*="var(--theme-palette-color-brand-green)"]'
+    )).not.toBeNull();
+  });
+});

--- a/entry_types/scrolled/package/spec/editor/views/inputs/ListboxInputView-spec.js
+++ b/entry_types/scrolled/package/spec/editor/views/inputs/ListboxInputView-spec.js
@@ -113,4 +113,45 @@ describe('ListboxInputView', () => {
 
     expect(getByRole('button')).toBeDisabled();
   });
+
+  it('supports custom item rendering for options', async () => {
+    const model = new Backbone.Model({variant: 'large'});
+    const View = ListboxInputView.extend({
+      renderItem(item) {
+        return `Item: ${item.text}`;
+      }
+    })
+    const inputView = new View({
+      model: model,
+      propertyName: 'variant',
+      values: ['default', 'large'],
+      texts: ['Default', 'Large']
+    });
+
+    const user = userEvent.setup();
+    const {getByRole} = render(inputView);
+    await user.click(getByRole('button', {name: 'Large'}));
+
+    expect(getByRole('option', {name: 'Item: Default'})).not.toBeNull();
+    expect(getByRole('option', {name: 'Item: Large'})).not.toBeNull();
+  });
+
+  it('supports custom item rendering for selected item', async () => {
+    const model = new Backbone.Model({variant: 'large'});
+    const View = ListboxInputView.extend({
+      renderSelectedItem(item) {
+        return `Selected: ${item.text}`;
+      }
+    })
+    const inputView = new View({
+      model: model,
+      propertyName: 'variant',
+      values: ['default', 'large'],
+      texts: ['Default', 'Large']
+    });
+
+    const {getByRole} = render(inputView);
+
+    expect(getByRole('button', {name: 'Selected: Large'})).not.toBeNull();
+  });
 });

--- a/entry_types/scrolled/package/spec/frontend/paletteColor-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/paletteColor-spec.js
@@ -1,0 +1,11 @@
+import {paletteColor} from 'frontend/paletteColor';
+
+describe('paletteColor', () => {
+  it('returns custom CSS property', () => {
+    expect(paletteColor('brand-red')).toEqual('var(--theme-palette-color-brand-red)');
+  });
+
+  it('returns undefined if name is undefined', () => {
+    expect(paletteColor(undefined)).toBeUndefined();
+  });
+});

--- a/entry_types/scrolled/package/src/contentElements/counter/Counter.js
+++ b/entry_types/scrolled/package/src/contentElements/counter/Counter.js
@@ -7,7 +7,8 @@ import {
   useContentElementEditorState,
   useContentElementLifecycle,
   useI18n,
-  useLocale
+  useLocale,
+  paletteColor
 } from 'pageflow-scrolled/frontend';
 
 import styles from './Counter.module.css';
@@ -113,7 +114,8 @@ export function Counter({configuration, contentElementId, sectionProps}) {
               styles[`animation-${configuration.entranceAnimation}`],
               {[styles[`animation-${configuration.entranceAnimation}-active`]]: animated
             })}
-            style={{'--counting-duration': `${countingDuration || 1000}ms`}}
+            style={{'--counting-duration': `${countingDuration || 1000}ms`,
+                    '--palette-color': paletteColor(configuration.numberColor)}}
           >
             {format(currentValue)}
           </div>

--- a/entry_types/scrolled/package/src/contentElements/counter/Counter.module.css
+++ b/entry_types/scrolled/package/src/contentElements/counter/Counter.module.css
@@ -5,6 +5,7 @@
 .number {
   display: inline-block;
   word-break: break-word;
+  color: var(--palette-color);
 }
 
 .centerRagged {

--- a/entry_types/scrolled/package/src/contentElements/counter/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/counter/editor.js
@@ -59,6 +59,10 @@ editor.contentElementTypes.register('counter', {
             position: 'inline'
           })
       });
+      this.group('PaletteColor', {
+        propertyName: 'numberColor',
+        entry
+      });
       this.group('ContentElementPosition');
     });
   }

--- a/entry_types/scrolled/package/src/contentElements/counter/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/counter/stories.js
@@ -50,6 +50,17 @@ storiesOfContentElement(module, {
         unit: '$',
         unitPlacement: 'leading'
       }
+    },
+    {
+      name: 'Pallete number color',
+      themeOptions: {
+        properties: {
+          paletteColorAccent: '#04f'
+        }
+      },
+      configuration: {
+        numberColor: 'accent'
+      }
     }
   ]
 });

--- a/entry_types/scrolled/package/src/contentElements/quote/Quote.js
+++ b/entry_types/scrolled/package/src/contentElements/quote/Quote.js
@@ -5,7 +5,8 @@ import {
   useContentElementConfigurationUpdate,
   useContentElementEditorState,
   useI18n,
-  useTheme
+  useTheme,
+  paletteColor
 } from 'pageflow-scrolled/frontend';
 
 import styles from './Quote.module.css';
@@ -19,7 +20,8 @@ export function Quote({configuration, contentElementId, sectionProps}) {
   return (
     <figure className={classNames(styles.figure,
                                   styles[`design-${theme.options.quoteDesign || 'largeHanging'}`],
-                                  {[styles.centerRagged]: sectionProps.layout === 'centerRagged'})}>
+                                  {[styles.centerRagged]: sectionProps.layout === 'centerRagged'})}
+            style={{color: paletteColor(configuration.color)}}>
       <blockquote className={styles.text}>
         <EditableText value={configuration.text}
                       contentElementId={contentElementId}

--- a/entry_types/scrolled/package/src/contentElements/quote/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/quote/editor.js
@@ -1,3 +1,4 @@
+import I18n from 'i18n-js';
 import {editor} from 'pageflow-scrolled/editor';
 import {SelectInputView, SeparatorView} from 'pageflow/ui';
 import {InfoBoxView} from 'pageflow/editor';
@@ -16,6 +17,10 @@ editor.contentElementTypes.register('quote', {
         values: ['large', 'medium', 'small']
       });
       this.group('ContentElementPosition');
+      this.group('PaletteColor', {
+        propertyName: 'color',
+        entry
+      });
 
       this.view(SeparatorView);
 

--- a/entry_types/scrolled/package/src/contentElements/quote/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/quote/stories.js
@@ -68,6 +68,16 @@ storiesOfContentElement(module, {
         }
       }
     },
-
+    {
+      name: 'Pallete color',
+      themeOptions: {
+        properties: {
+          paletteColorAccent: '#04f'
+        }
+      },
+      configuration: {
+        color: 'accent'
+      }
+    }
   ]
 });

--- a/entry_types/scrolled/package/src/editor/models/ScrolledEntry/index.js
+++ b/entry_types/scrolled/package/src/editor/models/ScrolledEntry/index.js
@@ -131,6 +131,26 @@ export const ScrolledEntry = Entry.extend({
     return [values, texts]
   },
 
+  getPaletteColors() {
+    const values = Object.keys(
+      this.scrolledSeed.config.theme.options.properties?.root || {}
+    ).filter(
+      key => key.indexOf('paletteColor') === 0
+    ).map(
+      key => dasherize(key.replace('paletteColor', ''))
+    );
+
+    const texts = values.map(underscore).map(name =>
+      I18n.t(
+        `pageflow_scrolled.editor.themes.${this.metadata.get('theme_name')}` +
+        `.palette_colors.${name}`,
+        {defaultValue: I18n.t(`pageflow_scrolled.editor.palette_colors.${name}`)}
+      )
+    );
+
+    return [values, texts];
+  },
+
   supportsSectionWidths() {
     const theme = this.scrolledSeed.config.theme;
 
@@ -139,3 +159,14 @@ export const ScrolledEntry = Entry.extend({
     );
   }
 });
+
+function dasherize(text) {
+  return (
+    text[0] +
+    text.slice(1).replace(/[A-Z]/g, match => `-${match}`)
+  ).toLowerCase();
+}
+
+function underscore(dasherizedWord) {
+  return dasherizedWord.replace(/-/g, '_')
+}

--- a/entry_types/scrolled/package/src/editor/views/configurationEditors/groups/CommonContentElementAttributes.js
+++ b/entry_types/scrolled/package/src/editor/views/configurationEditors/groups/CommonContentElementAttributes.js
@@ -2,7 +2,11 @@ import {ConfigurationEditorTabView, SelectInputView, TextInputView} from 'pagefl
 
 import {
   TypographyVariantSelectInputView
-} from '../../inputs/TypographyVariantSelectInputView'
+} from '../../inputs/TypographyVariantSelectInputView';
+
+import {
+  ColorSelectInputView
+} from '../../inputs/ColorSelectInputView';
 
 ConfigurationEditorTabView.groups.define('ContentElementPosition', function() {
   const contentElement = this.model.parent;
@@ -69,6 +73,23 @@ ConfigurationEditorTabView.groups.define(
                              'common_content_element_attributes.' +
                              'variant.blank',
         values: variants,
+        texts,
+      });
+    }
+  }
+);
+
+ConfigurationEditorTabView.groups.define(
+  'PaletteColor',
+  function({propertyName, entry}) {
+    const [values, texts] = entry.getPaletteColors();
+
+    if (values.length) {
+      this.input(propertyName, ColorSelectInputView, {
+        blankTranslationKey: 'pageflow_scrolled.editor.' +
+                             'common_content_element_attributes.' +
+                             'palette_color.blank',
+        values,
         texts,
       });
     }

--- a/entry_types/scrolled/package/src/editor/views/inputs/ColorSelectInputView.js
+++ b/entry_types/scrolled/package/src/editor/views/inputs/ColorSelectInputView.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import styles from './ColorSelectInputView.module.css';
+
+import {ListboxInputView} from './ListboxInputView';
+
+export const ColorSelectInputView = ListboxInputView.extend({
+  renderItem,
+  renderSelectedItem: renderItem
+});
+
+function renderItem(item) {
+  return (
+    <div className={classNames(styles.item, {[styles.blank]: !item.value})}>
+      <div className={styles.swatch}
+           style={{'--color': `var(--theme-palette-color-${item.value})`}} />
+      {item.text}
+    </div>
+  );
+}

--- a/entry_types/scrolled/package/src/editor/views/inputs/ColorSelectInputView.module.css
+++ b/entry_types/scrolled/package/src/editor/views/inputs/ColorSelectInputView.module.css
@@ -1,0 +1,17 @@
+.item {
+  display: flex;
+  align-items: center;
+}
+
+.swatch {
+  background-color: var(--color);
+  width: space(4);
+  height: space(4);
+  border: solid 1px var(--ui-on-surface-color-lighter);
+  border-radius: rounded(sm);
+  margin-right: space(2);
+}
+
+.blank .swatch {
+  display: none;
+}

--- a/entry_types/scrolled/package/src/editor/views/inputs/ListboxInputView.js
+++ b/entry_types/scrolled/package/src/editor/views/inputs/ListboxInputView.js
@@ -47,6 +47,10 @@ export const ListboxInputView = Marionette.ItemView.extend({
     ];
   },
 
+  renderSelectedItem(item) {
+    return item.text;
+  },
+
   renderItem(item) {
     return item.text;
   },
@@ -67,6 +71,7 @@ export const ListboxInputView = Marionette.ItemView.extend({
           items: this.items,
           disabled: this.isDisabled(),
 
+          renderSelectedItem: item => this.renderSelectedItem(item),
           renderItem: item => this.renderItem(item),
 
           selectedItem: this.items.find(item =>
@@ -85,13 +90,13 @@ export const ListboxInputView = Marionette.ItemView.extend({
 
 function Dropdown({
   items, disabled,
-  renderItem,
+  renderItem, renderSelectedItem,
   selectedItem, onChange
 }) {
   return (
     <Listbox value={selectedItem.value} disabled={disabled} onChange={onChange}>
       <Listbox.Button className={styles.button}>
-        {selectedItem.text}
+        {renderSelectedItem(selectedItem)}
       </Listbox.Button>
       <Listbox.Options className={styles.options}>
         {items.map(item => (

--- a/entry_types/scrolled/package/src/frontend/index.js
+++ b/entry_types/scrolled/package/src/frontend/index.js
@@ -97,6 +97,7 @@ export {default as registerTemplateWidgetType} from './registerTemplateWidgetTyp
 export {Widget} from './Widget';
 
 export {utils} from './utils';
+export {paletteColor} from './paletteColor';
 
 global.pageflowScrolledRender = async function(seed) {
   setupI18n(seed.i18n);

--- a/entry_types/scrolled/package/src/frontend/paletteColor.js
+++ b/entry_types/scrolled/package/src/frontend/paletteColor.js
@@ -1,0 +1,9 @@
+/**
+ * Resolve a palette color to a CSS custom property.
+ *
+ * @example
+ * <div style={{backgroundColor: paletteColor(configuration.backgroundColor)}}>
+ */
+export function paletteColor(name) {
+  return name && `var(--theme-palette-color-${name})`;
+}


### PR DESCRIPTION
Let themes define color properties of the form `palette_color_*` which can be used by content elements in color settings to let users pick a color from a predefined palette.

Quotes and counters are the first elements to support palette colors.

REDMINE-20218