### PR TITLE
Fix hiding focus outline

### DIFF
--- a/entry_types/scrolled/package/src/frontend/focusOutline.module.css
+++ b/entry_types/scrolled/package/src/frontend/focusOutline.module.css
@@ -4,8 +4,8 @@ body > :global(#root) [tabindex]:focus {
   outline: 3px solid #518ad2;
 }
 
-.focusOutlineDisabled [tabindex]:focus,
-.focusOutlineDisabled button:focus,
-.focusOutlineDisabled a:focus {
+.focusOutlineDisabled > :global(#root) [tabindex]:focus,
+.focusOutlineDisabled > :global(#root) button:focus,
+.focusOutlineDisabled > :global(#root) a:focus {
   outline: none;
 }


### PR DESCRIPTION
Recently changed to prevent display in editor UI. Caused rule to disable focus rect after non-keyboard input to have to low specificity.