### PR TITLE
Pass real request object to additional seed callable

### DIFF
--- a/entry_types/scrolled/app/views/pageflow_scrolled/entry_json_seed/_entry.json.jbuilder
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entry_json_seed/_entry.json.jbuilder
@@ -36,7 +36,7 @@ json.config do
     entry_config
       .additional_frontend_seed_data
       .for(entry,
-           self,
+           request,
            include_unused: options[:include_unused_additional_seed_data])
   )
 

--- a/entry_types/scrolled/spec/helpers/pageflow_scrolled/entry_json_seed_helper_spec.rb
+++ b/entry_types/scrolled/spec/helpers/pageflow_scrolled/entry_json_seed_helper_spec.rb
@@ -954,6 +954,29 @@ module PageflowScrolled
                                        })
       end
 
+      it 'passes request to seed callable' do
+        pageflow_configure do |config|
+          config.for_entry_type(PageflowScrolled.entry_type) do |entry_type_config|
+            entry_type_config.additional_frontend_seed_data.register(
+              'someSeed',
+              proc { |request:, **| {some: request.original_url} }
+            )
+          end
+        end
+
+        entry = create(:published_entry, type_name: 'scrolled')
+
+        result = render(helper, entry)
+
+        expect(result).to include_json(config: {
+                                         additionalSeedData: {
+                                           someSeed: {
+                                             some: 'http://test.host'
+                                           }
+                                         }
+                                       })
+      end
+
       context 'consent vendors' do
         include_context 'fake translations'
 


### PR DESCRIPTION
So far, we passed the template object which happened to respond to `params` just like `request`.