### PR TITLE
Workaround Chrome auto zoom animation bug

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/v1/Backdrop/Effects-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/v1/Backdrop/Effects-spec.js
@@ -36,4 +36,18 @@ describe('Backdrop Effects getFilter', () => {
 
     expect(result).toEqual('grayscale(20%)');
   });
+
+  it('returns null by default', () => {
+    const result = getFilter([]);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for animation effects', () => {
+    const result = getFilter([
+      {name: 'autoZoom', value: 70}
+    ]);
+
+    expect(result).toBeNull();
+  });
 });

--- a/entry_types/scrolled/package/src/frontend/Backdrop.module.css
+++ b/entry_types/scrolled/package/src/frontend/Backdrop.module.css
@@ -11,10 +11,6 @@
   background-color: #333;
 }
 
-.effects {
-  height: 100%;
-}
-
 @media print {
   .Backdrop {
     page-break-inside: avoid;

--- a/entry_types/scrolled/package/src/frontend/v1/Backdrop/Effects.module.css
+++ b/entry_types/scrolled/package/src/frontend/v1/Backdrop/Effects.module.css
@@ -1,0 +1,21 @@
+.effects {
+  height: 100%;
+}
+
+.autoZoom {
+  animation: autoZoom var(--auto-zoom-duration) 1 ease;
+  animation-fill-mode: forwards;
+}
+
+@keyframes autoZoom {
+  from {
+    transform: translate(calc(-1 * var(--auto-zoom-origin-x)), calc(-1 * var(--auto-zoom-origin-y)))
+               scale(1)
+               translate(var(--auto-zoom-origin-x), var(--auto-zoom-origin-y));
+  }
+  to {
+    transform: translate(calc(-1 * var(--auto-zoom-origin-x)), calc(-1 * var(--auto-zoom-origin-y)))
+               scale(1.2)
+               translate(var(--auto-zoom-origin-x), var(--auto-zoom-origin-y));
+  }
+}


### PR DESCRIPTION
When applying the auto-zoom effect, Chrome sometimes stopped painting the backdrop, showing the dark default backdrop instead. Using a CSS keyframe animation instead of calling `animate` appears to avoid the problem.

REDMINE-20789