### PR TITLE
Fix flickering when sorting sections after returning to the outline

### DIFF
--- a/package/src/ui/views/SortableCollectionView.js
+++ b/package/src/ui/views/SortableCollectionView.js
@@ -46,6 +46,11 @@ export const SortableCollectionView = CollectionView.extend({
     return this;
   },
 
+  onClose() {
+    CollectionView.prototype.onClose.call(this);
+    this.sortable.destroy();
+  },
+
   disableSorting() {
     this.sortable.option('disabled', true);
   },


### PR DESCRIPTION
Properly tear down sortables. On second visit of the outline, the old sortables were still intervening and causing chaotic behavior.

REDMINE-20837