### PR TITLE
Fix two column motif area content measuring

### DIFF
--- a/entry_types/scrolled/lib/tasks/pageflow_scrolled/storybook.rake
+++ b/entry_types/scrolled/lib/tasks/pageflow_scrolled/storybook.rake
@@ -33,8 +33,7 @@ namespace :pageflow_scrolled do
 
         account = seeds.account(name: 'storybook-seed') do |account_in_progress|
           account_in_progress.features_configuration =
-            account_in_progress.features_configuration.merge('scrolled_entry_type' => true,
-                                                             'frontend_v2' => true)
+            account_in_progress.features_configuration.merge('scrolled_entry_type' => true)
         end
 
         seeds.sample_scrolled_entry(

--- a/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.js
+++ b/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.js
@@ -25,7 +25,7 @@ export function TwoColumn(props) {
     <div className={classNames(styles.root, styles[props.align],
                                narrow ? styles.narrowViewport : styles.wideViewport)}>
       <div className={classNames(styles.group)} key={props.align}>
-        <div className={styles.inline} ref={props.contentAreaRef} />
+        <div className={classNames(styles.box, styles.inline)} ref={props.contentAreaRef} />
       </div>
       {renderItems(props, narrow)}
       {renderPlaceholder(props.placeholder)}


### PR DESCRIPTION
Ensure content probe element has correct width. Caused two column layout to move content down even if motif fits nexts to cotnent.

This went unnoticed since storybook used v2 frontend. Switch storybook back to v1 frontend since this what is still used in production.

REDMINE-20384