### PR TITLE
Make text block spacing more consistent between editor and published entry

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/EditableText-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/EditableText-spec.js
@@ -254,6 +254,21 @@ describe('EditableText', () => {
     expect(container.querySelector('p')).toHaveTextContent('\uFEFF', {normalizeWhitespace: false})
   });
 
+  it('does not render zero width no break space between two formatted words', () => {
+    const value = [{
+      type: 'paragraph',
+      children: [
+        {text: 'One', bold: true},
+        {text: ' '},
+        {text: 'two', bold: true}
+      ]
+    }];
+
+    const {container} = render(<EditableText value={value} />);
+
+    expect(container.querySelector('p')).toHaveTextContent('One two', {normalizeWhitespace: false})
+  });
+
   it('defaults to empty paragraph to prevent empty text blocks from collapsing', () => {
     const {container} = render(<EditableText />);
 

--- a/entry_types/scrolled/package/spec/frontend/EditableText-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/EditableText-spec.js
@@ -254,6 +254,12 @@ describe('EditableText', () => {
     expect(container.querySelector('p')).toHaveTextContent('\uFEFF', {normalizeWhitespace: false})
   });
 
+  it('defaults to empty paragraph to prevent empty text blocks from collapsing', () => {
+    const {container} = render(<EditableText />);
+
+    expect(container.querySelector('p')).toHaveTextContent('\uFEFF', {normalizeWhitespace: false})
+  });
+
   it('renders typography variant class names for paragraphs', () => {
     const value = [{
       type: 'paragraph',

--- a/entry_types/scrolled/package/src/contentElements/textBlock/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/textBlock/stories.js
@@ -36,7 +36,10 @@ storiesOfContentElement(module, {
       {
         type: 'paragraph',
         children: [
-          {text: 'At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. '},
+          {text: 'At', bold: true},
+          {text: ' '},
+          {text: 'vero', underline: true},
+          {text: ' eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. '},
           {
             "text": "This is a "
           },

--- a/entry_types/scrolled/package/src/frontend/EditableText.js
+++ b/entry_types/scrolled/package/src/frontend/EditableText.js
@@ -10,19 +10,24 @@ import textStyles from './Text.module.css';
 
 import styles from './EditableText.module.css';
 
+const defaultValue = [{
+  type: 'paragraph',
+  children: [{ text: '' }],
+}];
+
 export const EditableText = withInlineEditingAlternative('EditableText', function EditableText({
   value, className, scaleCategory = 'body'
 }) {
   return (
     <div className={classNames(styles.root, className)}>
       <Text scaleCategory={scaleCategory}>
-        {render(value)}
+        {render(value || defaultValue)}
       </Text>
     </div>
   );
 });
 
-function render(children = []) {
+function render(children) {
   return children.map((element, index) => {
     if (element.type) {
       return renderElement({attributes: {key: index}, element, children: render(element.children)});

--- a/entry_types/scrolled/package/src/frontend/EditableText.js
+++ b/entry_types/scrolled/package/src/frontend/EditableText.js
@@ -36,7 +36,8 @@ function render(children) {
       return renderLeaf({
         attributes: {key: index},
         leaf: element,
-        children: element.text.trim() === '' ? '\uFEFF' : element.text
+        children: children.length === 1 &&
+                  element.text.trim() === '' ? '\uFEFF' : element.text
       });
     }
   });


### PR DESCRIPTION
Prevent collapsing single space leafs between formatted words. Prevent empty text blocks from collapsing.

REDMINE-20413

fixes #1967