### PR TITLE
Ignore console error caused by wysihtml5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,6 @@ gem 'capybara-chromedriver-logger', git: 'https://github.com/codevise/capybara-c
 
 # See https://github.com/charkost/prosopite/pull/79
 gem 'prosopite', git: 'https://github.com/tf/prosopite', branch: 'location-backtrace-cleaner'
+
+# Fixes for Chrome that removed DOMNodeRemoved event
+gem 'wysihtml-rails', git: 'https://github.com/codevise/wysihtml-rails', branch: '0-5-5-dom-node-removed-fix'

--- a/spec/support/pageflow/support/config/capybara.rb
+++ b/spec/support/pageflow/support/config/capybara.rb
@@ -37,6 +37,9 @@ Capybara::Chromedriver::Logger.filters = [
   # page sections.
   /Target node has markup rendered by React/i,
 
+  # Caused by wysihtml5 editor using legacy event
+  /Listener added for a 'DOMNodeRemoved' mutation event/,
+
   # Ignore failure of debounced request to save order of storylines
   %r{storylines/order - Failed to load resource: the server responded with a status of 401},
 


### PR DESCRIPTION
Prevent hint about removal of DOMNodeRemoved event from breaking Capybara specs.