### PR TITLE
Set text direction attribute for scrolled entries

### DIFF
--- a/entry_types/scrolled/app/controllers/pageflow_scrolled/entries_controller.rb
+++ b/entry_types/scrolled/app/controllers/pageflow_scrolled/entries_controller.rb
@@ -9,6 +9,7 @@ module PageflowScrolled
     helper Pageflow::SocialShareHelper
     helper Pageflow::MetaTagsHelper
     helper Pageflow::StructuredDataHelper
+    helper Pageflow::TextDirectionHelper
     helper FaviconHelper
 
     def show

--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/editor/seed_html_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/editor/seed_html_helper.rb
@@ -6,6 +6,7 @@ module PageflowScrolled
       include ReactServerSideRenderingHelper
       include Pageflow::WidgetsHelper
       include Pageflow::StructuredDataHelper
+      include Pageflow::TextDirectionHelper
       include FaviconHelper
       include PacksHelper
       include WebpackPublicPathHelper

--- a/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entries/show.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<%= content_tag(:html, lang: @entry.locale) do %>
+<%= content_tag(:html, lang: @entry.locale, dir: text_direction(@entry.locale)) do %>
   <head>
     <title><%= pretty_entry_title(@entry) %></title>
 

--- a/entry_types/scrolled/spec/controllers/pageflow_scrolled/entries_controller_spec.rb
+++ b/entry_types/scrolled/spec/controllers/pageflow_scrolled/entries_controller_spec.rb
@@ -112,6 +112,28 @@ module PageflowScrolled
         expect(response.body).to have_selector('html[lang=de]')
       end
 
+      it 'uses ltr text direction for de entry loclae' do
+        entry = create(:entry,
+                       :published,
+                       type_name: 'scrolled',
+                       published_revision_attributes: {locale: 'de'})
+
+        get_with_entry_env(:show, entry: entry)
+
+        expect(response.body).to have_selector('html[dir=ltr]')
+      end
+
+      it 'uses rtl text direction for ar entry loclae' do
+        entry = create(:entry,
+                       :published,
+                       type_name: 'scrolled',
+                       published_revision_attributes: {locale: 'ar'})
+
+        get_with_entry_env(:show, entry: entry)
+
+        expect(response.body).to have_selector('html[dir=rtl]')
+      end
+
       it 'renders structured data' do
         entry = create(:entry, :published, type_name: 'scrolled')
 


### PR DESCRIPTION
Ensure consistent display in editor and published entry. Slate detects RTL text and sets a dir attribute on text nodes. Outside of the editor text was still always LTR.

This is just a first step, with many more layout issues in right-to-left mode remaining.

REDMINE-20378