### PR TITLE
Fix image gallery scrolling in editor on Safari

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/imageGallery/useIntersectionObserver.js
+++ b/entry_types/scrolled/package/src/contentElements/imageGallery/useIntersectionObserver.js
@@ -14,7 +14,7 @@ export function useIntersectionObserver({threshold, onVisibleIndexChange}) {
             (child) => child === entry.target
           );
 
-          if (entry.isIntersecting) {
+          if (entry.isIntersecting && entry.intersectionRatio >= threshold) {
             onVisibleIndexChange(entryIndex);
           }
         });


### PR DESCRIPTION
Safari (tested with 17.3) also triggers the observer callback for children whose `intersectionRatio` is below the threshold. This only happens inside the editor iframe. In the preview or published entries, the behavior matches Chrome and Firefox.

We need to double check `intersectionRatio` ourselves to prevent invoking the `onVisibleIndexChange` callback for all of the children, which leads to a broken image gallery.

REDMINE-20635