### PR TITLE
Set entry instance variable when rendering page type templates

### DIFF
--- a/app/helpers/pageflow/page_types_helper.rb
+++ b/app/helpers/pageflow/page_types_helper.rb
@@ -15,16 +15,16 @@ module Pageflow
     end
 
     def page_type_templates(entry)
+      # Required by RevisionFileHelper#find_file_in_entry
+      @entry = entry
+
       safe_join(Pageflow.config.page_types.map do |page_type|
         content_tag(:script,
                     render(template: page_type.template_path,
                            locals: {
                              configuration: {},
                              page: Page.new,
-                             entry: entry,
-
-                             # Required by RevisionFileHelper#find_file_in_entry
-                             :@entry => entry
+                             entry: entry
                            },
                            layout: false).to_str,
                     type: 'text/html', data: {template: "#{page_type.name}_page"})


### PR DESCRIPTION
Rails 7 no longer allows to set instance variables via render locals [1]. Since `RevisionFileHelper#find_file_in_entry` depends on a `@entry` instance variable being set, we need to set in on the view object ourselves.

REDMINE-20487

[1] https://github.com/rails/rails/pull/41464