### PR TITLE
Add editor API to add additional appearance inputs

### DIFF
--- a/package/spec/editor/views/EditMetaDataView-spec.js
+++ b/package/spec/editor/views/EditMetaDataView-spec.js
@@ -52,6 +52,27 @@ describe('EditMetaDataView', () => {
     ]));
   });
 
+  it('renders additional appearance inputs on widgets tab', () => {
+    const entry = factories.entry();
+    const editor = factories.editorApi();
+    editor.registerAppearanceInputs(tabView => {
+      tabView.input('cheese', CheckBoxInputView);
+    });
+    const view = new EditMetaDataView({
+      model: entry,
+      tab: 'widgets',
+      editor
+    });
+
+    view.render();
+    var configurationEditor = ConfigurationEditor.find(view);
+
+    expect(configurationEditor.tabNames()).toEqual(expect.arrayContaining(['widgets']));
+    expect(configurationEditor.inputPropertyNames()).toEqual(expect.arrayContaining([
+      'cheese'
+    ]));
+  });
+
   support.useFakeTranslations({
     'pageflow.entry_types.strange.editor.entry_metadata_configuration_attributes.quark.label': 'Up',
     'pageflow.entry_types.strange.editor.entry_metadata_configuration_attributes.quark.inline_help': 'Help yourself!'

--- a/package/src/editor/api/index.js
+++ b/package/src/editor/api/index.js
@@ -32,6 +32,7 @@ export const EditorApi = Object.extend(
     this.mainMenuItems = [];
     this.initializers = [];
     this.fileSelectionHandlers = {};
+    this.appearanceInputsCallbacks = [];
 
     /**
      * Failures API
@@ -182,6 +183,17 @@ export const EditorApi = Object.extend(
    */
   registerMainMenuItem: function(options) {
     this.mainMenuItems.push(options);
+  },
+
+  /**
+   * Register additional inputs to show in the appearance tab under
+   * title and options. Passed callback receives tabView and options
+   * with entry.
+   *
+   * @since edge
+   */
+  registerAppearanceInputs(callback) {
+    this.appearanceInputsCallbacks.push(callback);
   },
 
   /**

--- a/package/src/editor/views/EditMetaDataView.js
+++ b/package/src/editor/views/EditMetaDataView.js
@@ -77,6 +77,11 @@ export const EditMetaDataView = Marionette.Layout.extend({
           entry,
           site: state.site
         });
+
+      editor.appearanceInputsCallbacks.forEach(callback => {
+        callback(this, {entry})
+      });
+
       entry.widgets && this.view(EditWidgetsView, {
         model: entry,
         widgetTypes: editor.widgetTypes


### PR DESCRIPTION
So far there was only a way for entry types to add inputs. Now we can also add inputs from additional editor packs to add theme specific options.

REDMINE-20892