### PR TITLE
Do not show cutoff mode indicator on newly created sections

### DIFF
--- a/entry_types/scrolled/package/spec/editor/models/Cutoff-spec.js
+++ b/entry_types/scrolled/package/spec/editor/models/Cutoff-spec.js
@@ -19,4 +19,38 @@ describe('Cutoff', () => {
 
     expect(entry.metadata.configuration.get('cutoff_section_perma_id')).toBeUndefined();
   });
+
+  it('reports cutoff to be at section with matching perma id', () => {
+    const entry = createEntry({
+      metadata: {configuration: {cutoff_section_perma_id: 100}},
+      sections: [
+        {id: 1, permaId: 100},
+        {id: 2, permaId: 101},
+      ]
+    });
+
+    expect(entry.cutoff.isAtSection(entry.sections.get(1))).toEqual(true);
+  });
+
+  it('does not report cutoff to be at section with other perma id', () => {
+    const entry = createEntry({
+      metadata: {configuration: {cutoff_section_perma_id: 100}},
+      sections: [
+        {id: 1, permaId: 100},
+        {id: 2, permaId: 101},
+      ]
+    });
+
+    expect(entry.cutoff.isAtSection(entry.sections.get(2))).toEqual(false);
+  });
+
+  it('does not report cutoff to be at unsafed section when not set', () => {
+    const entry = createEntry({
+      sections: [
+        {id: undefined , permaId: undefined}
+      ]
+    });
+
+    expect(entry.cutoff.isAtSection(entry.sections.first())).toEqual(false);
+  });
 });

--- a/entry_types/scrolled/package/src/editor/models/Cutoff.js
+++ b/entry_types/scrolled/package/src/editor/models/Cutoff.js
@@ -20,7 +20,10 @@ export const Cutoff = Object.extend({
   },
 
   isAtSection(section) {
-    return this.entry.metadata.configuration.get('cutoff_section_perma_id') === section.get('permaId');
+    const cutoffSectionPermaId =
+      this.entry.metadata.configuration.get('cutoff_section_perma_id');
+
+    return !!cutoffSectionPermaId && cutoffSectionPermaId === section.get('permaId');
   },
 
   reset() {


### PR DESCRIPTION
When no cutoff section has been set, new sections, which do not have a perma id yet, were recognized as matching the cutoff section perma id.

REDMINE-20674