### PR TITLE
Fix chapter scroller issue on Chrome 126 on OS X

### DIFF
--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/Scroller.module.css
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/Scroller.module.css
@@ -2,8 +2,9 @@
 
 @media screen and breakpoint-md {
   .scroller {
-    overflow: hidden;
+    overflow: scroll;
     scroll-behavior: smooth;
+    scrollbar-width: none;
 
     /* Prevent clipping chapter tooltips vertically. */
     padding-bottom: 90vh;
@@ -12,6 +13,10 @@
     /* For browsers that do not support clip-path (e.g. IE11). */
     margin: 0 auto;
     width: 58%;
+  }
+
+  .scroller::-webkit-scrollbar {
+    display: none;
   }
 
   .scroller > * {


### PR DESCRIPTION
On some machines setting `scrollLeft` does not work on containers with no pointer-events. Switching overflow to scroll works around the problem. Use CSS to prevent scroll bars showing up.

REDMINE-20780