### PR TITLE
Make filtering of entry translations menu less restrictive

### DIFF
--- a/app/models/pageflow/draft_entry.rb
+++ b/app/models/pageflow/draft_entry.rb
@@ -14,7 +14,7 @@ module Pageflow
       entry.title
     end
 
-    def translations(scope = -> { self })
+    def translations(scope = -> { self }, **)
       return [] unless entry.translation_group
 
       PublishedEntry.wrap_all_drafts(

--- a/app/models/pageflow/entry_translation_group.rb
+++ b/app/models/pageflow/entry_translation_group.rb
@@ -6,8 +6,23 @@ module Pageflow
              foreign_key: 'translation_group_id',
              dependent: :nullify
 
+    has_many :published_entries,
+             -> { published },
+             foreign_key: 'translation_group_id',
+             class_name: 'Entry'
+
     has_many :publicly_visible_entries,
              -> { published_without_password_protection.published_without_noindex },
+             foreign_key: 'translation_group_id',
+             class_name: 'Entry'
+
+    has_many :entries_published_without_password_protection,
+             -> { published_without_password_protection },
+             foreign_key: 'translation_group_id',
+             class_name: 'Entry'
+
+    has_many :entries_published_without_noindex,
+             -> { published_without_noindex },
              foreign_key: 'translation_group_id',
              class_name: 'Entry'
 

--- a/app/models/pageflow/published_entry.rb
+++ b/app/models/pageflow/published_entry.rb
@@ -20,12 +20,12 @@ module Pageflow
       revision.title.presence || entry.title
     end
 
-    def translations(scope = -> { self })
+    def translations(scope = -> { self }, include_noindex: false)
       return [] unless entry.translation_group
 
       if published_revision?
         self.class.wrap_all(
-          entry.translation_group.publicly_visible_entries.instance_exec(&scope)
+          published_translation_entries(include_noindex:).instance_exec(&scope)
         )
       else
         self.class.wrap_all_drafts(
@@ -98,6 +98,20 @@ module Pageflow
     end
 
     private
+
+    def published_translation_entries(include_noindex:)
+      translation_group = entry.translation_group
+
+      if password_protected? && include_noindex
+        translation_group.published_entries
+      elsif password_protected?
+        translation_group.entries_published_without_noindex
+      elsif include_noindex
+        translation_group.entries_published_without_password_protection
+      else
+        translation_group.publicly_visible_entries
+      end
+    end
 
     def custom_revision?
       @custom_revision

--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/entry_json_seed_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/entry_json_seed_helper.rb
@@ -33,7 +33,7 @@ module PageflowScrolled
                     sections: main_storyline.sections,
                     content_elements: main_storyline.content_elements,
                     widgets: scrolled_entry.resolve_widgets(insert_point: :react),
-                    options: options)
+                    options:)
     end
   end
 end

--- a/entry_types/scrolled/app/views/pageflow_scrolled/entry_json_seed/_entry_translations.json.jbuilder
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entry_json_seed/_entry_translations.json.jbuilder
@@ -1,5 +1,5 @@
 json.entry_translations do
-  json.array!(entry.translations(-> { preload(:site) })) do |translation|
+  json.array!(entry.translations(-> { preload(:site) }, include_noindex: true)) do |translation|
     json.(translation, :id, :locale)
     json.display_locale t('pageflow.public._language', locale: translation.locale)
 

--- a/entry_types/scrolled/spec/helpers/pageflow_scrolled/entry_json_seed_helper_spec.rb
+++ b/entry_types/scrolled/spec/helpers/pageflow_scrolled/entry_json_seed_helper_spec.rb
@@ -746,7 +746,7 @@ module PageflowScrolled
       end
 
       context 'entry translations' do
-        it 'renders links to published translations of published entry' do
+        it 'renders links to published translations of published entry including noindex entries' do
           de_entry = create(
             :published_entry,
             type_name: 'scrolled',
@@ -755,6 +755,7 @@ module PageflowScrolled
           )
           en_entry = create(
             :published_entry,
+            :published_with_noindex,
             translation_of: de_entry,
             type_name: 'scrolled',
             title: 'entry-en',

--- a/spec/factories/published_entries.rb
+++ b/spec/factories/published_entries.rb
@@ -13,19 +13,29 @@ module Pageflow
         without_feature { nil }
 
         translation_of { nil }
+
+        entry_trait { :published }
+      end
+
+      trait :published_with_password do
+        entry_trait { :published_with_password }
+      end
+
+      trait :published_with_noindex do
+        entry_trait { :published_with_noindex }
       end
 
       initialize_with do
         PublishedEntry.new(create(:entry,
-                                  :published,
-                                  title: title,
-                                  account: account,
-                                  site: site,
-                                  type_name: type_name,
+                                  entry_trait,
+                                  title:,
+                                  account:,
+                                  site:,
+                                  type_name:,
                                   published_revision_attributes: revision_attributes,
-                                  permalink_attributes: permalink_attributes,
-                                  with_feature: with_feature,
-                                  without_feature: without_feature))
+                                  permalink_attributes:,
+                                  with_feature:,
+                                  without_feature:))
       end
 
       to_create { |published_entry| published_entry.entry.save! }

