### PR TITLE
Allow entry specific public_entry_url_options

### DIFF
--- a/app/helpers/pageflow/entries_helper.rb
+++ b/app/helpers/pageflow/entries_helper.rb
@@ -46,7 +46,7 @@ module Pageflow
         params =
           options
           .reverse_merge(trailing_slash: entry.site.trailing_slash_in_canonical_urls)
-          .reverse_merge(Pageflow.config.site_url_options(entry.site) || {})
+          .reverse_merge(Pageflow.config_for(entry).public_entry_url_options_for(entry) || {})
 
         if entry.permalink.present?
           routes.permalink_url(*entry_permalink_parts(entry), params)

--- a/app/helpers/pageflow/feeds_helper.rb
+++ b/app/helpers/pageflow/feeds_helper.rb
@@ -14,7 +14,7 @@ module Pageflow
           {
             locale: entry.locale,
             format: 'atom'
-          }.merge(Pageflow.config.site_url_options(entry.site) || {})
+          }.merge(Pageflow.config.site_url_options_for(entry.site) || {})
         )
 
       tag(:link,

--- a/app/helpers/pageflow/hreflang_links_helper.rb
+++ b/app/helpers/pageflow/hreflang_links_helper.rb
@@ -8,11 +8,8 @@ module Pageflow
     # Render alternate links to all published entries that have been
     # marked as translations of the given entry.
     def hreflang_link_tags_for_entry(entry)
-      translations =
-        entry.translations(-> { preload(:site, :translation_group, permalink: :directory) })
-
       safe_join(
-        translations.each_with_object([]) do |translation, links|
+        translations_for_hreflang_links(entry).each_with_object([]) do |translation, links|
           links << hreflang_link_tag(translation)
 
           if translation.default_translation?
@@ -23,6 +20,12 @@ module Pageflow
     end
 
     private
+
+    def translations_for_hreflang_links(entry)
+      entry.translations(
+        -> { preload(:site, :account, :translation_group, permalink: :directory) }
+      )
+    end
 
     def hreflang_link_tag(entry, hreflang: entry.locale)
       tag('link',

--- a/app/helpers/pageflow/sites_helper.rb
+++ b/app/helpers/pageflow/sites_helper.rb
@@ -1,11 +1,11 @@
 module Pageflow
   module SitesHelper
-    DEFAULT_PUBLIC_ENTRY_OPTIONS = lambda do |site|
+    DEFAULT_SITE_URL_OPTIONS = lambda do |site|
       site.cname.present? ? {host: site.cname} : nil
     end
 
     def pretty_site_url(site)
-      pageflow.public_root_url(Pageflow.config.site_url_options(site))
+      pageflow.public_root_url(Pageflow.config.site_url_options_for(site))
     end
   end
 end

--- a/app/models/pageflow/home_button.rb
+++ b/app/models/pageflow/home_button.rb
@@ -29,7 +29,7 @@ module Pageflow
 
     def site_home_button_url
       if site.home_url.present?
-        options = Pageflow.config.site_url_options(site) || {}
+        options = Pageflow.config.site_url_options_for(site) || {}
         Pageflow::Engine.routes.url_for(options.merge(controller: 'pageflow/entries',
                                                       action: 'index',
                                                       only_path: !options[:host]))

--- a/app/models/pageflow/site.rb
+++ b/app/models/pageflow/site.rb
@@ -23,7 +23,7 @@ module Pageflow
     end
 
     def host
-      Pageflow.config.site_url_options(self)&.dig(:host)
+      Pageflow.config.site_url_options_for(self)&.dig(:host)
     end
 
     def cname_domain

--- a/app/models/pageflow/sitemaps.rb
+++ b/app/models/pageflow/sitemaps.rb
@@ -5,9 +5,11 @@ module Pageflow
       PublishedEntry.wrap_all(
         site
           .entries
-          .preload(permalink: :directory,
+          .preload(:account,
+                   permalink: :directory,
                    translation_group: {
                      publicly_visible_entries: [
+                       :account,
                        :published_revision,
                        {permalink: :directory}
                      ]

--- a/entry_types/scrolled/app/views/pageflow_scrolled/entry_json_seed/_entry_translations.json.jbuilder
+++ b/entry_types/scrolled/app/views/pageflow_scrolled/entry_json_seed/_entry_translations.json.jbuilder
@@ -1,5 +1,5 @@
 json.entry_translations do
-  json.array!(entry.translations(-> { preload(:site) }, include_noindex: true)) do |translation|
+  json.array!(entry.translations(-> { preload(:site, :account) }, include_noindex: true)) do |translation|
     json.(translation, :id, :locale)
     json.display_locale public_locale_name_for(translation.locale)
 

--- a/spec/helpers/pageflow/sites_helper_spec.rb
+++ b/spec/helpers/pageflow/sites_helper_spec.rb
@@ -26,8 +26,26 @@ module Pageflow
         expect(helper.pretty_site_url(site)).to eq('http://public.example.com/')
       end
 
-      it 'can be configured via lambda in public_entry_url_options' do
-        Pageflow.config.public_entry_url_options = lambda { |site| {host: "#{site.account.name}.example.com" } }
+      it 'can be configured via legacy lambda in public_entry_url_options' do
+        Pageflow.config.public_entry_url_options = lambda do |site|
+          {host: "#{site.account.name}.example.com"}
+        end
+        account = create(:account, name: 'myaccount')
+
+        expect(helper.pretty_site_url(account.default_site)).to eq('http://myaccount.example.com/')
+      end
+
+      it 'can be configured via hash in site_url_options' do
+        Pageflow.config.site_url_options = {host: 'some.example.com'}
+        account = create(:account)
+
+        expect(helper.pretty_site_url(account.default_site)).to eq('http://some.example.com/')
+      end
+
+      it 'can be configured via lambda in site_url_options' do
+        Pageflow.config.site_url_options = lambda do |site|
+          {host: "#{site.account.name}.example.com"}
+        end
         account = create(:account, name: 'myaccount')
 
         expect(helper.pretty_site_url(account.default_site)).to eq('http://myaccount.example.com/')

--- a/spec/models/pageflow/site_spec.rb
+++ b/spec/models/pageflow/site_spec.rb
@@ -33,7 +33,17 @@ module Pageflow
     end
 
     describe '#host' do
-      it 'returns host based on public_entry_url_options' do
+      it 'returns host based on site_url_options' do
+        Pageflow.config.site_url_options = lambda do |site|
+          {host: "#{site.name}.example.com"}
+        end
+
+        site = build(:site, name: 'some')
+
+        expect(site.host).to eq('some.example.com')
+      end
+
+      it 'returns host based on legacy public_entry_url_options' do
         Pageflow.config.public_entry_url_options = lambda do |site|
           {host: "#{site.name}.example.com"}
         end


### PR DESCRIPTION
Split off `site_url_options` and pass entry instead of site to `public_entry_url_options` if both config options are defined. Allow defining `public_entry_url_options` in feature flag.

REDMINE-20969