### PR TITLE
Improve onVisible/onInvisible callbacks

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/useDelayedBoolean-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/useDelayedBoolean-spec.js
@@ -1,0 +1,69 @@
+import {renderHook, act} from '@testing-library/react-hooks';
+import {useDelayedBoolean} from 'frontend/useDelayedBoolean';
+
+jest.useFakeTimers();
+
+describe('useDelayedBoolean', () => {
+  it('sets the initial value', () => {
+    const {result} = renderHook(
+      () => useDelayedBoolean(
+        true,
+        {fromTrueToFalse: 1000}
+      ),
+    );
+
+    expect(result.current).toBe(true);
+  });
+
+  it('switches back to false after a delay', () => {
+    const {result, rerender} = renderHook(
+      ({value}) => useDelayedBoolean(
+        value,
+        {fromTrueToFalse: 1000}
+      ),
+      {initialProps: {value: true}}
+    );
+
+    rerender({value: false});
+    expect(result.current).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('switches back to true immediatly', () => {
+    const {result, rerender} = renderHook(
+      ({value}) => useDelayedBoolean(
+        value,
+        {fromTrueToFalse: 1000}
+      ),
+      {initialProps: {value: false}}
+    );
+
+    rerender({value: true});
+
+    expect(result.current).toBe(true);
+  });
+
+  it('cancels the switch-back timer if value becomes true again', () => {
+    const {result, rerender} = renderHook(
+      ({value}) => useDelayedBoolean(
+        value,
+        {fromTrueToFalse: 1000}
+      ),
+      {initialProps: {value: true}}
+    );
+
+    rerender({value: false});
+    act(() => jest.advanceTimersByTime(500));
+    rerender({value: true});
+    act(() => jest.advanceTimersByTime(500));
+
+    rerender({value: false});
+    expect(result.current).toBe(true);
+    act(() => jest.advanceTimersByTime(500));
+    expect(result.current).toBe(true);
+  });
+});

--- a/entry_types/scrolled/package/spec/frontend/useSectionLifecycle-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/useSectionLifecycle-spec.js
@@ -141,6 +141,54 @@ describe('useSectionLifecycle', () => {
       expect(getByTestId('testElement')).toHaveTextContent('visible');
     });
 
+    it('stays false even if element is in viewport in fade section', async () => {
+      const {getByTestId} = renderInEntry(<Entry />, {
+        seed: {
+          sections: [{id: 10, configuration: {transition: 'fade'}}],
+          contentElements: [{sectionId: 10, typeName: 'test'}]
+        }
+      });
+
+      act(() =>
+        simulateScrollingIntoView(getByTestId('testElement'))
+      );
+
+      expect(getByTestId('testElement')).not.toHaveTextContent('visible');
+    });
+
+    it('is true if once section is active in fade section', async () => {
+      const {getByTestId} = renderInEntry(<Entry />, {
+        seed: {
+          sections: [{id: 10, configuration: {transition: 'fade'}}],
+          contentElements: [{sectionId: 10, typeName: 'test'}]
+        }
+      });
+
+      act(() =>
+        simulateScrollingIntoView(findIsActiveProbe(getByTestId('testElement')))
+      );
+
+      expect(getByTestId('testElement')).toHaveTextContent('visible');
+    });
+
+    it('shortly stays true once fade section is no longer active', async () => {
+      const {getByTestId} = renderInEntry(<Entry />, {
+        seed: {
+          sections: [{id: 10, configuration: {transition: 'fade'}}],
+          contentElements: [{sectionId: 10, typeName: 'test'}]
+        }
+      });
+
+      act(() =>
+        simulateScrollingIntoView(getByTestId('testElement'))
+      );
+      act(() =>
+        simulateScrollingOutOfView(findIsActiveProbe(getByTestId('testElement')))
+      );
+
+      expect(getByTestId('testElement')).not.toHaveTextContent('visible');
+    });
+
     it('stays false even with element inside viewport when rendered inside StaticPreview', async () => {
       const {getByTestId} = renderInEntry(<StaticPreview><Entry /></StaticPreview>, {
         seed: {

--- a/entry_types/scrolled/package/src/frontend/Section.js
+++ b/entry_types/scrolled/package/src/frontend/Section.js
@@ -49,7 +49,8 @@ const Section = withInlineEditingDecorator('SectionDecorator', function Section(
                                    {[styles.narrow]: section.width === 'narrow'},
                                    {[styles.invert]: section.invert})}
              style={useBackdropSectionCustomProperties(backdrop)}>
-      <SectionLifecycleProvider onActivate={onActivate} isLast={!section.nextSection}>
+      <SectionLifecycleProvider onActivate={onActivate}
+                                onlyVisibleWhileActive={section.transition.startsWith('fade')}>
         <SectionAtmo audioFilePermaId={section.atmoAudioFileId} />
 
         <SectionContents section={section}

--- a/entry_types/scrolled/package/src/frontend/useDelayedBoolean.js
+++ b/entry_types/scrolled/package/src/frontend/useDelayedBoolean.js
@@ -1,0 +1,23 @@
+import {useState, useEffect, useRef} from 'react';
+
+export function useDelayedBoolean(value, {fromTrueToFalse}) {
+  const [, setFlag] = useState(false);
+  const timeoutRef = useRef(null);
+  const ref = useRef(false);
+
+  useEffect(() => {
+    if (value) {
+      ref.current = true;
+    }
+    else if (ref.current) {
+      timeoutRef.current = setTimeout(() => {
+        ref.current = false;
+        setFlag(value => !value);
+      }, fromTrueToFalse);
+
+      return () => clearTimeout(timeoutRef.current);
+    }
+  }, [value, fromTrueToFalse]);
+
+  return value || ref.current;
+};


### PR DESCRIPTION
We want to start background videos in fade sections only once the section becomes active to prevent missing the beginning.

Invoke `onVisible` only once the section is active for fade section. Invoke `onInvisible` with a short delay once the section is no longer active to prevent pausing background videos while the fade transition is still in progress.

REDMINE-20230