### PR TITLE
Prevent normalizing color input too early

### DIFF
--- a/package/spec/ui/views/inputs/ColorInputView-spec.js
+++ b/package/spec/ui/views/inputs/ColorInputView-spec.js
@@ -68,6 +68,24 @@ describe('pageflow.ColorInputView', () => {
     expect(model.get('color')).toBe('#bbbbbb');
   });
 
+  it('does not update color input with normalized value', () => {
+    var model = new Backbone.Model({
+      color: '#ababab'
+    });
+    var colorInputView = new ColorInputView({
+      model: model,
+      propertyName: 'color'
+    });
+
+    var colorInput = ColorInput.render(
+      colorInputView,
+      {appendTo: testContext.htmlSandbox}
+    );
+    colorInput.fillIn('#bbb', testContext.clock);
+
+    expect(colorInput.value()).toBe('#bbb');
+  });
+
   it('allows passing swatches', () => {
     var model = new Backbone.Model();
     var colorInputView = new ColorInputView({

--- a/package/src/ui/views/inputs/ColorInputView.js
+++ b/package/src/ui/views/inputs/ColorInputView.js
@@ -49,12 +49,16 @@ export const ColorInputView = Marionette.ItemView.extend({
     this.ui.input.minicolors({
       changeDelay: 200,
       change: _.bind(function(color) {
+        this._saving = true;
+
         if (color === this.defaultValue()) {
           this.model.unset(this.options.propertyName);
         }
         else {
           this.model.set(this.options.propertyName, color);
         }
+
+        this._saving = false;
       }, this)
     });
 
@@ -89,8 +93,11 @@ export const ColorInputView = Marionette.ItemView.extend({
   },
 
   load: function() {
-    this.ui.input.minicolors('value',
-                             this.model.get(this.options.propertyName) || this.defaultValue());
+    if (!this._saving) {
+      this.ui.input.minicolors('value',
+                               this.model.get(this.options.propertyName) || this.defaultValue());
+    }
+
     this.$el.toggleClass('is_default', !this.model.has(this.options.propertyName));
   },
 


### PR DESCRIPTION
When pausing after typing the first three digits of a color code (e.g., #abc), minicolors already updates the value with a normalized representation (e.g., #aabbcc). Before, the `change` handler updated the model, which in turn triggered the `load` method, causing the value of the input to be updated. This prevented the user from finishing typing the full color code.

REDMINE-20413