### PR TITLE
Prevent tall stand-alone elements from breaking layout

### DIFF
--- a/entry_types/scrolled/package/src/frontend/ContentElementScrollSpace.module.css
+++ b/entry_types/scrolled/package/src/frontend/ContentElementScrollSpace.module.css
@@ -1,5 +1,5 @@
 .wrapper {
-  height: 130vh;
+  min-height: 130vh;
 }
 
 .inner {
@@ -9,7 +9,7 @@
 
 @supports (height: 100lvh) {
   .wrapper {
-    height: 130lvh;
+    min-height: 130lvh;
   }
 
   .inner {


### PR DESCRIPTION
If the element itself, e.g. a list of teasers, is already taller than the viewport, the stand-alone effect does not make sense. Prevent the spacer height from restricting the height of the element, causing it to overflow over the following elements.