### PR TITLE
Prevent white lines around external link image

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLink.module.css
+++ b/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLink.module.css
@@ -10,11 +10,11 @@
 }
 
 .link_item {
+  display: flex;
+  flex-direction: column;
   width: 45%;
   vertical-align: top;
   margin: 2% auto;
-  background-color: lightContentSurfaceColor;
-  color: darkContentTextColor;
   text-decoration: none;
   transition: transform 0.3s;
   border-radius: var(--theme-content-element-box-border-radius);
@@ -22,20 +22,11 @@
   will-change: transform;
 }
 
-.link_item.invert {
-  background-color: darkContentSurfaceColor;
-  color: lightContentTextColor;
-}
-
 .link_item.layout_center {
   width: 29%;
 }
 
 .link_item:hover {
-  -webkit-transform: scale(1.05);
-  -moz-transform: scale(1.05);
-  -ms-transform: scale(1.05);
-  -o-transform: scale(1.05);
   transform: scale(1.05);
 }
 
@@ -49,16 +40,23 @@
   background-size: cover;
   padding-top: 56.25%;
   position: relative;
-
 }
 
 .link_details {
-  margin: 20px;
+  flex: 1;
+  padding: 20px;
+  color: darkContentTextColor;
+  background-color: lightContentSurfaceColor;
+}
+
+.invert > .link_details {
+  background-color: darkContentSurfaceColor;
+  color: lightContentTextColor;
 }
 
 .link_details > .link_title {
   font-weight: bold;
-  margin-bottom: 20px;
+  margin: 0 0 20px;
 }
 
 @media screen and breakpoint-sm {
@@ -71,6 +69,7 @@
   width: 100%;
   white-space: normal;
   line-height: 1.3em;
+  margin-bottom: 0;
 }
 
 .tooltip {


### PR DESCRIPTION
When scaling items, the background sometimes becomes visible at the borders of the image due to rendering rounding errors. Apply content surface color only to details below image.

REDMINE-20413