### PR TITLE
Allow using javascript scheme for all credit box links

### DIFF
--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -86,28 +86,33 @@ module Pageflow
       links = []
 
       if entry.site.imprint_link_label.present? && entry.site.imprint_link_url.present?
-        links << link_to(raw(entry.site.imprint_link_label),
-                         entry.site.imprint_link_url,
-                         target: '_blank',
-                         tabindex: 2,
-                         class: 'legal')
+        links << link_to(
+          raw(entry.site.imprint_link_label),
+          entry.site.imprint_link_url,
+          target: entry.site.imprint_link_url.start_with?('javascript:') ? nil : '_blank',
+          tabindex: 2,
+          class: 'legal'
+        )
       end
 
       if entry.site.copyright_link_label.present? && entry.site.copyright_link_url.present?
-        links << link_to(raw(entry.site.copyright_link_label),
-                         entry.site.copyright_link_url,
-                         target: '_blank',
-                         tabindex: 2,
-                         class: 'copy')
+        links << link_to(
+          raw(entry.site.copyright_link_label),
+          entry.site.copyright_link_url,
+          target: entry.site.copyright_link_url.start_with?('javascript:') ? nil : '_blank',
+          tabindex: 2,
+          class: 'copy'
+        )
       end
 
       if entry.site.privacy_link_url.present?
-        links << link_to(I18n.t('pageflow.public.privacy_notice'),
-                         entry_privacy_link_url(entry),
-                         target:
-                           entry.site.privacy_link_url.start_with?('javascript:') ? nil : '_blank',
-                         tabindex: 2,
-                         class: 'privacy')
+        links << link_to(
+          I18n.t('pageflow.public.privacy_notice'),
+          entry_privacy_link_url(entry),
+          target: entry.site.privacy_link_url.start_with?('javascript:') ? nil : '_blank',
+          tabindex: 2,
+          class: 'privacy'
+        )
       end
 
       if links.any?


### PR DESCRIPTION
Workaround for cases where we want to have a privacy link and a separate link to trigger a consent layer. This allowsto abuse the copyright link as a way to open the consent layer.

REDMINE-20765