--- a/spec/models/pageflow/draft_entry_spec.rb
+++ b/spec/models/pageflow/draft_entry_spec.rb
@@ -28,6 +28,19 @@ module Pageflow
 
         expect(result[0].entry.association(:permalink).loaded?).to eq(true)
       end
+
+      it 'ignores include_noindex argument' do
+        entry = create(:entry)
+        translation = create(:entry)
+        entry.mark_as_translation_of(translation)
+        draft_entry = DraftEntry.new(entry)
+
+        result = draft_entry.translations(include_noindex: true)
+
+        expect(result.length).to eq(2)
+        expect(result[0].title).to eq(entry.title)
+        expect(result[1].title).to eq(translation.title)
+      end
     end
 
     describe '#find_files' do

--- a/spec/models/pageflow/published_entry_spec.rb
+++ b/spec/models/pageflow/published_entry_spec.rb
@@ -253,6 +253,31 @@ module Pageflow
         expect(result[0].title).to eq(entry.title)
       end
 
+      it 'does not filter out password protected entries if entry is published with password' do
+        entry = create(:entry, :published_with_password)
+        translation = create(:entry, :published_with_password)
+        entry.mark_as_translation_of(translation)
+        published_entry = PublishedEntry.new(entry)
+
+        result = published_entry.translations
+
+        expect(result.length).to eq(2)
+        expect(result[0].title).to eq(entry.title)
+        expect(result[1].title).to eq(translation.title)
+      end
+
+      it 'filters out non-published entries if entry is published with password' do
+        entry = create(:entry, :published_with_password)
+        translation = create(:entry)
+        entry.mark_as_translation_of(translation)
+        published_entry = PublishedEntry.new(entry)
+
+        result = published_entry.translations
+
+        expect(result.length).to eq(1)
+        expect(result[0].title).to eq(entry.title)
+      end
+
       it 'filters out noindex entries' do
         entry = create(:entry, :published)
         translation = create(:entry, :published_with_noindex)
@@ -263,6 +288,82 @@ module Pageflow
 
         expect(result.length).to eq(1)
         expect(result[0].title).to eq(entry.title)
+      end
+
+      it 'filters out noindex entries if entry is published with password' do
+        entry = create(:entry, :published_with_password)
+        translation = create(:entry, :published_with_noindex)
+        entry.mark_as_translation_of(translation)
+        published_entry = PublishedEntry.new(entry)
+
+        result = published_entry.translations
+
+        expect(result.length).to eq(1)
+        expect(result[0].title).to eq(entry.title)
+      end
+
+      describe 'with include_noindex' do
+        it 'includes noindex entries' do
+          entry = create(:entry, :published)
+          translation = create(:entry, :published_with_noindex)
+          entry.mark_as_translation_of(translation)
+          published_entry = PublishedEntry.new(entry)
+
+          result = published_entry.translations(include_noindex: true)
+
+          expect(result.length).to eq(2)
+          expect(result[0].title).to eq(entry.title)
+          expect(result[1].title).to eq(translation.title)
+        end
+
+        it 'filters out non-published entries' do
+          entry = create(:entry, :published)
+          translation = create(:entry)
+          entry.mark_as_translation_of(translation)
+          published_entry = PublishedEntry.new(entry)
+
+          result = published_entry.translations(include_noindex: true)
+
+          expect(result.length).to eq(1)
+          expect(result[0].title).to eq(entry.title)
+        end
+
+        it 'filters out password protected entries' do
+          entry = create(:entry, :published)
+          translation = create(:entry, :published_with_password)
+          entry.mark_as_translation_of(translation)
+          published_entry = PublishedEntry.new(entry)
+
+          result = published_entry.translations(include_noindex: true)
+
+          expect(result.length).to eq(1)
+          expect(result[0].title).to eq(entry.title)
+        end
+
+        it 'does not filter out password protected entries if entry is published with password' do
+          entry = create(:entry, :published_with_password)
+          translation = create(:entry, :published_with_password)
+          entry.mark_as_translation_of(translation)
+          published_entry = PublishedEntry.new(entry)
+
+          result = published_entry.translations(include_noindex: true)
+
+          expect(result.length).to eq(2)
+          expect(result[0].title).to eq(entry.title)
+          expect(result[1].title).to eq(translation.title)
+        end
+
+        it 'filters out non-published entries for password protected entry' do
+          entry = create(:entry, :published_with_password)
+          translation = create(:entry)
+          entry.mark_as_translation_of(translation)
+          published_entry = PublishedEntry.new(entry)
+
+          result = published_entry.translations(include_noindex: true)
+
+          expect(result.length).to eq(1)
+          expect(result[0].title).to eq(entry.title)
+        end
       end
 
       it 'supports using drafts' do


### PR DESCRIPTION
Also list translations that have been published with noindex. Keep filtering those out in hreflang meta tags, but let users switch between translations even if a translation is excluded from search engine indexes.

For entries that have been published with password protection, also list password protected translations. We still want to filter out password protected translations in publicly visible entries to allow temporarily publishing a translation (e.g., for proof reading) without having it show up in already published content. Still, if all entries of a translation group are supposed to be published with password protection, we still want to let users take advantage of the translations menu feature.

REDMINE-20740