### PR TITLE
Do not require auth object for ransackable_* methods

### DIFF
--- a/app/models/pageflow/account.rb
+++ b/app/models/pageflow/account.rb
@@ -28,11 +28,11 @@ module Pageflow
       [:features_configuration]
     end
 
-    def self.ransackable_attributes(_auth_object)
+    def self.ransackable_attributes(_auth_object = nil)
       %w[id name]
     end
 
-    def self.ransackable_associations(_auth_object)
+    def self.ransackable_associations(_auth_object = nil)
       []
     end
   end

--- a/app/models/pageflow/entry.rb
+++ b/app/models/pageflow/entry.rb
@@ -132,15 +132,15 @@ module Pageflow
       title.to_s.parameterize
     end
 
-    def self.ransackable_attributes(_auth_object)
+    def self.ransackable_attributes(_auth_object = nil)
       %w[title type_name created_at edited_at first_published_at]
     end
 
-    def self.ransackable_associations(_auth_object)
+    def self.ransackable_associations(_auth_object = nil)
       %w[account published_revision]
     end
 
-    def self.ransackable_scopes(_)
+    def self.ransackable_scopes(_auth_object = nil)
       [:with_publication_state, :published]
     end
 

--- a/app/models/pageflow/revision.rb
+++ b/app/models/pageflow/revision.rb
@@ -206,6 +206,10 @@ module Pageflow
         .merge(read_attribute(:configuration) || {})
     end
 
+    def self.ransackable_attributes(_auth_object = nil)
+      %w[published_at]
+    end
+
     private
 
     def files(model)
@@ -233,10 +237,6 @@ module Pageflow
 
     def available_themes
       @available_themes ||= Pageflow.config_for(entry).themes
-    end
-
-    def self.ransackable_attributes(_auth_object)
-      %w[published_at]
     end
   end
 end

--- a/app/models/pageflow/site.rb
+++ b/app/models/pageflow/site.rb
@@ -56,11 +56,11 @@ module Pageflow
       first_paged_entry_template.theme_name
     end
 
-    def self.ransackable_attributes(_auth_object)
+    def self.ransackable_attributes(_auth_object = nil)
       %w[name]
     end
 
-    def self.ransackable_associations(_auth_object)
+    def self.ransackable_associations(_auth_object = nil)
       %w[account]
     end
   end

--- a/lib/pageflow/user_mixin.rb
+++ b/lib/pageflow/user_mixin.rb
@@ -71,7 +71,7 @@ module Pageflow
     end
 
     module ClassMethods
-      def ransackable_attributes(_auth_object)
+      def ransackable_attributes(_auth_object = nil)
         %w[first_name last_name email]
       end
     end


### PR DESCRIPTION
Active Admin 3.2 [1] calls `ransackable_associations` without passing an auth object.

[1] https://github.com/activeadmin/activeadmin/pull/8164