### PR TITLE
Prevent sticky gallery and sticky image from overlapping

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/Layout-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/Layout-spec.js
@@ -144,7 +144,7 @@ describe('Layout', () => {
         expect(container.textContent).toEqual('[wide normal 1 wide custom 2 wide normal 3 wide custom 4 ]');
       });
 
-      it('places sticky elements with custom margin in separate box in same group', () => {
+      it('places sticky elements with and without custom margin in separate groups', () => {
         const items = [
           {id: 1, type: 'probe', position: 'sticky'},
           {id: 2, type: 'probeWithCustomMargin', position: 'sticky'}
@@ -157,7 +157,7 @@ describe('Layout', () => {
           </Layout>
         );
 
-        expect(container.textContent).toEqual('[sticky normal 1 sticky custom 2 ]');
+        expect(container.textContent).toEqual('[sticky normal 1 ][sticky custom 2 ]');
       });
 
       it('does not apply custom margins for full elements', () => {

--- a/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.js
+++ b/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.js
@@ -81,7 +81,8 @@ function groupItemsByPosition(items, availablePositions) {
     const position = availablePositions.includes(item.position) ? item.position : 'inline';
     const customMargin = !!elementSupportsCustomMargin && positionsSupportingCustomMargin.includes(position);
 
-    if (!currentGroup || previousPosition !== position) {
+    if (!currentGroup || previousPosition !== position ||
+        (position === 'sticky' && currentBox.customMargin !== customMargin)) {
       currentBox = null;
 
       if (!(previousPosition === 'sticky' && position === 'inline')) {

--- a/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.module.css
+++ b/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.module.css
@@ -69,7 +69,7 @@
   --content-max-width: min(var(--content-width), var(--two-column-sticky-content-max-width, 600px));
   position: sticky;
   float: right;
-  clear: right;
+  clear: both;
   top: 33%;
   width: var(--content-width);
 }


### PR DESCRIPTION
Since one uses custom margin and one doesn't, they cannot be in one box. Multiple sticky boxes inside a single group do not interact correctly, we create a new group.

REDMINE-20325