### PR TITLE
Set inverse of draft and published_revision associations on entry

### DIFF
--- a/app/models/pageflow/entry.rb
+++ b/app/models/pageflow/entry.rb
@@ -29,8 +29,8 @@ module Pageflow
 
     has_many :imports, class_name: 'Pageflow::FileImport', dependent: :destroy
 
-    has_one :draft, -> { editable }, :class_name => 'Revision'
-    has_one :published_revision, -> { published }, :class_name => 'Revision'
+    has_one :draft, -> { editable }, class_name: 'Revision', inverse_of: :entry
+    has_one :published_revision, -> { published }, class_name: 'Revision', inverse_of: :entry
 
     has_one :edit_lock, :dependent => :destroy
 

--- a/spec/models/pageflow/entry_spec.rb
+++ b/spec/models/pageflow/entry_spec.rb
@@ -82,6 +82,22 @@ module Pageflow
       end
     end
 
+    describe '#draft' do
+      it 'sets inverse of association' do
+        entry = create(:entry)
+
+        expect(entry.draft.entry).to be(entry)
+      end
+    end
+
+    describe '#published_revision' do
+      it 'sets inverse of association' do
+        entry = create(:entry, :published)
+
+        expect(entry.published_revision.entry).to be(entry)
+      end
+    end
+
     describe '#entry_type' do
       it 'returns entry type' do
         pageflow_configure do |config|


### PR DESCRIPTION
This enables an edge-case where the account of an example entry is changed transiently before creating a theme customization preview. Make sure feature flags of the account are taken into account correctly.

Generally, this should be an improvement since draft and published revisions no longer need to look up there entries in a separate query.

REDMINE-20474