### PR TITLE
Prevent error when deleting content element with transient state

### DIFF
--- a/entry_types/scrolled/package/spec/editor/controllers/PreviewMessageController-spec.js
+++ b/entry_types/scrolled/package/spec/editor/controllers/PreviewMessageController-spec.js
@@ -453,6 +453,20 @@ describe('PreviewMessageController', () => {
     })).resolves.toEqual({some: 'state'});
   });
 
+  it('ignores transient state updates of content element that has just been removed', () => {
+    const entry = factories.entry(ScrolledEntry, {}, {
+      entryTypeSeed: normalizeSeed({
+        contentElements: []
+      })
+    });
+    const iframeWindow = createIframeWindow();
+    controller = new PreviewMessageController({entry, iframeWindow});
+
+    return expect(() => {
+      postUpdateTransientContentElementStateMessage({id: 5, state: {some: 'state'}});
+    }).not.toThrowError();
+  });
+
   it('sends CHANGE_EMULATION_MODE message to iframe on change:emulation_mode event on model', async () => {
     const entry = factories.entry(ScrolledEntry, {}, {
       entryTypeSeed: normalizeSeed({

--- a/entry_types/scrolled/package/src/editor/controllers/PreviewMessageController.js
+++ b/entry_types/scrolled/package/src/editor/controllers/PreviewMessageController.js
@@ -158,7 +158,9 @@ export const PreviewMessageController = Object.extend({
       }
       else if (message.data.type === 'UPDATE_TRANSIENT_CONTENT_ELEMENT_STATE') {
         const {id, state} = message.data.payload;
-        this.entry.contentElements.get(id).set('transientState', state);
+        const contentElement = this.entry.contentElements.get(id);
+
+        contentElement && contentElement.set('transientState', state);
       }
       else if (message.data.type === 'SAVED_SCROLL_POINT' && this.currentScrollPointCallback) {
         this.currentScrollPointCallback();


### PR DESCRIPTION
Unmounting the component can cause useEffect to run that triggers a transient state update. Ignore update messages for elements that are not present in Backbone collection.