### PR TITLE
Support scopes in storybook theme properties

### DIFF
--- a/entry_types/scrolled/package/spec/support/__spec__/stories-spec.js
+++ b/entry_types/scrolled/package/spec/support/__spec__/stories-spec.js
@@ -78,7 +78,9 @@ describe('exampleStories', () => {
         name: 'With Properties',
         themeOptions: {
           properties: {
-            accentColor: 'red'
+            root: {
+              accentColor: 'red'
+            }
           }
         }
       }]
@@ -91,13 +93,19 @@ describe('exampleStories', () => {
           theme: expect.objectContaining({
             options: expect.objectContaining({
               properties: expect.objectContaining({
-                accentColor: 'red'
+                root: {
+                  accentColor: 'red'
+                }
               })
             })
           })
         })
       }),
-      cssProperties: {'--theme-accent-color': 'red'}
+      cssRules: {
+        root: {
+          '--theme-accent-color': 'red'
+        }
+      }
     }));
   });
 

--- a/entry_types/scrolled/package/src/contentElements/counter/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/counter/stories.js
@@ -55,7 +55,9 @@ storiesOfContentElement(module, {
       name: 'Pallete number color',
       themeOptions: {
         properties: {
-          paletteColorAccent: '#04f'
+          root: {
+            paletteColorAccent: '#04f'
+          }
         }
       },
       configuration: {

--- a/entry_types/scrolled/package/src/contentElements/quote/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/quote/stories.js
@@ -56,7 +56,9 @@ storiesOfContentElement(module, {
       name: 'Centered Attribution',
       themeOptions: {
         properties: {
-          quoteAttributionMinWidth: '50%'
+          root: {
+            quoteAttributionMinWidth: '50%'
+          }
         }
       }
     },
@@ -65,11 +67,13 @@ storiesOfContentElement(module, {
       themeOptions: {
         quoteDesign: 'inline',
         properties: {
-          quoteLeftMark: '"»"',
-          quoteRightMark: '"«"',
-          quoteMarkFontWeight: 'normal',
-          quoteIndent: 0,
-          quoteMarkOpacity: 1
+          root: {
+            quoteLeftMark: '"»"',
+            quoteRightMark: '"«"',
+            quoteMarkFontWeight: 'normal',
+            quoteIndent: 0,
+            quoteMarkOpacity: 1
+          }
         }
       }
     },
@@ -77,8 +81,10 @@ storiesOfContentElement(module, {
       name: 'Double angle',
       themeOptions: {
         properties: {
-          quoteLeftMark: '"»"',
-          quoteLeftMarkTop: '-0.35em'
+          root: {
+            quoteLeftMark: '"»"',
+            quoteLeftMarkTop: '-0.35em'
+          }
         }
       }
     },
@@ -86,7 +92,9 @@ storiesOfContentElement(module, {
       name: 'Pallete color',
       themeOptions: {
         properties: {
-          paletteColorAccent: '#04f'
+          root: {
+            paletteColorAccent: '#04f'
+          }
         }
       },
       configuration: {

--- a/entry_types/scrolled/package/src/contentElements/textBlock/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/textBlock/stories.js
@@ -111,7 +111,9 @@ storiesOfContentElement(module, {
       configuration: linkExampleConfiguration,
       themeOptions: {
         properties: {
-          contentLinkColor: 'red'
+          root: {
+            contentLinkColor: 'red'
+          }
         }
       }
     },
@@ -120,8 +122,10 @@ storiesOfContentElement(module, {
       configuration: linkExampleConfiguration,
       themeOptions: {
         properties: {
-          lightContentLinkColor: 'yellow',
-          darkContentLinkColor: 'green',
+          root: {
+            lightContentLinkColor: 'yellow',
+            darkContentLinkColor: 'green',
+          }
         }
       }
     },
@@ -133,8 +137,10 @@ storiesOfContentElement(module, {
       },
       themeOptions: {
         properties: {
-          lightContentLinkColor: 'yellow',
-          darkContentLinkColor: 'green',
+          root: {
+            lightContentLinkColor: 'yellow',
+            darkContentLinkColor: 'green',
+          }
         }
       }
     },
@@ -143,10 +149,12 @@ storiesOfContentElement(module, {
       themeOptions: {
         quoteDesign: 'hanging',
         properties: {
-          quoteLeftMark: '"»"',
-          quoteRightMark: '"«"',
-          quoteMarkOpacity: 1,
-          quoteMarkFontWeight: 'normal'
+          root: {
+            quoteLeftMark: '"»"',
+            quoteRightMark: '"«"',
+            quoteMarkOpacity: 1,
+            quoteMarkFontWeight: 'normal'
+          }
         }
       }
     },
@@ -155,8 +163,10 @@ storiesOfContentElement(module, {
       themeOptions: {
         quoteDesign: 'inline',
         properties: {
-          quoteLeftMark: '"»"',
-          quoteRightMark: '"«"'
+          root: {
+            quoteLeftMark: '"»"',
+            quoteRightMark: '"«"'
+          }
         }
       }
     },
@@ -164,12 +174,14 @@ storiesOfContentElement(module, {
       name: 'With custom lists',
       themeOptions: {
         properties: {
-          textBlockUnorderedListStyleType: '"-  "',
-          textBlockUnorderedListMarkerColor: 'red',
-          textBlockUnorderedListIndent: '15px',
-          textBlockOrderedListIndent: '60px',
-          textBlockFirstListItemMarginTop: '2rem',
-          textBlockListItemMarginTop: 0
+          root: {
+            textBlockUnorderedListStyleType: '"-  "',
+            textBlockUnorderedListMarkerColor: 'red',
+            textBlockUnorderedListIndent: '15px',
+            textBlockOrderedListIndent: '60px',
+            textBlockFirstListItemMarginTop: '2rem',
+            textBlockListItemMarginTop: 0
+          }
         }
       }
     }


### PR DESCRIPTION
So far theme properties in stories were set directly as keys below `themeOptions.properties`. In real themes, a scope like `root` or `defaultNavigation` needs to be inserted as an intermediate level.

To allow testing these scopes in stories, we now generate a full style tag with scope rules instead of only setting the properties as inline styles on a wrapper div.

REDMINE-20411