### PR TITLE
Add public_entry_cache_control_header config option 

### DIFF
--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -85,11 +85,21 @@ module Pageflow
 
       delegate_to_rack_app!(entry.entry_type.frontend_app) do |_status, headers, _body|
         allow_iframe_for_embed(headers)
+        apply_cache_control(entry, headers)
       end
     end
 
     def allow_iframe_for_embed(headers)
       headers.except!('X-Frame-Options') if params[:embed]
+    end
+
+    def apply_cache_control(entry, headers)
+      config = Pageflow.config_for(entry)
+
+      return if config.public_entry_cache_control_header.blank?
+      return if entry.password_protected?
+
+      headers['Cache-Control'] = config.public_entry_cache_control_header
     end
   end
 end

--- a/lib/pageflow/configuration.rb
+++ b/lib/pageflow/configuration.rb
@@ -195,6 +195,19 @@ module Pageflow
     # @since 12.4
     attr_accessor :public_entry_redirect
 
+    # Cache-Control header to set for published entries that have been
+    # published without a password. For password protected entries,
+    # cache control is always set to private to prevent caching
+    # authenticated responses in public caches like CDNs and serving
+    # them to unauthenticated users.
+    #
+    # Can be wrapped in a `features.register` block to use different
+    # caching strategies for different entries or accounts.
+    #
+    # @since edge
+    # @return [String]
+    attr_accessor :public_entry_cache_control_header
+
     # Either a lambda or an object with a `call` method taking a
     # {Site} as paramater and returing a hash of options used to
     # construct the url of a published entry.
@@ -548,6 +561,7 @@ module Pageflow
       delegate :page_types, to: :config
       delegate :themes, to: :config
       delegate :widget_types, to: :config
+      delegate :public_entry_cache_control_header=, to: :config
 
       delegate :for_entry_type, to: :config
     end

--- a/spec/support/pageflow/global_config_api_test_helper.rb
+++ b/spec/support/pageflow/global_config_api_test_helper.rb
@@ -24,7 +24,7 @@ module Pageflow
     #     # ...
     #   end
     def pageflow_configure(&block)
-      GlobalConfigApiTestHelper.custom_configure_block = block
+      GlobalConfigApiTestHelper.custom_configure_block << block
       Pageflow.configure!
     end
 
@@ -39,12 +39,14 @@ module Pageflow
 
         config.before(:suite) do
           Pageflow.configure do |pageflow_config|
-            GlobalConfigApiTestHelper.custom_configure_block&.call(pageflow_config)
+            GlobalConfigApiTestHelper.custom_configure_block.each do |block|
+              block.call(pageflow_config)
+            end
           end
         end
 
         config.before do
-          GlobalConfigApiTestHelper.custom_configure_block = nil
+          GlobalConfigApiTestHelper.custom_configure_block = []
           Pageflow.configure!
         end
       end


### PR DESCRIPTION
Allow including a `Cache-Control` header in the response for published
entries. Skip for password protected entries to prevent leaking
protected content into public caches.

REDMINE-20428