### PR TITLE
Display rights of all files in credits box

### DIFF
--- a/entry_types/scrolled/package/spec/collections-spec.js
+++ b/entry_types/scrolled/package/spec/collections-spec.js
@@ -3,6 +3,7 @@ import {
   watchCollection,
   updateConfiguration,
   createItemsSelector,
+  createMultipleItemsSelector,
   getItems,
   getItem
 } from 'collections';
@@ -979,5 +980,38 @@ describe('createItemsSelector', () => {
     const items2 = selector(state);
 
     expect(items1).not.toBe(items2);
+  });
+});
+
+describe('createMultipleItemsSelector', () => {
+  it('returns function that returns multiple arrays of items in order', () => {
+    const {result} = renderHook(() => useCollections({
+      imageFiles: [{id: 10}, {id: 11}, {id: 12}],
+      videoFiles: [{id: 30}, {id: 31}]
+    }));
+
+    const [state,] = result.current;
+    const arraysOfItems = createMultipleItemsSelector(
+      ['imageFiles', 'videoFiles']
+    )(state);
+
+    expect(arraysOfItems).toEqual({
+      imageFiles: [{id: 10}, {id: 11}, {id: 12}],
+      videoFiles: [{id: 30}, {id: 31}]
+    });
+  });
+
+  it('returns referentially equal array if state is unchanged', () => {
+    const {result} = renderHook(() => useCollections({
+      imageFiles: [{id: 10}, {id: 11}, {id: 12}],
+      videoFiles: [{id: 30}, {id: 31}]
+    }));
+
+    const [state,] = result.current;
+    const selector = createMultipleItemsSelector(['imageFiles', 'videoFiles']);
+    const result1 = selector(state);
+    const result2 = selector(state);
+
+    expect(result1).toBe(result2);
   });
 });

--- a/entry_types/scrolled/package/spec/entryState/legalInfo-spec.js
+++ b/entry_types/scrolled/package/spec/entryState/legalInfo-spec.js
@@ -89,14 +89,17 @@ describe('useFileRights', () => {
       () => useFileRights(), {
         seed: {
           imageFiles: [
-            {rights: 'author'}
+            {rights: 'author B'}
+          ],
+          videoFiles: [
+            {rights: 'author A'}
           ]
         }
       }
     );
 
     const fileRights = result.current;
-    expect(fileRights).toEqual('author');
+    expect(fileRights).toEqual('author A, author B');
   });
 
   it('returns comma separated list of file rights', () => {
@@ -140,13 +143,17 @@ describe('useFileRights', () => {
             {rights: 'author2'},
             {rights: 'author1'},
           ],
+          videoFiles: [
+            {rights: 'author2'},
+            {rights: 'author3'},
+          ],
           defaultFileRights: 'author1'
         }
       }
     );
 
     const fileRights = result.current;
