### PR TITLE
Exclude react-rails 2.7 from supported versions

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -94,7 +94,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'marionette-rails', '~> 1.1.0'
 
   # React.js assets and server side rendering helpers
-  s.add_dependency 'react-rails', '~> 2.6'
+  s.add_dependency 'react-rails', '~> 2.6.2'
 
   # Templating engine used to render jst tempaltes.
   s.add_dependency 'ejs', '~> 1.1'


### PR DESCRIPTION
Currently breaks server side rendering with error of the form

    ActionView::Template::Error:
    TypeError: Cannot read property 'version' of undefined

Probably related to this change:
https://github.com/reactjs/react-rails/pull/1269/files#diff-46071864dd030eabbafccec157424caade6e2c3b0f30ebaf9f4fd3f224377216R3