### PR TITLE
Relax size option when cropping in webp processor

### DIFF
--- a/lib/pageflow/paperclip_processors/webp.rb
+++ b/lib/pageflow/paperclip_processors/webp.rb
@@ -28,7 +28,7 @@ module Pageflow
           thumbnail = Vips::Image.thumbnail(
             ANIMATED_FORMATS.include?(@current_format) ? "#{source.path}[n=-1]" : source.path,
             width,
-            size: :down,
+            size: @should_crop ? :both : :down,
             height: height,
             crop: crop
           )

--- a/spec/pageflow/paperclip_processors/webp_spec.rb
+++ b/spec/pageflow/paperclip_processors/webp_spec.rb
@@ -5,7 +5,7 @@ module Pageflow
     describe Webp do
       describe '#make' do
         it 'shrinks jpg correctly' do
-          processor = Webp.new(fixture_jpg, geometry: '600x300>')
+          processor = Webp.new(fixture_1200x800_jpg, geometry: '600x300>')
 
           result = processor.make
           new_image = Vips::Image.new_from_file(result.path)
@@ -16,7 +16,7 @@ module Pageflow
         end
 
         it 'does not shrink if already smaller' do
-          processor = Webp.new(fixture_jpg, geometry: '2000x2000>')
+          processor = Webp.new(fixture_1200x800_jpg, geometry: '2000x2000>')
 
           result = processor.make
           new_image = Vips::Image.new_from_file(result.path)
@@ -26,8 +26,8 @@ module Pageflow
           expect(new_image.height).to eq(800)
         end
 
-        it 'crops them correctly' do
-          processor = Webp.new(fixture_jpg, geometry: '600x300#')
+        it 'supports cropping' do
+          processor = Webp.new(fixture_1200x800_jpg, geometry: '600x300#')
 
           result = processor.make
           new_image = Vips::Image.new_from_file(result.path)
@@ -37,8 +37,19 @@ module Pageflow
           expect(new_image.height).to eq(300)
         end
 
+        it 'can crop images smaller than crop area' do
+          processor = Webp.new(fixture_7x15_png, geometry: '40x40#')
+
+          result = processor.make
+          new_image = Vips::Image.new_from_file(result.path)
+
+          expect(result.path).to end_with('.webp')
+          expect(new_image.width).to eq(40)
+          expect(new_image.height).to eq(40)
+        end
+
         it 'handles gif files' do
-          processor = Webp.new(fixture_gif, geometry: '600x300>')
+          processor = Webp.new(fixture_1x1_gif, geometry: '600x300>')
 
           result = processor.make
           new_image = Vips::Image.new_from_file(result.path)
@@ -48,11 +59,15 @@ module Pageflow
           expect(new_image.height).to eq(1)
         end
 
-        def fixture_jpg
+        def fixture_7x15_png
+          File.open(Engine.root.join('spec', 'fixtures', 'image.png'))
+        end
+
+        def fixture_1200x800_jpg
           File.open(Engine.root.join('spec', 'fixtures', 'image.jpg'))
         end
 
-        def fixture_gif
+        def fixture_1x1_gif
           File.open(Engine.root.join('spec', 'fixtures', 'image.gif'))
         end
       end


### PR DESCRIPTION
vips raises `smartcrop: bad extract area` error when image is smaller than cropped size and only sclaing down is allowed. In fact, we want to scale the image up, when using a cropping geometry.

REDMINE-20473