### PR TITLE
Pass PublishedEntry when transforming theme customization overrides

### DIFF
--- a/app/models/pageflow/entry_at_revision.rb
+++ b/app/models/pageflow/entry_at_revision.rb
@@ -45,7 +45,7 @@ module Pageflow
     end
 
     def theme
-      @theme ||= CustomizedTheme.find(entry: entry, theme: revision.theme)
+      @theme ||= CustomizedTheme.find(entry: self, theme: revision.theme)
     end
 
     def home_button

--- a/lib/pageflow/theme_customizations.rb
+++ b/lib/pageflow/theme_customizations.rb
@@ -23,7 +23,7 @@ module Pageflow
 
       theme_customization.assign_attributes(overrides: overrides, selected_file_ids: file_ids)
 
-      theme = CustomizedTheme.build(entry: entry,
+      theme = CustomizedTheme.build(entry: PublishedEntry.new(entry, entry.draft),
                                     theme: entry.draft.theme,
                                     theme_customization: theme_customization)
 

--- a/spec/pageflow/theme_customizations_spec.rb
+++ b/spec/pageflow/theme_customizations_spec.rb
@@ -195,7 +195,7 @@ module Pageflow
 
       expect(transform)
         .to have_received(:call).with({colors: {accent: '#0f0'}},
-                                      entry: entry.to_model,
+                                      entry:,
                                       theme: entry.revision.theme)
     end
 
@@ -219,7 +219,7 @@ module Pageflow
 
       expect(transform)
         .to have_received(:call).with({colors: {accent: '#0f0'}},
-                                      entry: entry.to_model,
+                                      entry: kind_of(PublishedEntry),
                                       theme: entry.draft.theme)
     end
 
@@ -416,7 +416,7 @@ module Pageflow
                                           small: %r{small/image.png}
                                         }
                                       },
-                                      entry: entry.to_model,
+                                      entry:,
                                       theme: entry.revision.theme)
     end
 


### PR DESCRIPTION
Make it possible to rewrite overrides based on revision configuration (i.e. appearance settings). To keep the interface consistent, we need to construct a preliminary PublishedEntry to pass when previewing a theme customization.

REDMINE-20892