### PR TITLE
Allow changing light and dark text color of headings

### DIFF
--- a/entry_types/scrolled/doc/creating_themes/custom_colors_and_dimensions.md
+++ b/entry_types/scrolled/doc/creating_themes/custom_colors_and_dimensions.md
@@ -46,8 +46,10 @@ The following scopes are available:
 * `cards_appearance`: Change content colors for sections using
   appearance "Card".
 
-* `external_links`: Override content color options for external link
-  cards.
+* `external_links`: Override content colors for external link cards.
+
+* `headings`: Override content text color for external link heading
+  elements and headings in text blocks.
 
 Custom widget and content element types can define additional scopes.
 

--- a/entry_types/scrolled/package/src/contentElements/heading/Heading.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/Heading.js
@@ -5,6 +5,7 @@ import {
   Text,
   EditableInlineText,
   useContentElementConfigurationUpdate,
+  useDarkBackground,
   useI18n
 } from 'pageflow-scrolled/frontend';
 
@@ -15,6 +16,7 @@ export function Heading({configuration, sectionProps}) {
   const firstSectionInEntry = level === 0;
   const updateConfiguration = useContentElementConfigurationUpdate();
   const {t} = useI18n({locale: 'ui'});
+  const darkBackground = useDarkBackground();
 
   const legacyValue = configuration.children;
   const Tag = firstSectionInEntry ? 'h1' : 'h2';
@@ -23,8 +25,10 @@ export function Heading({configuration, sectionProps}) {
 
   return (
     <Tag className={classNames(styles.root,
+                               'scope-headings',
                                configuration.typographyVariant &&
                                `typography-heading-${configuration.typographyVariant}`,
+                               darkBackground ? styles.light : styles.dark,
                                {[styles.forcePaddingTop]: forcePaddingTop},
                                {[styles[sectionProps.layout]]:
                                  configuration.position === 'wide' ||

--- a/entry_types/scrolled/package/src/contentElements/heading/Heading.module.css
+++ b/entry_types/scrolled/package/src/contentElements/heading/Heading.module.css
@@ -1,3 +1,8 @@
+@value (
+  darkContentTextColor,
+  lightContentTextColor
+) from "pageflow-scrolled/values/colors.module.css";
+
 .root {
   margin-top: 0.2em;
   margin-bottom: 0;
@@ -8,6 +13,14 @@
   .right {
     text-align: right;
   }
+}
+
+.light {
+  color: lightContentTextColor;
+}
+
+.dark {
+  color: darkContentTextColor;
 }
 
 .centerRagged,

--- a/entry_types/scrolled/package/src/contentElements/heading/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/stories.js
@@ -31,6 +31,29 @@ storiesOfContentElement(module, {
       configuration: {
         textSize: 'small'
       }
+    },
+    {
+      name: 'With custom content text colors',
+      themeOptions: {
+        properties: {
+          headings: {
+            lightContentTextColor: 'red'
+          }
+        }
+      }
+    },
+    {
+      name: 'With custom content text colors in inverted section',
+      sectionConfiguration: {
+        invert: true
+      },
+      themeOptions: {
+        properties: {
+          headings: {
+            darkContentTextColor: 'red'
+          }
+        }
+      }
     }
   ]
 });

--- a/entry_types/scrolled/package/src/contentElements/textBlock/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/textBlock/stories.js
@@ -184,6 +184,35 @@ storiesOfContentElement(module, {
           }
         }
       }
+    },
+    {
+      name: 'With custom content text colors',
+      themeOptions: {
+        properties: {
+          root: {
+            lightContentTextColor: 'green',
+          },
+          headings: {
+            lightContentTextColor: 'red'
+          }
+        }
+      }
+    },
+    {
+      name: 'With custom content text colors in inverted section',
+      sectionConfiguration: {
+        invert: true
+      },
+      themeOptions: {
+        properties: {
+          root: {
+            darkContentTextColor: 'green',
+          },
+          headings: {
+            darkContentTextColor: 'red'
+          }
+        }
+      }
     }
   ]
 });

--- a/entry_types/scrolled/package/src/frontend/EditableText.js
+++ b/entry_types/scrolled/package/src/frontend/EditableText.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import {camelize} from './utils/camelize';
 import {withInlineEditingAlternative} from './inlineEditing';
 import {useChapter, useFile} from '../entryState';
+import {useDarkBackground} from './backgroundColor';
 import {Text} from './Text';
 import textStyles from './Text.module.css';
 
@@ -56,17 +57,34 @@ export function renderElement({attributes, children, element}) {
   case 'list-item':
     return <li {...attributes}>{children}</li>;
   case 'heading':
+    const {key, ...otherAttributes} = attributes;
+
     return (
-      <h2 {...attributes}
-          className={classNames(variantClassName, textStyles['heading-xs'])}>
+      <Heading key={key}
+               attributes={otherAttributes}
+               variantClassName={variantClassName}>
         {children}
-      </h2>
+      </Heading>
     );
   case 'link':
     return renderLink({attributes, children, element});
   default:
     return <p {...attributes} className={variantClassName}>{children}</p>;
   }
+}
+
+function Heading({attributes, variantClassName, children}) {
+  const darkBackground = useDarkBackground();
+
+  return (
+    <h2 {...attributes}
+        className={classNames(variantClassName,
+                              darkBackground ? styles.light : styles.dark,
+                              'scope-headings',
+                              textStyles['heading-xs'])}>
+      {children}
+    </h2>
+  );
 }
 
 function renderLink({attributes, children, element}) {

--- a/entry_types/scrolled/package/src/frontend/EditableText.module.css
+++ b/entry_types/scrolled/package/src/frontend/EditableText.module.css
@@ -1,3 +1,16 @@
+@value (
+  darkContentTextColor,
+  lightContentTextColor
+) from "pageflow-scrolled/values/colors.module.css";
+
 .root {
   white-space: pre-line;
+}
+
+.light {
+  color: lightContentTextColor;
+}
+
+.dark {
+  color: darkContentTextColor;
 }


### PR DESCRIPTION
Introduce `headings` scope to be able to restrict the existing `darkContentTextColor` and `lightContentTextColor`.

REDMINE-20411