### PR TITLE
Decouple host application from scrolled widget packs

### DIFF
--- a/entry_types/scrolled/lib/generators/pageflow_scrolled/install/install_generator.rb
+++ b/entry_types/scrolled/lib/generators/pageflow_scrolled/install/install_generator.rb
@@ -129,26 +129,7 @@ module PageflowScrolled
         create_file 'app/javascript/packs/pageflow-scrolled-server.js', <<-JS
           import 'pageflow-scrolled/frontend-server';
           import 'pageflow-scrolled/contentElements-frontend';
-          import 'pageflow-scrolled/widgets/defaultNavigation';
-          import 'pageflow-scrolled/widgets/consentBar';
-        JS
-      end
-
-      def default_navigation_widget_packs
-        widget_dir = 'app/javascript/packs/pageflow-scrolled/widgets'
-
-        create_file File.join(widget_dir, 'defaultNavigation.js'), <<-JS
-          import 'pageflow-scrolled/widgets/defaultNavigation';
-          import 'pageflow-scrolled/widgets/defaultNavigation.css';
-        JS
-      end
-
-      def consent_bar_widget_packs
-        widget_dir = 'app/javascript/packs/pageflow-scrolled/widgets'
-
-        create_file File.join(widget_dir, 'consentBar.js'), <<-JS
-          import 'pageflow-scrolled/widgets/consentBar';
-          import 'pageflow-scrolled/widgets/consentBar.css';
+          import 'pageflow-scrolled/widgets-server';
         JS
       end
 

--- a/entry_types/scrolled/package/config/webpack.js
+++ b/entry_types/scrolled/package/config/webpack.js
@@ -7,5 +7,19 @@ module.exports = {
       // supported by the browser.
       'video.js$': 'video.js/core.es.js'
     },
+  },
+  entry: {
+    'pageflow-scrolled/widgets/defaultNavigation': {
+      import: [
+        'pageflow-scrolled/widgets/defaultNavigation',
+        'pageflow-scrolled/widgets/defaultNavigation.css'
+      ]
+    },
+    'pageflow-scrolled/widgets/consentBar': {
+      import: [
+        'pageflow-scrolled/widgets/consentBar',
+        'pageflow-scrolled/widgets/consentBar.css'
+      ]
+    }
   }
 };

--- a/entry_types/scrolled/package/widgets-server.js
+++ b/entry_types/scrolled/package/widgets-server.js
@@ -1,0 +1,2 @@
+import 'pageflow-scrolled/widgets/defaultNavigation';
+import 'pageflow-scrolled/widgets/consentBar';


### PR DESCRIPTION
Implicitly define packs via pageflow-scrolled/config. Allow importing all widget for SSR.

### Manual Update Step

* Remove `defaultNavigation.js` and `consentBar.js` from `app/javascript/packs/pageflow-scrolled/widgets`
* Import `pageflow-scrolled/widgets-server` instead of `pageflow-scrolled/widgets/defaultNavigation` and `pageflow-scrolled/widgets/consentBar` in `app/javascript/packs/pageflow-scrolled-server.js`

REDMINE-20093