### PR TITLE
Add scopes for light and dark content

### DIFF
--- a/entry_types/scrolled/package/spec/support/__spec__/stories-spec.js
+++ b/entry_types/scrolled/package/spec/support/__spec__/stories-spec.js
@@ -80,6 +80,14 @@ describe('exampleStories', () => {
           properties: {
             root: {
               accentColor: 'red'
+            },
+            dark: {
+              accentColor: 'green'
+            }
+          },
+          typography: {
+            heading: {
+              fontWeight: 'bold'
             }
           }
         }
@@ -102,9 +110,17 @@ describe('exampleStories', () => {
         })
       }),
       cssRules: {
-        root: {
+        ':root': {
           '--theme-accent-color': 'red'
-        }
+        },
+
+        '.scope-dark': {
+          '--theme-accent-color': 'green'
+        },
+
+        '.typography-heading': {
+          'font-weight': 'bold'
+        },
       }
     }));
   });

--- a/entry_types/scrolled/package/spec/support/stories.js
+++ b/entry_types/scrolled/package/spec/support/stories.js
@@ -103,10 +103,18 @@ export function storiesOfContentElement(module, options) {
   });
 }
 
+export function ExampleEntry({seed}) {
+  return (
+    <RootProviders seed={seed}>
+      <style>
+        {renderCss(themeOptionsCssRules(seed.config.theme.options))}
+      </style>
+      <Entry />
+    </RootProviders>
+  );
+}
 function renderCss(rules) {
-  return Object.entries(rules).map(([name, properties]) => {
-    const selector = (name === 'root' ? ':root' : `.scope-${name}`);
-
+  return Object.entries(rules).map(([selector, properties]) => {
     const declations = Object.entries(properties).map(([key, value]) =>
       `${key}: ${value};`
     ).join('\n');
@@ -340,19 +348,32 @@ function exampleStoryGroup({
     }),
     requireConsentOptIn: !!consentVendors,
     parameters,
-    cssRules: Object.entries(examples[index].themeOptions?.properties || {}).reduce(
+    cssRules: themeOptionsCssRules(examples[index].themeOptions)
+  }));
+}
+
+function themeOptionsCssRules(themeOptions) {
+  return {
+    ...Object.entries(themeOptions?.typography || {}).reduce(
       (result, [scope, properties]) => {
-        result[scope] = themeCssProperties(properties);
+        result[`.typography-${scope}`] = cssProperties(properties);
+        return result;
+      },
+      {}
+    ),
+    ...Object.entries(themeOptions?.properties || {}).reduce(
+      (result, [scope, properties]) => {
+        result[scope === 'root' ? ':root' : `.scope-${scope}`] = cssProperties(properties, '--theme-');
         return result;
       },
       {}
     )
-  }));
+  }
 }
 
-function themeCssProperties(properties) {
+function cssProperties(properties, prefix = '') {
   return Object.keys(properties).reduce((result, key) => {
-    result[`--theme-${dasherize(key)}`] = properties[key];
+    result[`${prefix}${dasherize(key)}`] = properties[key];
     return result;
   }, {});
 }

--- a/entry_types/scrolled/package/src/frontend/Section.js
+++ b/entry_types/scrolled/package/src/frontend/Section.js
@@ -56,7 +56,7 @@ const Section = withInlineEditingDecorator('SectionDecorator', function Section(
                                    backdropSectionClassNames,
                                    {[styles.first]: section.sectionIndex === 0},
                                    {[styles.narrow]: section.width === 'narrow'},
-                                   {[styles.invert]: section.invert})}
+                                   section.invert ? styles.darkContent : styles.lightContent)}
              style={useBackdropSectionCustomProperties(backdrop)}>
       <SectionLifecycleProvider onActivate={onActivate}
                                 entersWithFadeTransition={section.transition?.startsWith('fade')}>

