### PR TITLE
Support entry type specific editor translations for file types

### DIFF
--- a/doc/creating_file_types.md
+++ b/doc/creating_file_types.md
@@ -137,7 +137,7 @@ names to the `metaDataAttributes` option, when registering the file
 type.
 
     # app/assets/javascripts/pageflow/panorama/editor/config.js
-    pageflow.editor.fileTypes.register('pageflow_image_files', {
+    pageflow.editor.fileTypes.register('image_files', {
       model: pageflow.ImageFile,
       matchUpload: /^image/,
       metaDataAttributes: ['dimensions']
@@ -163,6 +163,87 @@ value:
 See `pageflow.TextFileMetaDataItemValueView` for more information. You
 can also create a custom view by extending
 `pageflow.FileMetaDataItemValueView`.
+
+## Configuration Editor Inputs
+
+Use the `configurationEditorInputs` option when registering a file type
+to add custom fields to the file settings dialog. Each item describes an
+attribute and the input view used to edit it. Input views can be further
+configured via `inputViewOptions`.
+
+    pageflow.editor.fileTypes.register('image_files', {
+      model: pageflow.ImageFile,
+      matchUpload: /^image/,
+      configurationEditorInputs: [
+        {
+          name: 'custom',
+          inputView: pageflow.TextInputView,
+          inputViewOptions: {
+            maxLength: 5000
+          }
+        }
+      ]
+    });
+
+Translations can be provided under
+`pageflow.editor.files.attributes.image_files.custom` to change the label,
+inline help or select option texts. Entry types can override these by defining
+translations under `pageflow.entry_types.<name>.editor.files.attributes.image_files.custom`.
+
+## Upload Confirmation Table Columns
+
+After files are selected the editor displays a confirmation table before the
+upload begins. Use the `confirmUploadTableColumns` option to add custom columns
+to this table. Columns can specify `cellViewOptions` in addition to the view
+class.
+
+    pageflow.editor.fileTypes.register('image_files', {
+      model: pageflow.ImageFile,
+      matchUpload: /^image/,
+      confirmUploadTableColumns: [
+        {
+          name: 'custom',
+          cellView: pageflow.TextTableCellView,
+          cellViewOptions: {
+            default: '-'
+          }
+        }
+      ]
+    });
+
+Translate column headers and cell contents via keys under
+`pageflow.editor.files.attributes.image_files.custom`. Entry types can override
+these translations under
+`pageflow.entry_types.<name>.editor.files.attributes.image_files.custom`.
+
+## Filters
+
+File collections can expose filters which determine subsets of the
+collection. Each filter has a `name` used for translations and a
+`matches` function deciding whether a file belongs to the filter. Users do
+not select filters directly. Instead, filters can be referenced when rendering
+`FileInputViews`.
+
+    pageflow.editor.fileTypes.register('image_files', {
+      model: pageflow.ImageFile,
+      matchUpload: /^image/,
+      filters: [
+        {
+          name: 'with_projection',
+          matches: function(file) { return file.has('projection'); }
+        }
+      ]
+    });
+
+    this.input('image', FileInputView, {
+      collection: 'image_files',
+      filter: 'with_projection'
+    });
+
+Translations for filter names and blank slates can be defined under
+`pageflow.editor.files.filters.image_files.with_projection`. Entry types can
+override them via
+`pageflow.entry_types.<name>.editor.files.filters.image_files.with_projection`.
 
 ## Custom Processing Stages
 
@@ -424,6 +505,25 @@ from:
 When creating color map files, Pageflow will make sure that the custom
 attribute references an image file from the same revision to prevent
 privilege escalation.
+
+
+## Modifying File Types
+
+Existing file types can be extended by calling `fileTypes.modify` before
+the editor boots. Only a few properties can be changed this way. Any
+changes are appended to the configuration provided when the file type
+was registered.
+
+    pageflow.editor.fileTypes.modify('image_files', {
+      configurationEditorInputs: [
+        {name: 'custom', inputView: pageflow.TextInputView}
+      ]
+    });
+
+The properties that may be modified are `configurationEditorInputs`,
+`configurationUpdaters`, `confirmUploadTableColumns` and `filters`. A
+modification containing any other keys will raise an error during
+initialization.
 
 ## Import/Export
 

--- a/entry_types/scrolled/config/locales/new/vr_image_projection.de.yml
+++ b/entry_types/scrolled/config/locales/new/vr_image_projection.de.yml
@@ -1,0 +1,24 @@
+de:
+  pageflow:
+    entry_types:
+      scrolled:
+        editor:
+          files:
+            attributes:
+              image_files:
+                projection:
+                  cell_text:
+                    blank: "(Kein)"
+                    equirectangular_mono: Equirectangular (Mono)
+                    equirectangular_stereo: Equirectangular (Stereo)
+                  column_header: Projektion
+                  inline_help: Lege fest, ob es sich um ein mono- oder stereoskopisches 360°-Bild handelt. Diese können als Posterbild für 360°-Videos verwendet werden.
+                  label: 360° Projektion
+                  values:
+                    equirectangular_mono: Equirectangular (Mono)
+                    equirectangular_stereo: Equirectangular (Stereo)
+            filters:
+              image_files:
+                with_projection:
+                  blank_slate: Gebe in den Datei-Einstellungen eines Bildes eine Projektion an, um es als 360° Bild zu markieren.
+                  name: 360° Bilder

--- a/entry_types/scrolled/config/locales/new/vr_image_projection.en.yml
+++ b/entry_types/scrolled/config/locales/new/vr_image_projection.en.yml
@@ -1,0 +1,24 @@
+en:
+  pageflow:
+    entry_types:
+      scrolled:
+        editor:
+          files:
+            attributes:
+              image_files:
+                projection:
+                  cell_text:
+                    blank: "(none)"
+                    equirectangular_mono: Equirectangular (mono)
+                    equirectangular_stereo: Equirectangular (stereo)
+                  column_header: Projection
+                  inline_help: Determine whether this image is a mono- or stereoscopic 360° image. It can be chosen as poster image for 360° videos.
+                  label: 360° projection
+                  values:
+                    equirectangular_mono: Equirectangular (mono)
+                    equirectangular_stereo: Equirectangular (stereo)
+            filters:
+              image_files:
+                with_projection:
+                  blank_slate: Choose a projection in the file settings, to mark it as a 360° image.
+                  name: 360° images

--- a/package/spec/editor/views/EditFileView-spec.js
+++ b/package/spec/editor/views/EditFileView-spec.js
@@ -17,7 +17,9 @@ describe('EditFileView', () => {
   useFakeTranslations({
     'pageflow.editor.files.common_attributes.source_url.label': 'Source URL',
     'pageflow.editor.files.common_attributes.license.label': 'License',
-    'pageflow.file_licenses.cc0.name': 'CC0'
+    'pageflow.file_licenses.cc0.name': 'CC0',
+    'pageflow.entry_types.strange.editor.files.attributes.image_files.custom.label': 'Entry Label',
+    'pageflow.editor.files.attributes.image_files.custom.label': 'Fallback Label'
   });
 
   it('renders configurationEditorInputs of file type', () => {
@@ -76,6 +78,42 @@ describe('EditFileView', () => {
     const {queryByLabelText} = within(view.el);
 
     expect(queryByLabelText('Source URL')).toBeNull();
+  });
+
+  it('uses entry type-specific translation keys if provided', () => {
+    editor.registerEntryType('strange');
+    const fileType = f.fileType({
+      configurationEditorInputs: [
+        {name: 'custom', inputView: TextInputView}
+      ]
+    });
+    const view = new EditFileView({
+      model: f.file({}, {fileType}),
+      entry: new Backbone.Model()
+    });
+
+    view.render();
+    const configurationEditor = ConfigurationEditorTab.find(view);
+
+    expect(configurationEditor.inputLabels()).toEqual(expect.arrayContaining(['Entry Label']));
+  });
+
+  it('falls back to generic translation keys', () => {
+    editor.registerEntryType('other');
+    const fileType = f.fileType({
+      configurationEditorInputs: [
+        {name: 'custom', inputView: TextInputView}
+      ]
+    });
+    const view = new EditFileView({
+      model: f.file({}, {fileType}),
+      entry: new Backbone.Model()
+    });
+
+    view.render();
+    const configurationEditor = ConfigurationEditorTab.find(view);
+
+    expect(configurationEditor.inputLabels()).toEqual(expect.arrayContaining(['Fallback Label']));
   });
 
   it('renders extended file rights fields if supported by entry type', () => {

--- a/package/spec/editor/views/FilteredFilesView-spec.js
+++ b/package/spec/editor/views/FilteredFilesView-spec.js
@@ -1,0 +1,52 @@
+import {FilteredFilesView, editor} from 'pageflow/editor';
+import * as support from '$support';
+import {within} from '@testing-library/dom';
+
+describe('FilteredFilesView', () => {
+  const f = support.factories;
+
+  support.useFakeTranslations({
+    'pageflow.entry_types.strange.editor.files.filters.image_files.with_projection.name': 'Entry Type Filter',
+    'pageflow.entry_types.strange.editor.files.filters.image_files.with_projection.blank_slate': 'Entry Type Blank',
+    'pageflow.editor.files.filters.image_files.with_projection.name': 'Fallback Filter',
+    'pageflow.editor.files.filters.image_files.with_projection.blank_slate': 'Fallback Blank'
+  });
+
+  it('uses entry type-specific translations if provided', () => {
+    editor.registerEntryType('strange');
+
+    const fileTypes = f.fileTypes(function() { this.withImageFileType({filters: [{name: 'with_projection', matches: () => true}]}); });
+    const fileType = fileTypes.first();
+    const entry = f.entry({}, {fileTypes, filesAttributes: {}});
+    const view = new FilteredFilesView({
+      entry: entry,
+      fileType: fileType,
+      filterName: 'with_projection'
+    });
+
+    view.render();
+    const {getByText} = within(view.el);
+
+    expect(getByText('Entry Type Filter')).not.toBeNull();
+    expect(getByText('Entry Type Blank')).not.toBeNull();
+  });
+
+  it('falls back to generic translations', () => {
+    editor.registerEntryType('other');
+
+    const fileTypes = f.fileTypes(function() { this.withImageFileType({filters: [{name: 'with_projection', matches: () => true}]}); });
+    const fileType = fileTypes.first();
+    const entry = f.entry({}, {fileTypes, filesAttributes: {}});
+    const view = new FilteredFilesView({
+      entry: entry,
+      fileType: fileType,
+      filterName: 'with_projection'
+    });
+
+    view.render();
+    const {getByText} = within(view.el);
+
+    expect(getByText('Fallback Filter')).not.toBeNull();
+    expect(getByText('Fallback Blank')).not.toBeNull();
+  });
+});

--- a/package/spec/editor/views/UploadableFilesView-spec.js
+++ b/package/spec/editor/views/UploadableFilesView-spec.js
@@ -2,13 +2,19 @@ import Backbone from 'backbone';
 
 import {TextTableCellView} from 'pageflow/ui';
 
-import {UploadableFilesView} from 'pageflow/editor';
+import {UploadableFilesView, editor} from 'pageflow/editor';
 
 import * as support from '$support';
 import {Table} from '$support/dominos/ui';
 
 describe('UploadableFilesView', () => {
   var f = support.factories;
+
+  support.useFakeTranslations({
+    'pageflow.entry_types.strange.editor.files.attributes.image_files.custom.column_header':
+      'Entry Column',
+    'pageflow.editor.files.attributes.image_files.custom.column_header': 'Fallback Column'
+  });
 
   it('renders confirmUploadTableColumns of file type', () => {
     var fileType = f.fileType({
@@ -28,5 +34,43 @@ describe('UploadableFilesView', () => {
     var table = Table.find(view);
 
     expect(table.columnNames()).toEqual(expect.arrayContaining(['custom']));
+  });
+
+  it('uses entry type-specific translation keys if provided', () => {
+    editor.registerEntryType('strange');
+    var fileType = f.fileType({
+      collectionName: 'image_files',
+      confirmUploadTableColumns: [
+        {name: 'custom', cellView: TextTableCellView}
+      ]
+    });
+    var view = new UploadableFilesView({
+      collection: f.filesCollection({fileType: fileType}),
+      fileType: fileType,
+      selection: new Backbone.Model()
+    });
+
+    view.render();
+
+    expect(view.$el.find('th').eq(2)).toHaveText('Entry Column');
+  });
+
+  it('falls back to generic translation keys', () => {
+    editor.registerEntryType('other');
+    var fileType = f.fileType({
+      collectionName: 'image_files',
+      confirmUploadTableColumns: [
+        {name: 'custom', cellView: TextTableCellView}
+      ]
+    });
+    var view = new UploadableFilesView({
+      collection: f.filesCollection({fileType: fileType}),
+      fileType: fileType,
+      selection: new Backbone.Model()
+    });
+
+    view.render();
+
+    expect(view.$el.find('th').eq(2)).toHaveText('Fallback Column');
   });
 });

--- a/package/src/editor/views/EditFileView.js
+++ b/package/src/editor/views/EditFileView.js
@@ -17,9 +17,13 @@ export const EditFileView = Marionette.ItemView.extend({
     var fileType = this.model.fileType();
     var entry = this.options.entry || state.entry;
 
+    var entryTypeName = editor.entryType.name;
+
     var tab = new ConfigurationEditorTabView({
       model: this.model.configuration,
       attributeTranslationKeyPrefixes: [
+        'pageflow.entry_types.' + entryTypeName + '.editor.files.attributes.' + fileType.collectionName,
+        'pageflow.entry_types.' + entryTypeName + '.editor.files.common_attributes',
         'pageflow.editor.files.attributes.' + fileType.collectionName,
         'pageflow.editor.files.common_attributes',
         'pageflow.editor.nested_files.' + fileType.collectionName,

--- a/package/src/editor/views/FilteredFilesView.js
+++ b/package/src/editor/views/FilteredFilesView.js
@@ -71,7 +71,14 @@ export const FilteredFilesView = Marionette.ItemView.extend({
   filterTranslation: function(keyName, options) {
     var filterName = this.options.filterName;
 
+    var entryTypeName = editor.entryType.name;
+
     return i18nUtils.findTranslation([
+      'pageflow.entry_types.' + entryTypeName + '.editor.files.filters.' +
+        this.options.fileType.collectionName + '.' +
+        filterName + '.' +
+        keyName,
+      'pageflow.entry_types.' + entryTypeName + '.editor.files.common_filters.' + keyName,
       'pageflow.editor.files.filters.' +
         this.options.fileType.collectionName + '.' +
         filterName + '.' +

--- a/package/src/editor/views/UploadableFilesView.js
+++ b/package/src/editor/views/UploadableFilesView.js
@@ -3,6 +3,7 @@ import Marionette from 'backbone.marionette';
 import _ from 'underscore';
 
 import {PresenceTableCellView, TableView, TextTableCellView} from 'pageflow/ui';
+import {editor} from '../base';
 
 export const UploadableFilesView = Marionette.View.extend({
   className: 'uploadable_files',
@@ -16,15 +17,20 @@ export const UploadableFilesView = Marionette.View.extend({
   },
 
   render: function() {
+    var entryTypeName = editor.entryType.name;
+
     this.appendSubview(new TableView({
       collection: this.uploadableFiles,
       attributeTranslationKeyPrefixes: [
+        'pageflow.entry_types.' + entryTypeName + '.editor.files.attributes.' +
+          this.options.fileType.collectionName,
+        'pageflow.entry_types.' + entryTypeName + '.editor.files.common_attributes',
         'pageflow.editor.files.attributes.' + this.options.fileType.collectionName,
         'pageflow.editor.files.common_attributes'
       ],
       columns: this.commonColumns({
         fileTypeDisplayName: I18n.t('pageflow.editor.files.tabs.' +
-                                       this.options.fileType.collectionName)
+                                   this.options.fileType.collectionName)
       }).concat(this.fileTypeColumns()),
       selection: this.options.selection,
       selectionAttribute: 'file'


### PR DESCRIPTION
Allow scoping translations for configuration editor inputs, filters and table columns to entry type.

So far Pageflow Scrolled implicitly relied on translations from the `pageflow-vr` gem for its `vrImage` element. `pageflow-vr` only works with Pageflow Paged, though. This chagne allows to break the unintended dependency.

fixes #2100