### PR TITLE
Allow hiding chapters in navigation

### DIFF
--- a/entry_types/scrolled/config/locales/de.yml
+++ b/entry_types/scrolled/config/locales/de.yml
@@ -560,10 +560,8 @@ de:
       edit_chapter:
         attributes:
           summary:
-            inline_help: Zusammenfassung des Kapitels für die Darstellung in der Navigationsleiste. Nur Kapitel die sowohl Titel als auch Zusammenfassung gesetzt haben werden als Menüpunkt zur Navigation hinzugefügt.
             label: Zusammenfassung
           title:
-            inline_help: Wird in der Editor-Übersicht und der Navigationsleiste des Beitrags angezeigt. Nur Kapitel die sowohl Titel als auch Zusammenfassung gesetzt haben werden als Menüpunkt zur Navigation hinzugefügt.
             label: Titel
         confirm_destroy: |-
           Kapitel einschließlich ALLER enthaltener Abschnitte wirklich löschen?

--- a/entry_types/scrolled/config/locales/en.yml
+++ b/entry_types/scrolled/config/locales/en.yml
@@ -552,10 +552,8 @@ en:
       edit_chapter:
         attributes:
           summary:
-            inline_help: Summary of the chapter for display in the navigation bar. Only chapters with both title and summary set will get added as menu items to the navigation.
             label: Summary
           title:
-            inline_help: The chapter title will be displayed in the editor overview and the navigation bar of the entry. Only chapters with both title and summary set will get added as menu items to the navigation.
             label: Title
         confirm_destroy: |-
           Really delete this chapter including ALL its sections?

--- a/entry_types/scrolled/config/locales/new/hide_chapter.de.yml
+++ b/entry_types/scrolled/config/locales/new/hide_chapter.de.yml
@@ -1,0 +1,27 @@
+de:
+  pageflow_scrolled:
+    editor:
+      chapter_item:
+        chapter: Kapitel
+        unnamed: Unbenannt
+        hidden_in_navigation: In der Navigationsleiste ausgeblendet
+      edit_chapter:
+        attributes:
+          hideInNavigation:
+            label: In der Navigationsleiste ausblenden
+            inline_help: |-
+              Kapitel kann als Link-Ziel verwendet werden, erscheint
+              allerdings nicht in der Navigationsleiste.
+          summary:
+            inline_help: Zusammenfassung des Kapitels für die Darstellung in der Navigationsleiste.
+          title:
+            inline_help: |-
+              Der Titel des Kapitels erscheint in der
+              Navigationsleiste. Er wird außerdem verwendet, um den
+              Teil der Webadresse zu erstellen, der es ermöglicht,
+              direkt zu diesem Kapitel zu springen.<br><br>
+
+              Zum Beispiel: Wenn dein Kapitel 'Unsere Mission' heißt,
+              kann man über eine Webadresse der Form
+              <code>yourwebsite.com/story#unsere-mission</code> direkt
+              zu diesem Kapitel springen.

--- a/entry_types/scrolled/config/locales/new/hide_chapter.en.yml
+++ b/entry_types/scrolled/config/locales/new/hide_chapter.en.yml
@@ -1,0 +1,26 @@
+en:
+  pageflow_scrolled:
+    editor:
+      chapter_item:
+        chapter: Chapter
+        unnamed: Untitled
+        hidden_in_navigation: Hidden in navigation bar
+      edit_chapter:
+        attributes:
+          hideInNavigation:
+            label: Hide in navigation bar
+            inline_help: |-
+              Chapter can be used as link destination but does not
+              appear in the navigation bar.
+          summary:
+            inline_help: Summary of the chapter for display in the navigation bar.
+          title:
+            inline_help_html: |-
+              The title of the chapter appears in the navigation
+              bar. It is also used to create the part of the web
+              address that helps link directly to that chapter.<br><br>
+
+              For example, if your chapter is titled 'Our Mission,'
+              the system will create a web address like
+              <code>yourwebsite.com/story#our-mission</code>, so
+              people can jump straight to that chapter

