### PR TITLE
Fix publishing entry feature spec

### DIFF
--- a/spec/support/dominos/editor/publish_entry_panel.rb
+++ b/spec/support/dominos/editor/publish_entry_panel.rb
@@ -20,7 +20,7 @@ module Dom
         node.find('input[name=publish_until_time]').set(time)
 
         # capybara doesn't hide the datepicker overlay properly
-        blur_input_fields
+        blur_date_field
       end
 
       def save
@@ -53,10 +53,8 @@ module Dom
         node.has_selector?('.publish_entry.published')
       end
 
-      def blur_input_fields
-        node.find('h2').click
-        # Wait for date drop down to fade out
-        sleep 1
+      def blur_date_field
+        node.find('input[name=publish_until]').native.send_keys(:tab)
       end
     end
   end


### PR DESCRIPTION
Apparently the date picker overlay now opens to the top, hiding the header that we were trying to click to blur the input. Hit tab key instead to blur.