### PR TITLE
Filter out widgets of unknown widget types

### DIFF
--- a/app/models/pageflow/widget.rb
+++ b/app/models/pageflow/widget.rb
@@ -72,7 +72,14 @@ module Pageflow
       end
 
       def from_db_by_role
-        Widget.all.index_by(&:role)
+        reject_unknown_widget_types(Widget.all)
+          .index_by(&:role)
+      end
+
+      def reject_unknown_widget_types(widgets)
+        widgets.select do |widget|
+          config.widget_types.type_name?(widget.type_name)
+        end
       end
 
       def defaults_by_role

--- a/lib/pageflow/widget_types.rb
+++ b/lib/pageflow/widget_types.rb
@@ -41,6 +41,10 @@ module Pageflow
       @widget_types.fetch(name, &block)
     end
 
+    def type_name?(name)
+      @widget_types.key?(name)
+    end
+
     def default_configuration(name)
       @default_configurations[name]
     end

--- a/spec/controllers/pageflow/editor/widgets_controller_spec.rb
+++ b/spec/controllers/pageflow/editor/widgets_controller_spec.rb
@@ -9,6 +9,9 @@ module Pageflow
       before do
         pageflow_configure do |config|
           config.widget_types.clear
+          config.widget_types.register(
+            TestWidgetType.new(name: 'test_widget')
+          )
         end
       end
 


### PR DESCRIPTION
When a widget type is defined within a feature, revisions and entry templates still may contain widgets of that type once the feature has been disabled.

So far, we assigned a null widget type in that case, which rendered the empty string. In published scrolled entries, these widgets then got filtered out when compiling seed data since they did not match the special `:react` insert point [1]. In the editor, these widgets were still included in collections, which led to JS errors when trying to look up the editor or frontend JS counter part of a widget. Here we fail loudly, when a widget type is not defined to make integration errors between JS and Ruby easy to spot.

While we still want to support widgets with null widget types for placeholders, we can skip widgets that do not have a corresponding widget type when passing data to the editor.

Same in entry template forms: If there is no widget type defined for a given role, we do not need to display drop down that will only contain the blank option.

We therefore filter out widget from the db with unknown type in the resolver.

REDMINE-20207

[1] https://github.com/codevise/pageflow/blob/06574ea6b677fdc823074df5f2769c9196a788ba/entry_types/scrolled/app/helpers/pageflow_scrolled/entry_json_seed_helper.rb#L35