### PR TITLE
Use custom site urls in feed

### DIFF
--- a/app/models/pageflow/entries_feed.rb
+++ b/app/models/pageflow/entries_feed.rb
@@ -1,6 +1,6 @@
 module Pageflow
   # @api private
-  EntriesFeed = Struct.new(:title, :locale, :entries) do
+  EntriesFeed = Struct.new(:title, :locale, :custom_url, :root_url, :entries) do
     def updated_at
       entries.map(&:published_at).max
     end
@@ -10,6 +10,8 @@ module Pageflow
         new(
           site.title.presence || site.host,
           locale,
+          site.custom_feed_url&.gsub(':locale', locale),
+          site.canonical_entry_url_prefix&.gsub(':locale', locale),
           find_entries(site, locale)
         )
       end

--- a/app/views/pageflow/feeds/index.atom.builder
+++ b/app/views/pageflow/feeds/index.atom.builder
@@ -1,4 +1,6 @@
-atom_feed language: @feed.locale do |feed|
+atom_feed language: @feed.locale,
+          root_url: @feed.root_url,
+          url: @feed.custom_url do |feed|
   feed.title(@feed.title)
   feed.updated(@feed.updated_at&.utc)
 


### PR DESCRIPTION
Use custom_feed_url as self and canonical_entry_url_prefix as alternate. This accommodates setups where feeds are served from a location that proxies to the site.

REDMINE-20013