### PR TITLE
Remove legacy clip for revealed sections

### DIFF
--- a/entry_types/scrolled/package/src/frontend/utils.module.css
+++ b/entry_types/scrolled/package/src/frontend/utils.module.css
@@ -1,6 +1,4 @@
 .clip {
-  clip: rect(0, auto, auto, 0); /* IE 11 */
-
   /* When section height is a fractional value (e.g. 440.58px) Chrome
      109 cuts off a pixel at the bottom of the element. This sometimes
      leads to a visible line between sections.


### PR DESCRIPTION
We already adapted the clip-path before to prevent line artifacts from showing up between sections. Now there appear to be cases where the fallback `clip` property causes this problem as well. Since it was only meant to support IE 11, which we no longer support anyway, the fallback can be removed.

REDMINE-20413