### PR TITLE
Make custom icon directory name configurable via theme options

### DIFF
--- a/entry_types/scrolled/app/views/pageflow_scrolled/entry_json_seed/_theme.json.jbuilder
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entry_json_seed/_theme.json.jbuilder
@@ -8,9 +8,11 @@ json.theme do
 
     json.icons({})
     json.icons do
+      icons_directory = theme.options.fetch(:custom_icons_directory, 'icons')
+
       theme.options.fetch(:custom_icons, []).each do |icon_name|
         json.set!(icon_name,
-                  scrolled_theme_asset_path(theme, "icons/#{icon_name}.svg",
+                  scrolled_theme_asset_path(theme, File.join(icons_directory, "#{icon_name}.svg"),
                                             relative_url: true))
       end
     end

--- a/entry_types/scrolled/spec/helpers/pageflow_scrolled/entry_json_seed_helper_spec.rb
+++ b/entry_types/scrolled/spec/helpers/pageflow_scrolled/entry_json_seed_helper_spec.rb
@@ -698,6 +698,7 @@ module PageflowScrolled
           config.themes.register(:default, custom_icons: [:share])
         end
         entry = create(:published_entry, type_name: 'scrolled')
+
         result = render(helper, entry)
 
         expect(result).to include_json(config: {
@@ -705,6 +706,31 @@ module PageflowScrolled
                                            assets: {
                                              icons: {
                                                share: %r{themes/default/icons/share.*svg$}
+                                             }
+                                           }
+                                         }
+                                       })
+      end
+
+      it 'supports custom icons directories' do
+        pageflow_configure do |config|
+          config.themes.register(:default,
+                                 custom_icons: [:share],
+                                 custom_icons_directory: 'icons/someSet')
+        end
+        entry = create(:published_entry, type_name: 'scrolled')
+        theme_directory = Rails.root.join('app/javascript/pageflow-scrolled/themes/default')
+        FileUtils.mkdir_p(theme_directory.join('icons/someSet'))
+        FileUtils.cp(theme_directory.join('icons/share.svg'),
+                     theme_directory.join('icons/someSet/share.svg'))
+
+        result = render(helper, entry)
+
+        expect(result).to include_json(config: {
+                                         theme: {
+                                           assets: {
+                                             icons: {
+                                               share: %r{themes/default/icons/someSet/share.*svg$}
                                              }
                                            }
                                          }


### PR DESCRIPTION
This enabled toggling between different icon sets using theme option overrides.

REDMINE-20841