### PR TITLE
Allow registering additional editor packs with stylesheets

### DIFF
--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/packs_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/packs_helper.rb
@@ -22,6 +22,13 @@ module PageflowScrolled
       )
     end
 
+    def scrolled_editor_stylesheet_packs_tag(entry)
+      stylesheet_pack_tag(
+        *scrolled_editor_stylesheet_packs(entry),
+        media: 'all'
+      )
+    end
+
     def scrolled_frontend_packs(entry, widget_scope:)
       ['pageflow-scrolled-frontend'] +
         scrolled_additional_frontend_packs(entry, widget_scope) +
@@ -32,6 +39,10 @@ module PageflowScrolled
       ['pageflow-scrolled-editor'] +
         Pageflow.config_for(entry).additional_editor_packs.paths +
         scrolled_frontend_widget_type_packs(entry, :editor)
+    end
+
+    def scrolled_editor_stylesheet_packs(entry)
+      Pageflow.config_for(entry).additional_editor_packs.stylesheet_paths
     end
 
     private

--- a/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/editor/entries/_head.html.erb
@@ -9,3 +9,4 @@
 
 <%= scrolled_webpack_public_path_script_tag %>
 <%= scrolled_editor_javascript_packs_tag(entry) %>
+<%= scrolled_editor_stylesheet_packs_tag(entry) %>

--- a/entry_types/scrolled/lib/pageflow_scrolled/additional_packs.rb
+++ b/entry_types/scrolled/lib/pageflow_scrolled/additional_packs.rb
@@ -8,8 +8,8 @@ module PageflowScrolled
 
     # content_element_type_names option only takes effect for frontend
     # packs.
-    def register(path, content_element_type_names: [])
-      @packs << AdditionalPack.new(path, content_element_type_names)
+    def register(path, content_element_type_names: [], stylesheet: false)
+      @packs << AdditionalPack.new(path, content_element_type_names, stylesheet)
     end
 
     # @api private
@@ -25,6 +25,11 @@ module PageflowScrolled
     end
 
     # @api private
+    def stylesheet_paths
+      @packs.select(&:stylesheet).map(&:path)
+    end
+
+    # @api private
     def paths_for_content_element_types(type_names)
       @packs.reject { |pack|
         pack.content_element_type_names.present? &&
@@ -33,6 +38,6 @@ module PageflowScrolled
     end
 
     # @api private
-    AdditionalPack = Struct.new(:path, :content_element_type_names)
+    AdditionalPack = Struct.new(:path, :content_element_type_names, :stylesheet)
   end
 end

--- a/entry_types/scrolled/spec/helpers/pageflow_scrolled/packs_helper_spec.rb
+++ b/entry_types/scrolled/spec/helpers/pageflow_scrolled/packs_helper_spec.rb
@@ -247,5 +247,36 @@ module PageflowScrolled
         expect(result).to include('pageflow-scrolled/widgets/customNavigation')
       end
     end
+
+    describe 'scrolled_editor_stylesheet_packs' do
+      it 'empty by default' do
+        entry = create(:published_entry, type_name: 'scrolled')
+
+        result = helper.scrolled_editor_stylesheet_packs(entry)
+
+        expect(result).to eq([])
+      end
+
+      it 'includes additional editor packs in editor with stylesheet option' do
+        pageflow_configure do |config|
+          config.for_entry_type(PageflowScrolled.entry_type) do |entry_type_config|
+            entry_type_config.additional_editor_packs.register(
+              'pageflow-scrolled/only-js'
+            )
+
+            entry_type_config.additional_editor_packs.register(
+              'pageflow-scrolled/extra-editor',
+              stylesheet: true
+            )
+          end
+        end
+
+        entry = create(:published_entry, type_name: 'scrolled')
+
+        result = helper.scrolled_editor_stylesheet_packs(entry)
+
+        expect(result).to eq(['pageflow-scrolled/extra-editor'])
+      end
+    end
   end
 end


### PR DESCRIPTION
Core editor styles are inserted as inline style tags via `rollup-plugin-postcss` which relies on `style-inject`.

For additional editor packs in the host application, this mechanism does not work with Shakapacker's default setup. We thus add an option to also add links to additional stylesheet packs.

REDMINE-20374