### PR TITLE
Hide empty attribution line of quote element

### DIFF
--- a/entry_types/scrolled/package/spec/contentElements/quote/isBlank-spec.js
+++ b/entry_types/scrolled/package/spec/contentElements/quote/isBlank-spec.js
@@ -1,0 +1,22 @@
+import {isBlank} from 'contentElements/quote/isBlank';
+
+describe('isBlank', () => {
+  it('return true for empty array', () => {
+    expect(isBlank([])).toEqual(true);
+  });
+
+  it('returns true for node with single empty text child', () => {
+    expect(isBlank([{children: [{text: ''}]}])).toEqual(true);
+  });
+
+  it('returns false for node with non-empty text child', () => {
+    expect(isBlank([{children: [{text: 'some text'}]}])).toEqual(false);
+  });
+
+  it('returns false for multiple  nodes with empty text child', () => {
+    expect(isBlank([
+      {children: [{text: ''}]},
+      {children: [{text: ''}]}
+    ])).toEqual(false);
+  });
+});

--- a/entry_types/scrolled/package/src/contentElements/quote/Quote.js
+++ b/entry_types/scrolled/package/src/contentElements/quote/Quote.js
@@ -9,6 +9,8 @@ import {
   paletteColor
 } from 'pageflow-scrolled/frontend';
 
+import {isBlank} from './isBlank';
+
 import styles from './Quote.module.css';
 
 export function Quote({configuration, contentElementId, sectionProps}) {
@@ -52,10 +54,4 @@ function getTextScaleCategory(configuration) {
     default:
       return 'quoteText-md';
   }
-}
-
-function isBlank(value) {
-  return value.length <= 1 &&
-         value[0]?.children.length <= 1 &&
-         !value[0]?.children[0]?.text;
 }

--- a/entry_types/scrolled/package/src/contentElements/quote/isBlank.js
+++ b/entry_types/scrolled/package/src/contentElements/quote/isBlank.js
@@ -1,0 +1,6 @@
+export function isBlank(value) {
+  return value.length === 0 ||
+         (value.length === 1 &&
+          value[0].children.length <= 1 &&
+          !value[0].children[0]?.text);
+}


### PR DESCRIPTION
Once some text had been entered and removed, hiding the line already worked. Also detect initial empty array as blank.

REDMINE-20294