### PR TITLE
Do not force local Paperclip storage in storybook seeds

### DIFF
--- a/spec/support/pageflow/dummy/config/pageflow.rb
+++ b/spec/support/pageflow/dummy/config/pageflow.rb
@@ -1,16 +1,20 @@
 Pageflow.configure do |config|
-  config.paperclip_s3_root = 'test-host'
+  s3_bucket = config.paperclip_s3_default_options.dig(:s3_credentials, :bucket)
 
-  config.paperclip_s3_default_options.merge!(
-    storage: :filesystem,
-    url: '/system/s3/:class/:attachment/:id_partition/:style/:filename',
-    path: ':rails_root/public:url'
-  )
+  if s3_bucket == 'com-example-pageflow-development'
+    config.paperclip_s3_root = 'test-host'
 
-  config.paperclip_direct_upload_options = lambda do |_|
-    {
-      url: '#',
-      fields: []
-    }
+    config.paperclip_s3_default_options.merge!(
+      storage: :filesystem,
+      url: '/system/s3/:class/:attachment/:id_partition/:style/:filename',
+      path: ':rails_root/public:url'
+    )
+
+    config.paperclip_direct_upload_options = lambda do |_|
+      {
+        url: '#',
+        fields: []
+      }
+    end
   end
 end


### PR DESCRIPTION
The storybook GitHub action sets the `S3_*` environment variables to use example files from an S3 bucket. Leave Paperclip config untouched if these variables have been set.