### PR TITLE
Fix display of justified lists in center ragged lists in editor

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/textBlock/TextBlock.module.css
+++ b/entry_types/scrolled/package/src/contentElements/textBlock/TextBlock.module.css
@@ -120,6 +120,7 @@
   text-align: center;
 }
 
-.layout-centerRagged {
-  --editable-text-list-style-position: inside;
+.layout-centerRagged ol,
+.layout-centerRagged ul {
+  list-style-position: inside;
 }

--- a/entry_types/scrolled/package/src/frontend/EditableText.module.css
+++ b/entry_types/scrolled/package/src/frontend/EditableText.module.css
@@ -8,18 +8,14 @@
   white-space: pre-line;
 }
 
-.root ul,
-.root ol {
-  list-style-position: var(--editable-text-list-style-position);
-}
-
 .justify {
   text-align: justify;
 }
 
 ul.justify,
 ol.justify {
-  list-style-position: outside;
+  /* Override style set by center-ragged text block */
+  list-style-position: outside !important;
 }
 
 .light {


### PR DESCRIPTION
`root` class is not applied by inline editing component.