--- a/entry_types/scrolled/package/spec/editor/views/ChapterItemView-spec.js
+++ b/entry_types/scrolled/package/spec/editor/views/ChapterItemView-spec.js
@@ -1,0 +1,69 @@
+import {ChapterItemView} from 'editor/views/ChapterItemView';
+
+import {useEditorGlobals, useFakeXhr, useReactBasedBackboneViews} from 'support';
+import {screen} from '@testing-library/dom';
+import {useFakeTranslations} from 'pageflow/testHelpers';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('ChapterItemView', () => {
+  useFakeXhr();
+
+  useFakeTranslations({
+    'pageflow_scrolled.editor.chapter_item.chapter': 'Chapter',
+    'pageflow_scrolled.editor.chapter_item.drag_hint': 'Drag',
+    'pageflow_scrolled.editor.chapter_item.save_error': 'Error',
+    'pageflow_scrolled.editor.chapter_item.hidden_in_navigation': 'Hidden in navigation',
+  });
+
+  const {createEntry} = useEditorGlobals();
+  const {render} = useReactBasedBackboneViews();
+
+  it('renders chapter link', async () => {
+    const entry = createEntry({
+      chapters: [
+        {
+          id: 1,
+          permaId: 100,
+          position: 0,
+          configuration: {
+            title: 'Some title'
+          }
+        }
+      ]
+    });
+    const chapter = entry.chapters.get(1)
+    const view = new ChapterItemView({
+      entry,
+      model: chapter
+    });
+
+    render(view);
+
+    expect(screen.getByRole('link', {name: /Chapter 1 Some title/})).toBeInTheDocument();
+  });
+
+  it('marks chapter as hidden in navigation', async () => {
+    const entry = createEntry({
+      chapters: [
+        {
+          id: 1,
+          permaId: 100,
+          position: 0,
+          configuration: {
+            title: 'Some title',
+            hideInNavigation: true
+          }
+        }
+      ]
+    });
+    const chapter = entry.chapters.get(1)
+    const view = new ChapterItemView({
+      entry,
+      model: chapter
+    });
+
+    render(view);
+
+    expect(screen.getByRole('generic', {name: 'Hidden in navigation'})).toBeInTheDocument();
+  });
+});

--- a/entry_types/scrolled/package/spec/entryState/structure-spec.js
+++ b/entry_types/scrolled/package/spec/entryState/structure-spec.js
@@ -30,7 +30,8 @@ const chaptersSeed = [
     position: 2,
     configuration: {
       title: 'Chapter 2',
-      summary: 'A great chapter'
+      summary: 'A great chapter',
+      hideInNavigation: true
     }
   }
 ];
@@ -336,7 +337,8 @@ describe('useChapters', () => {
         chapterSlug: 'chapter-2',
         index: 1,
         title: 'Chapter 2',
-        summary: 'A great chapter'
+        summary: 'A great chapter',
+        hideInNavigation: true
       }
     ]);
   });

--- a/entry_types/scrolled/package/spec/widgets/defaultNavigation/Defaultnavigation-spec.js
+++ b/entry_types/scrolled/package/spec/widgets/defaultNavigation/Defaultnavigation-spec.js
@@ -102,6 +102,25 @@ describe('DefaultNavigation', () => {
     expect(getByRole('img', {name: 'Other logo'})).toHaveAttribute('src', 'other-logo.png');
   });
 