--- a/entry_types/scrolled/package/src/frontend/Section.module.css
+++ b/entry_types/scrolled/package/src/frontend/Section.module.css
@@ -67,15 +67,23 @@
     var(--theme-narrow-section-centered-inline-xl-content-max-width);
 }
 
+.lightContent {
+  composes: scope-lightContent from global;
+}
+
+.darkContent {
+  composes: scope-darkContent from global;
+}
+
 @media screen {
-  .Section {
+  .lightContent {
     color: lightContentTextColor;
     --content-text-color: lightContentTextColor;
     --content-link-color: lightContentLinkColor;
     background-color: #000;
   }
 
-  .invert {
+  .darkContent {
     background-color: #fff;
     color: darkContentTextColor;
     --content-text-color: darkContentTextColor;

--- a/entry_types/scrolled/package/src/frontend/__stories__/lightDarkContentScopes-stories.js
+++ b/entry_types/scrolled/package/src/frontend/__stories__/lightDarkContentScopes-stories.js
@@ -1,0 +1,101 @@
+import React from 'react';
+
+import {
+  normalizeAndMergeFixture,
+  exampleHeading,
+  exampleTextBlock,
+  ExampleEntry
+} from 'pageflow-scrolled/spec/support/stories';
+
+import {storiesOf} from '@storybook/react';
+storiesOf(`Frontend`, module)
+  .add(
+    'Light and Dark Content Scopes',
+    () => {
+      const themeOptions = {
+        properties: {
+          darkContent: {
+            accentColor: 'green'
+          },
+
+          lightContent: {
+            accentColor: 'yellow'
+          }
+        },
+        typography: {
+          heading: {
+            color: 'var(--theme-accent-color)'
+          }
+        }
+      };
+
+      return (
+        <ExampleEntry seed={exampleSeed(themeOptions)} />
+      );
+    }
+  )
+
+function exampleSeed(themeOptions) {
+  const sectionBaseConfiguration = {
+    transition: 'reveal'
+  };
+
+  return normalizeAndMergeFixture({
+    themeOptions,
+    sections: [
+      {
+        id: 1,
+        configuration: {
+          ...sectionBaseConfiguration,
+          backdrop: {
+            color: '#cad2c5'
+          }
+        }
+      },
+      {
+        id: 2,
+        configuration: {
+          ...sectionBaseConfiguration,
+          invert: true,
+          backdrop: {
+            color: '#cad2c5'
+          }
+        }
+      },
+      {
+        id: 3,
+        configuration: {
+          ...sectionBaseConfiguration,
+          appearance: 'cards',
+          backdrop: {
+            color: '#cad2c5'
+          }
+        }
+      },
+      {
+        id: 4,
+        configuration: {
+          ...sectionBaseConfiguration,
+          appearance: 'cards',
+          invert: true,
+          backdrop: {
+            color: '#cad2c5'
+          }
+        }
+      }
+    ],
+    contentElements: [
+      ...exampleContentElements(1),
+      ...exampleContentElements(2),
+      ...exampleContentElements(3),
+      ...exampleContentElements(4)
+    ]
+  });
+
+  function exampleContentElements(sectionId) {
+    return [
+      exampleHeading({sectionId, text: 'A Heading'}),
+      exampleTextBlock({sectionId}),
+    ];
+  }
+}

--- a/entry_types/scrolled/package/src/frontend/foregroundBoxes/CardBoxWrapper.module.css
+++ b/entry_types/scrolled/package/src/frontend/foregroundBoxes/CardBoxWrapper.module.css
@@ -62,6 +62,14 @@
   border-bottom-right-radius: var(--theme-cards-border-radius, 15px);
 }
 
+.cardBgWhite {
+  composes: scope-darkContent from global;
+}
+
+.cardBgBlack {
+  composes: scope-lightContent from global;
+}
+
 @media screen {
   .cardBgWhite::before {
     background-color: lightContentSurfaceColor;


### PR DESCRIPTION
While we already have separate theme properties for dark and light content text color etc. these scopes allow setting other theme properties like accent colors differently for dark and light content.

REDMINE-20892