### PR TITLE
Hide caption variants select if only one item

### DIFF
--- a/app/assets/stylesheets/pageflow/ui/forms.scss
+++ b/app/assets/stylesheets/pageflow/ui/forms.scss
@@ -121,6 +121,10 @@ textarea.short {
   .separator {
     border-top: solid 1px var(--ui-on-surface-color-lightest);
     margin: space(4) 0;
+
+    &:last-child {
+      display: none;
+    }
   }
 }
 

--- a/entry_types/scrolled/package/src/editor/views/configurationEditors/groups/CommonContentElementAttributes.js
+++ b/entry_types/scrolled/package/src/editor/views/configurationEditors/groups/CommonContentElementAttributes.js
@@ -125,19 +125,21 @@ ConfigurationEditorTabView.groups.define(
       name: 'figureCaption'
     });
 
-    this.input('captionVariant', SelectInputView, {
-      attributeTranslationKeyPrefixes: [
-        'pageflow_scrolled.editor.common_content_element_attributes'
-      ],
-      includeBlank: true,
-      blankTranslationKey: 'pageflow_scrolled.editor.' +
-                           'common_content_element_attributes.' +
-                           'captionVariant.blank',
-      values: variants,
-      texts,
-      disabledBindingModel: this.model.parent.transientState,
-      disabledBinding: 'hasCaption',
-      disabled: hasCaption => disableWhenNoCaption && !hasCaption
-    });
+    if (variants.length) {
+      this.input('captionVariant', SelectInputView, {
+        attributeTranslationKeyPrefixes: [
+          'pageflow_scrolled.editor.common_content_element_attributes'
+        ],
+        includeBlank: true,
+        blankTranslationKey: 'pageflow_scrolled.editor.' +
+                             'common_content_element_attributes.' +
+                             'captionVariant.blank',
+        values: variants,
+        texts,
+        disabledBindingModel: this.model.parent.transientState,
+        disabledBinding: 'hasCaption',
+        disabled: hasCaption => disableWhenNoCaption && !hasCaption
+      });
+    }
   }
 );


### PR DESCRIPTION
Also hide separator if last child of configuration editor tab.