### PR TITLE
Add even smaller counter text size

### DIFF
--- a/entry_types/scrolled/config/locales/new/counter.de.yml
+++ b/entry_types/scrolled/config/locales/new/counter.de.yml
@@ -56,5 +56,6 @@ de:
                 large: Groß
                 medium: Mittel
                 small: Klein
+                verySmall: Sehr klein
             numberColor:
               label: "Farbe"

--- a/entry_types/scrolled/config/locales/new/counter.en.yml
+++ b/entry_types/scrolled/config/locales/new/counter.en.yml
@@ -56,5 +56,6 @@ en:
                 large: Large
                 medium: Medium
                 small: Small
+                verySmall: Very small
             numberColor:
               label: Color

--- a/entry_types/scrolled/package/src/contentElements/counter/Counter.js
+++ b/entry_types/scrolled/package/src/contentElements/counter/Counter.js
@@ -133,6 +133,7 @@ export function Counter({configuration, contentElementId, sectionProps}) {
 }
 
 const numberScaleCategories = {
+  verySmall: 'counterNumber-xs',
   small: 'counterNumber-sm',
   medium: 'counterNumber-md',
   large: 'counterNumber-lg'

--- a/entry_types/scrolled/package/src/contentElements/counter/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/counter/editor.js
@@ -44,7 +44,7 @@ editor.contentElementTypes.register('counter', {
       });
       this.view(SeparatorView);
       this.input('textSize', SelectInputView, {
-        values: ['large', 'medium', 'small']
+        values: ['large', 'medium', 'small', 'verySmall']
       });
       this.group('ContentElementTypographyVariant', {
         entry,

--- a/entry_types/scrolled/package/src/frontend/Text.module.css
+++ b/entry_types/scrolled/package/src/frontend/Text.module.css
@@ -103,6 +103,13 @@
   font-weight: 700;
 }
 
+.counterNumber-xs {
+  composes: typography-counterNumber from global;
+  font-size: text-xl;
+  line-height: 1;
+  font-weight: 700;
+}
+
 .counterDescription {
   composes: typography-counterDescription from global;
   font-size: text-base;
@@ -151,6 +158,11 @@
 
   .counterNumber-sm {
     font-size: text-xl;
+    line-height: 1.1;
+  }
+
+  .counterNumber-xs {
+    font-size: text-l;
     line-height: 1.1;
   }
 }


### PR DESCRIPTION
Ensure 9-digit numbers with a unit still fit mobile viewport and
left/right aligned inline column without wrapping.

REDMINE-20171
