### PR TITLE
Fix webdrivers for Chrome 115

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,4 +30,4 @@ gem 'activemodel-serializers-xml'
 gem 'webpacker'
 
 # Make tests fail on JS errors
-gem 'capybara-chromedriver-logger', git: 'https://github.com/codevise/capybara-chromedriver-logger', branch: 'do-not-raise-on-filtered-errors', require: false
+gem 'capybara-chromedriver-logger', git: 'https://github.com/codevise/capybara-chromedriver-logger', branch: 'fix-selenium-4-deprecation', require: false

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -171,8 +171,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'puma', '~> 3.12'
 
   # Chrome Headless browser testing
-  s.add_development_dependency 'selenium-webdriver', '~> 3.6.x'
-  s.add_development_dependency 'webdrivers', '~> 4.0'
+  s.add_development_dependency 'webdrivers', '= 5.3.0'
 
   # View abstraction fro integration testing
   s.add_development_dependency 'domino', '~> 0.7.0'

--- a/spec/support/pageflow/support/config/capybara.rb
+++ b/spec/support/pageflow/support/config/capybara.rb
@@ -11,19 +11,14 @@ Capybara.register_driver :selenium_chrome_headless_no_sandbox do |app|
   # (see https://docs.travis-ci.com/user/chrome)
   browser_options.args << '--no-sandbox'
 
-  capabilities = {
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     # see https://github.com/SeleniumHQ/selenium/issues/3738
-    loggingPrefs: {browser: 'ALL'},
-    # see https://github.com/dbalatero/capybara-chromedriver-logger/issues/11
-    chromeOptions: {
-      w3c: false
-    }
-  }
+    'goog:loggingPrefs': {browser: 'ALL'}
+  )
 
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
-                                 options: browser_options,
-                                 desired_capabilities: capabilities)
+                                 capabilities: [browser_options, capabilities])
 end
 
 Capybara.javascript_driver = :selenium_chrome_headless_no_sandbox

--- a/spec/support/pageflow/support/config/webmock.rb
+++ b/spec/support/pageflow/support/config/webmock.rb
@@ -2,7 +2,12 @@ require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.before(:each) do
-    driver_urls = Webdrivers::Common.subclasses.map(&:base_url)
-    WebMock.disable_net_connect!(allow_localhost: true, allow: driver_urls)
+    WebMock.disable_net_connect!(
+      allow_localhost: true,
+      allow: [
+        'https://googlechromelabs.github.io',
+        'https://edgedl.me.gvt1.com'
+      ]
+    )
   end
 end


### PR DESCRIPTION
Upgrade to install "Chrome for Testing" from new location. See [1] for details. Once we use Ruby 3, we will be able to use `selenium-webdriver` 4.11 without the `webdrivers` gem.

REDMINE-20415

[1] https://github.com/titusfortner/webdrivers/blob/v5.3.1/README.md#update-future-of-this-project