### PR TITLE
Store previous src for media event file names

### DIFF
--- a/package/spec/frontend/media/MediaPool_spec.js
+++ b/package/spec/frontend/media/MediaPool_spec.js
@@ -148,6 +148,19 @@ describe('MediaPool', function() {
 
       expect(callback).toHaveBeenCalled();
     });
+
+    it('stores previous src until reallocated', function () {
+      let pool = new MediaPool();
+      let player = pool.allocatePlayer({playerType: MediaType.VIDEO});
+      player.src('www.example.com/test.mp4');
+      expect(player.getMediaElement().hasAttribute('src')).toBe(true);
+
+      pool.unAllocatePlayer(player);
+      expect(player.previousSrc).toStrictEqual('www.example.com/test.mp4');
+
+      player = pool.allocatePlayer({playerType: MediaType.VIDEO});
+      expect(player.previousSrc).toBeNull();
+    });
   });
 
   describe('#blessAll', function() {

--- a/package/src/frontend/VideoPlayer/mediaEvents.js
+++ b/package/src/frontend/VideoPlayer/mediaEvents.js
@@ -10,7 +10,7 @@ export const mediaEvents = function(player, context) {
   function triggerMediaEvent(name) {
     if (context) {
       events.trigger('media:' + name, {
-        fileName: player.currentSrc(),
+        fileName: player.previousSrc || player.currentSrc(),
         context: context,
         currentTime: player.currentTime(),
         duration: player.duration(),

--- a/package/src/frontend/media/MediaPool.js
+++ b/package/src/frontend/media/MediaPool.js
@@ -64,6 +64,7 @@ export class MediaPool {
 
       player.playerId = playerId || this.allocatedPlayers[playerType].length
       player.releaseCallback = onRelease;
+      player.previousSrc = null;
 
       return player;
     }
@@ -78,6 +79,8 @@ export class MediaPool {
     if (player) {
       let type = this.getMediaTypeFromEl(player.el());
       this.allocatedPlayers[type] = this.allocatedPlayers[type].filter(p=>p!=player);
+
+      player.previousSrc = player.currentSrc();
 
       player.controls(false);
       player.getMediaElement().loop = false;


### PR DESCRIPTION
When a player is unallocated, we reset src to a blank media file via a placeholder data url and pause the player. The player still triggers timeupdate and pause events that we want to turn into media events. We do not want to report the data url as file name, since analytics integrations rely on stable file names. We thus store the previous src and use that wehn reporting the remaining events.

REDMINE-20591