-    expect(fileRights).toEqual('author1, author2');
+    expect(fileRights).toEqual('author1, author2, author3');
   });
 
   it('does not insert extra comma if a file has no rights and defaults are not configured', () => {
@@ -182,11 +189,10 @@ describe('useFileRights', () => {
     expect(fileRights).toEqual('');
   });
 
-  it('returns empty string if no image files are present', () => {
+  it('returns empty string if no files are present', () => {
     const {result} = renderHookInEntry(
       () => useFileRights(), {
         seed: {
-          imageFiles: [],
           defaultFileRights: 'default'
         }
       }
@@ -206,12 +212,22 @@ describe('useFileRights', () => {
         setup: (dispatch, entryTypeSeed) => {
           watchCollections(factories.entry(ScrolledEntry, {}, {
             entryTypeSeed,
-            fileTypes: factories.fileTypesWithImageFileType(),
+            fileTypes: factories.fileTypes(function() {
+              this.withImageFileType();
+              this.withVideoFileType();
+              this.withTextTrackFileType();
+            }),
             filesAttributes: {
               image_files: [
                 {
                   perma_id: 1,
-                  rights: 'author'
+                  rights: 'author 1'
+                }
+              ],
+              video_files: [
+                {
+                  perma_id: 1,
+                  rights: 'author 2'
                 }
               ]
             }
@@ -221,6 +237,6 @@ describe('useFileRights', () => {
     );
 
     const fileRights = result.current;
-    expect(fileRights).toEqual('author');
+    expect(fileRights).toEqual('author 1, author 2');
   });
 });

--- a/entry_types/scrolled/package/src/collections.js
+++ b/entry_types/scrolled/package/src/collections.js
@@ -262,19 +262,27 @@ function getAttributes(model, {attributeNames, includeConfiguration}) {
 }
 
 export function getItems(state, collectionName) {
-  if (state[collectionName]) {
-    const items = state[collectionName].items;
-    return state[collectionName].order.map(key => items[key]);
-  }
-  else {
-    return [];
-  }
+  return toOrderedItems(state[collectionName]);
 }
 
 export function getItem(state, collectionName, key) {
   if (state[collectionName]) {
     return state[collectionName].items[key];
   }
+}
+
+export function createMultipleItemsSelector(collectionNames, filter) {
+  return createSelector(
+    ...collectionNames.map(collectionName =>
+      collections => collections[collectionName]
+    ),
+    (...collections) => {
+      return collectionNames.reduce((result, collectionName, index) => {
+        result[collectionName] = toOrderedItems(collections[index]);
+        return result;
+      }, {});
+    }
+  );
 }
 
 export function createItemsSelector(collectionName, filter) {
@@ -289,16 +297,18 @@ export function createItemsSelector(collectionName, filter) {
 
   return createSelector(
     collections => collections[collectionName],
-    collection => {
-      if (collection) {
-        const items = collection.items;
-        return collection.order.map(key => items[key]);
-      }
-      else {
-        return [];
-      }
-    }
+    toOrderedItems
   );
+}
+
+function toOrderedItems(collection) {
+  if (collection) {
+    const items = collection.items;
+    return collection.order.map(key => items[key]);
+  }
+  else {
+    return [];
+  }
 }
 
 const createShallowEqualArraysSelector = createSelectorCreator(

--- a/entry_types/scrolled/package/src/entryState/EntryStateProvider.js
+++ b/entry_types/scrolled/package/src/entryState/EntryStateProvider.js
@@ -1,7 +1,12 @@
 import React, {useMemo} from 'react';
 import {createContext, useContextSelector} from 'use-context-selector';
 
-import {useCollections, getItem, createItemsSelector} from '../collections';
+import {
+  useCollections,
+  getItem,
+  createItemsSelector,
+  createMultipleItemsSelector
+} from '../collections';
 
 const Context = createContext();
 
@@ -40,6 +45,19 @@ export function useEntryStateCollectionItem(collectionName, key) {
 }
 
 export function useEntryStateCollectionItems(collectionName, filter) {
-  const itemsSelector = useMemo(() => createItemsSelector(collectionName, filter), [collectionName, filter]);
+  const itemsSelector = useMemo(
+    () => createItemsSelector(collectionName, filter),
+    [collectionName, filter]
+  );
+
   return useEntryState(entryState => itemsSelector(entryState.collections));
+}
+
+export function useMultipleEntryStateCollectionItems(collectionNames) {
+  const multipleItemsSelector = useMemo(
+    () => createMultipleItemsSelector(collectionNames),
+    [collectionNames]
+  );
+
+  return useEntryState(entryState => multipleItemsSelector(entryState.collections));
 }

--- a/entry_types/scrolled/package/src/entryState/legalInfo.js
+++ b/entry_types/scrolled/package/src/entryState/legalInfo.js
@@ -1,27 +1,33 @@
 import {useEntryMetadata} from "./metadata";
-import {useEntryStateConfig, useEntryStateCollectionItems} from "./EntryStateProvider";
+import {
+  useEntryStateConfig,
+  useMultipleEntryStateCollectionItems
+} from "./EntryStateProvider";
 
 /**
  * Returns a string (comma-separated list) of copyrights of
- * all images used in the entry.
- * If none of the images has a rights attribute configured,
+ * all files used in the entry.
+ * If none of the files has a rights attribute configured,
  * it falls back to the default file rights of the entry's account,
  * otherwise returns an empty string
  *
  * @example
  *
  * const fileRights = useFileRights();
- * fileRights // => "author of image 1, author of image 2"
+ * fileRights // => "author of image 1, author of video 2"
  */
 export function useFileRights() {
   const config = useEntryStateConfig();
-  const imageFiles = useEntryStateCollectionItems('imageFiles');
+  const fileCollectionNames = Object.keys(config.fileModelTypes);
+  const files = useMultipleEntryStateCollectionItems(fileCollectionNames);
 
   const defaultFileRights = config.defaultFileRights?.trim();
 
-  return Array.from(new Set(imageFiles.map(function(imageFile) {
-    return imageFile.rights?.trim() || defaultFileRights;
-  }))).filter(Boolean).join(', ');
+  return Array.from(new Set(Object.keys(files).flatMap(key =>
+    files[key].map(file =>
+      file.rights?.trim() || defaultFileRights
+    )
+  ))).sort().filter(Boolean).join(', ');
 }
 
 /**


### PR DESCRIPTION
Previously only rights of image files where displayed. To do this, we need to extract rights information from all files collections. Add a new `useMultipleEntryStateCollectionItems` hook based on a new `createMultipleItemsSelector`, which can be used to extract multiple collections at once and only re-render when an item of one of the collection changes.

REDMINE-20295