### PR TITLE
Run plugin specs in reusable workflow against Rails 6.1

### DIFF
--- a/.github/workflows/reusable-workflow-rspec.yml
+++ b/.github/workflows/reusable-workflow-rspec.yml
@@ -9,6 +9,18 @@ jobs:
   rspec:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby-version: 2.6
+          - ruby-version: 3.2
+            rails-version: "~> 6.1"
+
+    env:
+      PAGEFLOW_RAILS_VERSION: ${{ matrix.rails-version }}
+      PAGEFLOW_DEPENDENCIES: ${{ matrix.rails-version && 'experimental' || 'default' }}
+
     services:
       mysql:
         image: mysql:5.7
@@ -41,16 +53,16 @@ jobs:
       uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/*.gemspec') }}-${{ hashFiles('**/Gemfile') }}
+        key: ${{ runner.os }}-ruby-${{ matrix.ruby-version }}-gems-${{ hashFiles('**/*.gemspec') }}-${{ hashFiles('**/Gemfile') }}
         restore-keys: |
-          ${{ runner.os }}-gems-
+          ${{ runner.os }}-ruby-${{ matrix.ruby-version }}-gems-
 
     # Ruby/Node
 
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: ${{ matrix.ruby-version }}
 
     # Dependencies
 


### PR DESCRIPTION
Set `PAGEFLOW_DEPENDENCIES` environment variable to `experimental` to signal that Pageflow should be installed from edge branch. This will let us experiment with different upgraded dependencies without needing to change plugin code.

REDMINE-19438