### PR TITLE
Add classnames as dependency of pageflow-scrolled

### DIFF
--- a/entry_types/scrolled/package/package.json
+++ b/entry_types/scrolled/package/package.json
@@ -10,6 +10,7 @@
     "@egjs/view360": "^3.4.3",
     "@floating-ui/react": "https://github.com/tf/floating-ui-react#react-16-focus-fix",
     "@headlessui/react": "^1.6.6",
+    "classnames": "^2.3.2",
     "core-js": "^3.6.5",
     "debounce": "^1.2.0",
     "deep-assign": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4570,7 +4570,7 @@ classlist.js@^1.1.20150312:
   resolved "https://registry.yarnpkg.com/classlist.js/-/classlist.js-1.1.20150312.tgz#1d70842f7022f08d9ac086ce69e5b250f2c57789"
   integrity sha1-HXCEL3Ai8I2awIbOaeWyUPLFd4k=
 
-classnames@^2.1.3, classnames@^2.2.5:
+classnames@^2.1.3, classnames@^2.2.5, classnames@^2.3.2:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==


### PR DESCRIPTION
So far `classnames` was present as a transitive depenency via `react-draggable`. Newer versions of the package no longer depend on `classnames`, causing things to break.

fixes #2237