### PR TITLE
Prevent last section from extending beyond footer

### DIFF
--- a/entry_types/scrolled/package/src/frontend/Content.module.css
+++ b/entry_types/scrolled/package/src/frontend/Content.module.css
@@ -1,5 +1,6 @@
 .Content {
   font-family: var(--theme-entry-font-family);
+  overflow: clip;
 }
 
 @media screen {


### PR DESCRIPTION
When the last section does not use full height, depending on its transition settings, its backdrop can still have full viewport height. This can cause the document to expand vertically resulting in empty space below the footer.

REDMINE-20872