### PR TITLE
Use theme entry font for captions of fullscreen image galleries

### DIFF
--- a/entry_types/scrolled/package/src/frontend/FullscreenViewer/index.module.css
+++ b/entry_types/scrolled/package/src/frontend/FullscreenViewer/index.module.css
@@ -4,6 +4,7 @@
   background-color: rgba(0,0,0, 0.9);
   opacity: 0;
   transition: opacity 0.2s linear;
+  font-family: var(--theme-entry-font-family);
 }
 
 .visible {


### PR DESCRIPTION
Since the fullscreen root element lies outside of the main content element, the normal font rule does not apply.