### PR TITLE
Improve onVisible/onInvisible callbacks for fade sections

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/useSectionLifecycle-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/useSectionLifecycle-spec.js
@@ -141,36 +141,6 @@ describe('useSectionLifecycle', () => {
       expect(getByTestId('testElement')).toHaveTextContent('visible');
     });
 
-    it('stays false even if element is in viewport in fade section', async () => {
-      const {getByTestId} = renderInEntry(<Entry />, {
-        seed: {
-          sections: [{id: 10, configuration: {transition: 'fade'}}],
-          contentElements: [{sectionId: 10, typeName: 'test'}]
-        }
-      });
-
-      act(() =>
-        simulateScrollingIntoView(getByTestId('testElement'))
-      );
-
-      expect(getByTestId('testElement')).not.toHaveTextContent('visible');
-    });
-
-    it('is true if once section is active in fade section', async () => {
-      const {getByTestId} = renderInEntry(<Entry />, {
-        seed: {
-          sections: [{id: 10, configuration: {transition: 'fade'}}],
-          contentElements: [{sectionId: 10, typeName: 'test'}]
-        }
-      });
-
-      act(() =>
-        simulateScrollingIntoView(findIsActiveProbe(getByTestId('testElement')))
-      );
-
-      expect(getByTestId('testElement')).toHaveTextContent('visible');
-    });
-
     it('shortly stays true once fade section is no longer active', async () => {
       const {getByTestId} = renderInEntry(<Entry />, {
         seed: {
@@ -183,10 +153,10 @@ describe('useSectionLifecycle', () => {
         simulateScrollingIntoView(getByTestId('testElement'))
       );
       act(() =>
-        simulateScrollingOutOfView(findIsActiveProbe(getByTestId('testElement')))
+        simulateScrollingOutOfView(getByTestId('testElement'))
       );
 
-      expect(getByTestId('testElement')).not.toHaveTextContent('visible');
+      expect(getByTestId('testElement')).toHaveTextContent('visible');
     });
 
     it('stays false even with element inside viewport when rendered inside StaticPreview', async () => {

--- a/entry_types/scrolled/package/src/frontend/Section.js
+++ b/entry_types/scrolled/package/src/frontend/Section.js
@@ -50,7 +50,7 @@ const Section = withInlineEditingDecorator('SectionDecorator', function Section(
                                    {[styles.invert]: section.invert})}
              style={useBackdropSectionCustomProperties(backdrop)}>
       <SectionLifecycleProvider onActivate={onActivate}
-                                onlyVisibleWhileActive={section.transition?.startsWith('fade')}>
+                                entersWithFadeTransition={section.transition?.startsWith('fade')}>
         <SectionAtmo audioFilePermaId={section.atmoAudioFileId} />
 
         <SectionContents section={section}


### PR DESCRIPTION
The previous attempt to fix the issue in #1947 did not take into account that sections that enter with a fade transition can still exit with a different transition. So using the `isActive` probe to determine `isVisible` does not work. Instead we adapt the `isVisible` intersection observer to apply a root margin. We then need to ensure that `onVisible` and `onActivate` are never called out of order even if the intersection observers fire in different orders.

This is important since we mute and play videos in `onVisible` and unmute in `onActivate`. Videos might otherwise stay muted if we get the execution order wrong.

REDMINE-20230