### PR TITLE
Allow turning default widgets off

### DIFF
--- a/app/models/pageflow/widget.rb
+++ b/app/models/pageflow/widget.rb
@@ -78,7 +78,8 @@ module Pageflow
 
       def reject_unknown_widget_types(widgets)
         widgets.select do |widget|
-          config.widget_types.type_name?(widget.type_name)
+          widget.type_name.blank? ||
+            config.widget_types.type_name?(widget.type_name)
         end
       end
 

--- a/spec/models/pageflow/widget_spec.rb
+++ b/spec/models/pageflow/widget_spec.rb
@@ -53,6 +53,19 @@ module Pageflow
         expect(widgets).to include_record_with(type_name: 'custom_navigation', role: 'navigation')
       end
 
+      it 'allows turning default widget off' do
+        default_widget_type = TestWidgetType.new(name: 'default_navigation',
+                                                 roles: ['navigation'])
+        config = Configuration.new
+        config.widget_types.register(default_widget_type, default: true)
+        revision = create(:revision)
+        create(:widget, subject: revision, role: 'navigation', type_name: '')
+
+        widgets = revision.widgets.resolve(config)
+
+        expect(widgets).to include_record_with(type_name: '', role: 'navigation')
+      end
+
       it 'overrides defaults with subject widgets' do
         default_widget_type = TestWidgetType.new(name: 'default_header',
                                                  roles: ['header'])


### PR DESCRIPTION
In #1961 we started filtering out widgets with unknown type name. We do not want to filter out widgets with empty type name, though. Otherwise there is no way to turn off a default widget.

REDMINE-20207