### PR TITLE
Allow opening external privacy settings via privacy link

### DIFF
--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -61,6 +61,8 @@ module Pageflow
 
     def entry_privacy_link_url(entry)
       return unless entry.site.privacy_link_url.present?
+      return entry.site.privacy_link_url if entry.site.privacy_link_url.start_with?('javascript:')
+
       "#{entry.site.privacy_link_url}?lang=#{entry.locale}"
     end
 
@@ -102,7 +104,8 @@ module Pageflow
       if entry.site.privacy_link_url.present?
         links << link_to(I18n.t('pageflow.public.privacy_notice'),
                          entry_privacy_link_url(entry),
-                         target: '_blank',
+                         target:
+                           entry.site.privacy_link_url.start_with?('javascript:') ? nil : '_blank',
                          tabindex: 2,
                          class: 'privacy')
       end

--- a/entry_types/scrolled/package/spec/widgets/defaultNavigation/LegalInfoLink-spec.js
+++ b/entry_types/scrolled/package/spec/widgets/defaultNavigation/LegalInfoLink-spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import {LegalInfoLink} from 'widgets/defaultNavigation/LegalInfoLink';
+
+import {render} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('LegalInfoLink', () => {
+  it('renders target blank by default', () => {
+    const {getByRole} = render(
+      <LegalInfoLink label="Copyright" url="https://example.com" />
+    );
+
+    expect(getByRole('link')).toHaveTextContent('Copyright');
+    expect(getByRole('link')).toHaveAttribute('href', 'https://example.com');
+    expect(getByRole('link')).toHaveAttribute('target', '_blank');
+    expect(getByRole('link')).toHaveAttribute('rel', 'noreferrer noopener');
+  });
+
+  it('supports javascript url scheme', () => {
+    const {getByRole} = render(
+      // eslint-disable-next-line no-script-url
+      <LegalInfoLink label="Copyright" url="javascript:pageflowDisplayPrivacySettings()" />
+    )
+
+    expect(getByRole('link')).toHaveTextContent('Copyright');
+    expect(getByRole('link')).toHaveAttribute('href', '#privacySettings');
+    expect(getByRole('link')).not.toHaveAttribute('target');
+    expect(getByRole('link')).not.toHaveAttribute('rel');
+  });
+});

--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/LegalInfoLink.js
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/LegalInfoLink.js
@@ -2,6 +2,22 @@ import React from 'react';
 import styles from "./LegalInfoMenu.module.css";
 
 export function LegalInfoLink(props) {
+  // eslint-disable-next-line no-script-url
+  if (props.url === 'javascript:pageflowDisplayPrivacySettings()' && props.label) {
+    return (
+      <div>
+        <a href="#privacySettings"
+           onClick={event => {
+             window.pageflowDisplayPrivacySettings();
+             event.preventDefault();
+           }}
+           className={styles.legalInfoLink}
+           dangerouslySetInnerHTML={{__html: props.label}}>
+        </a>
+      </div>
+    )
+  }
+
   return (
     <div>
       {props.label && props.url &&

--- a/spec/helpers/pageflow/entries_helper_spec.rb
+++ b/spec/helpers/pageflow/entries_helper_spec.rb
@@ -178,10 +178,10 @@ module Pageflow
     describe '#entry_privacy_link_url' do
       it 'uses configured url and locale' do
         site = create(:site,
-                         privacy_link_url: 'https://example.com/privacy')
+                      privacy_link_url: 'https://example.com/privacy')
         entry = PublishedEntry.new(create(:entry,
                                           :published,
-                                          site: site,
+                                          site:,
                                           published_revision_attributes: {
                                             locale: 'de'
                                           }))
@@ -200,6 +200,16 @@ module Pageflow
         result = helper.entry_privacy_link_url(entry)
 
         expect(result).to be_nil
+      end
+
+      it 'supports javascript scheme' do
+        site = create(:site,
+                      privacy_link_url: 'javascript:triggerConsentLayer()')
+        entry = PublishedEntry.new(create(:entry, :published, site:))
+
+        result = helper.entry_privacy_link_url(entry)
+
+        expect(result).to eq('javascript:triggerConsentLayer()')
       end
     end
 
@@ -368,17 +378,29 @@ module Pageflow
 
       it 'includes privacy link if configured' do
         site = create(:site,
-                         privacy_link_url: 'https://example.com/privacy')
+                      privacy_link_url: 'https://example.com/privacy')
         entry = PublishedEntry.new(create(:entry,
                                           :published,
-                                          site: site,
+                                          site:,
                                           published_revision_attributes: {
                                             locale: 'de'
                                           }))
 
         result = helper.entry_global_links(entry)
 
-        expect(result).to have_selector('a[href="https://example.com/privacy?lang=de"]')
+        expect(result)
+          .to have_selector('a[target="_blank"][href="https://example.com/privacy?lang=de"]')
+      end
+
+      it 'supports javascript scheme for privacy link' do
+        site = create(:site,
+                      privacy_link_url: 'javascript:triggerConsentLayer()')
+        entry = PublishedEntry.new(create(:entry, :published, site:))
+
+        result = helper.entry_global_links(entry)
+
+        expect(result)
+          .to have_selector('a:not([target])[href="javascript:triggerConsentLayer()"]')
       end
     end
   end


### PR DESCRIPTION
This is an ugly workaround to allow triggering a global function that displays a consent layer. This wants to be an official JS API instead someday. But since Pageflow itself currently does not have a concept of external consent, today is not that day.

REDMINE-20765