+  it('does not render chapters that have hide in navigation flag', () => {
+    const {queryByRole} = renderInEntry(
+      <DefaultNavigation configuration={{}} />,
+      {
+        seed: {
+          chapters: [
+            {configuration: {title: 'First chapter'}},
+            {configuration: {title: 'Hidden chapter', hideInNavigation: true}},
+            {configuration: {title: 'Second chapter'}}
+          ]
+        }
+      }
+    );
+
+    expect(queryByRole('link', {name: 'First chapter'})).not.toBeNull();
+    expect(queryByRole('link', {name: 'Second chapter'})).not.toBeNull();
+    expect(queryByRole('link', {name: 'Hidden chapter'})).toBeNull();
+  });
+
   it('supports extra buttons component', () => {
     const ExtraButtons = () => <button>Extra</button>;
     const {queryByRole} = renderInEntry(
@@ -141,6 +160,22 @@ describe('DefaultNavigation', () => {
     );
 
     expect(queryByRole('button', {name: 'Open mobile menu'})).not.toBeNull();
+  });
+
+  it('does not render mobile menu button if all chapters are hidden', () => {
+    const {queryByRole} = renderInEntry(
+      <DefaultNavigation configuration={{}} />,
+      {
+        seed: {
+          chapters: [
+            {configuration: {hideInNavigation: true}},
+            {configuration: {hideInNavigation: true}}
+          ]
+        }
+      }
+    );
+
+    expect(queryByRole('button', {name: 'Open mobile menu'})).toBeNull();
   });
 
   it('toggles class to show and hide mobile menu', async () => {

--- a/entry_types/scrolled/package/src/editor/views/ChapterItemView.js
+++ b/entry_types/scrolled/package/src/editor/views/ChapterItemView.js
@@ -67,7 +67,18 @@ export const ChapterItemView = Marionette.Layout.extend({
   },
 
   update() {
-    this.ui.title.text(this.model.configuration.get('title') || I18n.t('pageflow.editor.views.chapter_item_view.unnamed'));
-    this.ui.number.text(I18n.t('pageflow.editor.views.chapter_item_view.chapter') + ' ' + (this.model.get('position') + 1));
+    this.ui.title.text(
+      this.model.configuration.get('title') || I18n.t('pageflow_scrolled.editor.chapter_item.unnamed')
+    );
+    this.ui.title.toggleClass(styles.blank, !this.model.configuration.get('title'));
+
+    this.ui.number.text(
+      I18n.t('pageflow_scrolled.editor.chapter_item.chapter') + ' ' + (this.model.get('position') + 1)
+    );
+
+    if (this.model.configuration.get('hideInNavigation')) {
+      this.ui.title.attr('title', I18n.t('pageflow_scrolled.editor.chapter_item.hidden_in_navigation'));
+      this.ui.title.addClass(styles.hiddenInNavigation);
+    }
   }
 });

--- a/entry_types/scrolled/package/src/editor/views/ChapterItemView.module.css
+++ b/entry_types/scrolled/package/src/editor/views/ChapterItemView.module.css
@@ -42,7 +42,21 @@
   font-weight: bold;
 }
 
-.title {}
+.root:first-child:last-child .title.blank {
+  display: none;
+}
+
+.hiddenInNavigation {
+  opacity: 0.7;
+}
+
+.hiddenInNavigation::before {
+  content: "(";
+}
+
+.hiddenInNavigation::after {
+  content: ")";
+}
 
 .sections {
   composes: sections from './outline.module.css';

--- a/entry_types/scrolled/package/src/editor/views/EditChapterView.js
+++ b/entry_types/scrolled/package/src/editor/views/EditChapterView.js
@@ -1,5 +1,5 @@
 import {EditConfigurationView} from 'pageflow/editor';
-import {TextInputView, TextAreaInputView} from 'pageflow/ui';
+import {CheckBoxInputView, TextInputView, TextAreaInputView} from 'pageflow/ui';
 
 export const EditChapterView = EditConfigurationView.extend({
   translationKeyPrefix: 'pageflow_scrolled.editor.edit_chapter',
@@ -7,6 +7,7 @@ export const EditChapterView = EditConfigurationView.extend({
   configure: function(configurationEditor) {
     configurationEditor.tab('chapter', function() {
       this.input('title', TextInputView);
+      this.input('hideInNavigation', CheckBoxInputView);
       this.input('summary', TextAreaInputView, {
         disableLinks: true
       });

--- a/entry_types/scrolled/package/src/entryState/structure.js
+++ b/entry_types/scrolled/package/src/entryState/structure.js
@@ -269,7 +269,8 @@ export function useChapters() {
         index,
         title: chapter.configuration.title,
         summary: chapter.configuration.summary,
-        chapterSlug: chapterSlug
+        chapterSlug: chapterSlug,
+        hideInNavigation: chapter.configuration.hideInNavigation
       });
     });
   }, [chapters]);

--- a/entry_types/scrolled/package/src/widgets/defaultNavigation/DefaultNavigation.js
+++ b/entry_types/scrolled/package/src/widgets/defaultNavigation/DefaultNavigation.js
@@ -36,8 +36,10 @@ export function DefaultNavigation({
   const [navExpanded, setNavExpanded] = useState(true);
   const [mobileNavHidden, setMobileNavHidden] = useState(!configuration.defaultMobileNavVisible);
   const [readingProgress, setReadingProgress] = useState(0);
-  const chapters = useChapters();
+
+  const chapters = useChapters().filter(chapter => !chapter.hideInNavigation);
   const currentChapter = useCurrentChapter();
+
   const isPhonePlatform = usePhonePlatform();
   const shareProviders = useShareProviders({isPhonePlatform});
   const theme = useTheme();


### PR DESCRIPTION
* Fix inline help text in edit chapter view that claimed chapters where hidden if title or description are blank.

* Show title of hidden chapters in brackets in outline.

* Hide blank title of sole-chapter to prevent entries with only one chapter from looking incomplete.

* Filter out hidden chapters from entry state in default navigation.

REDMINE-20961