### PR TITLE
Support both Webpacker and Shakapacker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,13 +28,13 @@ if Pageflow::RailsVersion.experimental?
   # use shakapacker need to add it to their Gemfile themselves. Requiring
   # shakapacker in an engine file (like we normally do) would force all
   # host application to install shakapacker.
-  gem 'shakapacker'
+  gem 'shakapacker', '~> 7.0'
 else
   # Make webpacker available in specs. Host applications that want to
   # use webpacker need to add it to their Gemfile themselves. Requiring
   # webpacker in an engine file (like we normally do) would force all
   # host application to install webpacker.
-  gem 'webpacker'
+  gem 'webpacker', '~> 4.2'
 end
 
 # Make tests fail on JS errors

--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/packs_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/packs_helper.rb
@@ -2,7 +2,7 @@ module PageflowScrolled
   # @api private
   module PacksHelper
     def scrolled_frontend_javascript_packs_tag(entry, options)
-      if Pageflow::RailsVersion.experimental?
+      if defined?(Shakapacker)
         javascript_pack_tag(
           *scrolled_frontend_packs(entry, **options),
           defer: false
@@ -15,7 +15,7 @@ module PageflowScrolled
     end
 
     def scrolled_frontend_stylesheet_packs_tag(entry, options)
-      if Pageflow::RailsVersion.experimental?
+      if defined?(Shakapacker)
         stylesheet_pack_tag(
           *scrolled_frontend_packs(entry, **options),
           media: 'all'
@@ -29,7 +29,7 @@ module PageflowScrolled
     end
 
     def scrolled_editor_javascript_packs_tag(entry)
-      if Pageflow::RailsVersion.experimental?
+      if defined?(Shakapacker)
         javascript_pack_tag(
           *scrolled_editor_packs(entry),
           defer: false

--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/themes_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/themes_helper.rb
@@ -6,7 +6,7 @@ module PageflowScrolled
                                   theme_file_role: nil,
                                   theme_file_style: :resized,
                                   relative_url: false)
-      prefix = Pageflow::RailsVersion.experimental? ? 'static' : 'media'
+      prefix = defined?(Shakapacker) ? 'static' : 'media'
 
       path =
         theme.files.dig(theme_file_role, theme_file_style) ||

--- a/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
@@ -1,6 +1,6 @@
 <%= stylesheet_link_tag 'pageflow_paged/editor', media: 'all' %>
 
-<% if Pageflow::RailsVersion.experimental?  %>
+<% if defined?(Shakapacker)  %>
   <%= stylesheet_pack_tag 'pageflow-scrolled-frontend' %>
 <% else %>
   <%= stylesheet_packs_with_chunks_tag 'pageflow-scrolled-frontend' %>

--- a/entry_types/scrolled/spec/support/config/webpacker.rb
+++ b/entry_types/scrolled/spec/support/config/webpacker.rb
@@ -1,4 +1,4 @@
-unless Pageflow::RailsVersion.experimental?
+unless defined?(Shakapacker)
   # Make sure packs are recompiled for Capybara specs when Rollup
   # outputs change
 

--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -128,13 +128,6 @@ Gem::Specification.new do |s|
   # which we currently depend on in pageflow/engine.rb
   s.add_dependency 'sprockets', '< 4'
 
-  # Used for Webpack build in host application
-  if Pageflow::RailsVersion.experimental?
-    s.add_dependency 'shakapacker', '~> 7.0'
-  else
-    s.add_dependency 'webpacker', '~> 4.2'
-  end
-
   # Using translations from rails locales in javascript code.
   s.add_dependency 'i18n-js', '~> 2.1'
 
@@ -163,6 +156,13 @@ Gem::Specification.new do |s|
 
   # string encryptor/decryptor
   s.add_dependency 'symmetric-encryption', '~> 4.3.1'
+
+  # Used for Webpack build in host application
+  if Pageflow::RailsVersion.experimental?
+    s.add_development_dependency 'shakapacker', '~> 7.0'
+  else
+    s.add_development_dependency 'webpacker', '~> 4.2'
+  end
 
   # Used by the dummy rails application
   s.add_development_dependency 'mysql2', '~> 0.5.2'


### PR DESCRIPTION
We plan to eventually drop support for Webpacker. But until the Rails 6 migration is finished, we aim to support both.

Decouple from experimental Rails version environment variable and detect Shakapacker global instead.

Enhance install generator to create required PostCSS config. which is no longer generated by Shalapacker's install generator.

REDMINE-19438