### PR TITLE
Pass file importer logos through asset pipeline

### DIFF
--- a/app/views/pageflow/editor/config/_seeds.json.jbuilder
+++ b/app/views/pageflow/editor/config/_seeds.json.jbuilder
@@ -20,7 +20,7 @@ end
 
 json.file_importers Pageflow.config_for(entry).file_importers do |file_importer|
   json.importer_name file_importer.name
-  json.logo_source file_importer.logo_source
+  json.logo_source asset_url(file_importer.logo_source)
   json.authentication_provider file_importer.authentication_provider
   json.authentication_required file_importer.authentication_required current_user
 end

--- a/spec/support/helpers/test_file_importer.rb
+++ b/spec/support/helpers/test_file_importer.rb
@@ -9,7 +9,7 @@ module Pageflow
     end
 
     def logo_source
-      'cl'
+      'pageflow/empty.png'
     end
 
     def search(_adf, _asd)


### PR DESCRIPTION
Make it easier for file importer plugins to reference images from their repository.