### PR TITLE
Let themes opt out of fit viewport logic

### DIFF
--- a/entry_types/scrolled/package/src/frontend/FitViewport.module.css
+++ b/entry_types/scrolled/package/src/frontend/FitViewport.module.css
@@ -1,7 +1,10 @@
 .container {
   width: 100%;
   margin: 0 auto;
-  max-width: calc(100 * var(--vh) / var(--fit-viewport-aspect-ratio) * var(--fit-viewport-scale, 1));
+  max-width: var(
+    --theme-fit-viewport,
+    calc(100 * var(--vh) / var(--fit-viewport-aspect-ratio) * var(--fit-viewport-scale, 1))
+  );
 }
 
 .content {


### PR DESCRIPTION
In some contexts in can be ok to display elements that do not fit the viewport.

REDMINE-21083