### PR TITLE
Reset checkbox with undefined value when disabled binding changes

### DIFF
--- a/package/spec/ui/views/inputs/CheckBoxInputView-spec.js
+++ b/package/spec/ui/views/inputs/CheckBoxInputView-spec.js
@@ -77,6 +77,25 @@ describe('pageflow.CheckBoxInputView', () => {
     expect(view.ui.input.is(':checked')).toEqual(true);
   });
 
+  it('updates displayed value when disabled option returns true or undefined', () => {
+    var model = new Model({state: false});
+    var view = new CheckBoxInputView({
+      model: model,
+      propertyName: 'value',
+      disabledBinding: 'state',
+      disabled: function(state) { return state; },
+      displayCheckedIfDisabled: true
+    });
+
+    view.render();
+
+    expect(view.ui.input.is(':checked')).toEqual(false);
+    model.set('state', true);
+    expect(view.ui.input.is(':checked')).toEqual(true);
+    model.set('state', false);
+    expect(view.ui.input.is(':checked')).toEqual(false);
+  });
+
   describe('with storeInverted option', () => {
     it('displays checked by default', () => {
       var model = new Model();

--- a/package/src/ui/views/inputs/CheckBoxInputView.js
+++ b/package/src/ui/views/inputs/CheckBoxInputView.js
@@ -67,7 +67,7 @@ export const CheckBoxInputView = Marionette.ItemView.extend({
 
   load: function() {
     if (!this.isClosed) {
-      this.ui.input.prop('checked', this.displayValue());
+      this.ui.input.prop('checked', !!this.displayValue());
     }
   },
 


### PR DESCRIPTION
When `displayCheckedIfDisabled` was true, the checkbox remained checked.