### PR TITLE
Fall back to entry when share page is missing

### DIFF
--- a/entry_types/paged/app/controllers/pageflow_paged/entries_controller.rb
+++ b/entry_types/paged/app/controllers/pageflow_paged/entries_controller.rb
@@ -17,7 +17,7 @@ module PageflowPaged
 
       @entry.share_target =
         if params[:page].present?
-          @entry.pages.find_by_perma_id(params[:page])
+          @entry.pages.find_by_perma_id(params[:page]) || @entry
         else
           @entry
         end

--- a/entry_types/paged/spec/controllers/pageflow_paged/entries_controller_spec.rb
+++ b/entry_types/paged/spec/controllers/pageflow_paged/entries_controller_spec.rb
@@ -204,6 +204,18 @@ module PageflowPaged
             .for_property('og:title')
             .with_content_including('Shared page')
         end
+
+        it 'falls back to entry meta tags when page is missing' do
+          entry = create(:entry,
+                         :published,
+                         published_revision_attributes: {title: 'Shared entry'})
+
+          get_with_entry_env(:show, entry: entry, params: {page: 1234})
+
+          expect(response.body).to have_meta_tag
+            .for_property('og:title')
+            .with_content_including('Shared entry')
+        end
       end
     end
   end


### PR DESCRIPTION
Do not raise exception when page parameter refers to unknown page.