### PR TITLE
Make content text color available in custom property

### DIFF
--- a/entry_types/scrolled/package/src/frontend/Section.module.css
+++ b/entry_types/scrolled/package/src/frontend/Section.module.css
@@ -52,6 +52,7 @@
 @media screen {
   .Section {
     color: lightContentTextColor;
+    --content-text-color: lightContentTextColor;
     --content-link-color: lightContentLinkColor;
     background-color: #000;
   }
@@ -59,6 +60,7 @@
   .invert {
     background-color: #fff;
     color: darkContentTextColor;
+    --content-text-color: darkContentTextColor;
     --content-link-color: darkContentLinkColor;
   }
 }

--- a/entry_types/scrolled/package/src/frontend/foregroundBoxes/CardBoxWrapper.module.css
+++ b/entry_types/scrolled/package/src/frontend/foregroundBoxes/CardBoxWrapper.module.css
@@ -54,11 +54,13 @@
 
   .cardBgWhite {
     color: darkContentTextColor;
+    --content-text-color: darkContentTextColor;
     --content-link-color: darkContentLinkColor;
   }
 
   .cardBgBlack {
     color: lightContentTextColor;
+    --content-text-color: lightContentTextColor;
     --content-link-color: lightContentLinkColor;
   }
 }

--- a/entry_types/scrolled/package/values/colors.module.css
+++ b/entry_types/scrolled/package/values/colors.module.css
@@ -8,6 +8,7 @@
 @value darkContentLinkColor: var(--theme-dark-content-link-color, var(--theme-content-link-color, currentColor));
 
 @value contentLinkColor: var(--content-link-color);
+@value contentTextColor: var(--content-text-color);
 
 /* see src/frontend/global.module.css */
 


### PR DESCRIPTION
Can be used to apply `-webkit-text-stroke` based on the current text color when `color` (and thus `currentColor`) has been set to `transparent`.

REDMINE-20162