### PR TITLE
Fix hanging quote position in center-ragged layout

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/quote/Quote.module.css
+++ b/entry_types/scrolled/package/src/contentElements/quote/Quote.module.css
@@ -80,6 +80,12 @@
   right: calc(100% + var(--theme-quote-hanging-mark-spacing, 0.05em));
 }
 
+.centerRagged.design-hanging .text p:first-child::before {
+  position: static;
+  padding-right: var(--theme-quote-hanging-mark-spacing, 0.05em);
+  margin-left: calc(-1ch - var(--theme-quote-hanging-mark-spacing, 0.05em));
+}
+
 .design-largeCentered .text p:first-child::before,
 .design-largeHanging .text p:first-child::before {
   font-size: var(--quote-large-mark-font-size);

--- a/entry_types/scrolled/package/src/contentElements/quote/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/quote/stories.js
@@ -66,6 +66,23 @@ storiesOfContentElement(module, {
       }
     },
     {
+      name: 'Hanging Centered Ragged',
+      configuration: {
+        text: [
+          {
+            type: 'paragraph',
+            children: [{text: 'Be the change\n that you wish to see in the world'}]
+          }
+        ]
+      },
+      themeOptions: {
+        quoteDesign: 'hanging'
+      },
+      sectionConfiguration: {
+        layout: 'centerRagged'
+      }
+    },
+    {
       name: 'Hanging with custom spacing',
       themeOptions: {
         quoteDesign: 'hanging',


### PR DESCRIPTION
First line might start further on the right. We cannot just position the hanging opening quote relative to the bounding box of the quote.