### PR TITLE
Add single column phone layout for info tables

### DIFF
--- a/entry_types/scrolled/config/locales/de.yml
+++ b/entry_types/scrolled/config/locales/de.yml
@@ -1009,6 +1009,9 @@ de:
               label: "Text-Farbe (Erste Spalte)"
             valueColor:
               label: "Text-Farbe (Zweite Spalte)"
+            singleColumnInPhoneLayout:
+              label: "Einspaltig im Phone-Layout"
+              inline_help: "Ordnet Tabellenzeilen vertikal auf dem Handy an, um zu schmale Spalten zu verhindern. Besonders hilfreich für Tabellen mit langen Texten oder breiten Inhalten."
           help_texts:
             shortcuts: |-
               <dl class="shortcuts">

--- a/entry_types/scrolled/config/locales/en.yml
+++ b/entry_types/scrolled/config/locales/en.yml
@@ -992,6 +992,9 @@ en:
               label: "Text color (First column)"
             valueColor:
               label: "Text align (Second column)"
+            singleColumnInPhoneLayout:
+              label: "Single column in phone layout"
+              inline_help: "Stacks table rows vertically in phone layout to prevent content from being squeezed into narrow columns. Especially helpful for tables with long text or wide content that would otherwise be hard to read on small screens."
           help_texts:
             shortcuts: |-
               <dl class="shortcuts">

--- a/entry_types/scrolled/package/spec/frontend/EditableTable-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/EditableTable-spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {EditableTable} from 'frontend';
+import * as phoneLayout from 'frontend/usePhoneLayout';
 
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect'
@@ -190,5 +191,15 @@ describe('EditableTable', () => {
     expect(
       screen.queryAllByRole('cell').map(cell => cell.getAttribute('data-blank'))
     ).toEqual(['', null, null, '']);
+  });
+
+  it('renders data-stacked attribute when stackedInPhoneLayout and in phone layout', () => {
+    jest.spyOn(phoneLayout, 'usePhoneLayout').mockReturnValue(true);
+
+    const {getByRole} = render(<EditableTable value={[]} stackedInPhoneLayout />);
+
+    expect(getByRole('table')).toHaveAttribute('data-stacked');
+
+    phoneLayout.usePhoneLayout.mockRestore();
   });
 });

--- a/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableTable-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableTable-spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {EditableTable} from 'frontend';
 import {loadInlineEditingComponents} from 'frontend/inlineEditing';
+import * as phoneLayout from 'frontend/usePhoneLayout';
 
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect'
@@ -157,5 +158,15 @@ describe('EditableText', () => {
     expect(
       screen.getAllByRole('cell')[0].querySelector('[contenteditable=false]')
     ).toBeNull();
+  });
+
+  it('renders data-stacked attribute when stackedInPhoneLayout and in phone layout', () => {
+    jest.spyOn(phoneLayout, 'usePhoneLayout').mockReturnValue(true);
+
+    const {getByRole} = render(<EditableTable value={[]} stackedInPhoneLayout />);
+
+    expect(getByRole('table')).toHaveAttribute('data-stacked');
+
+    phoneLayout.usePhoneLayout.mockRestore();
   });
 });

--- a/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableTable/withFixedColumns-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableTable/withFixedColumns-spec.js
@@ -1967,4 +1967,48 @@ describe('handleTableNavigation', () => {
       focus: {path: [0, 1, 0], offset: 1}
     });
   });
+
+  it('does nothing in stacked layout when pressing ArrowDown', () => {
+    const editor = withFixedColumns(
+      <editor>
+        <row>
+          <label>
+            Label<cursor />
+          </label>
+          <value>
+            Value
+          </value>
+        </row>
+      </editor>
+    );
+
+    const event = {key: 'ArrowDown', preventDefault: jest.fn()};
+    const before = editor.selection;
+    handleTableNavigation(editor, event, true);
+
+    expect(editor.selection).toEqual(before);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('does nothing in stacked layout when pressing ArrowUp', () => {
+    const editor = withFixedColumns(
+      <editor>
+        <row>
+          <label>
+            Label
+          </label>
+          <value>
+            <cursor />Value
+          </value>
+        </row>
+      </editor>
+    );
+
+    const event = {key: 'ArrowUp', preventDefault: jest.fn()};
+    const before = editor.selection;
+    handleTableNavigation(editor, event, true);
+
+    expect(editor.selection).toEqual(before);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
 });

--- a/entry_types/scrolled/package/src/contentElements/infoTable/InfoTable.js
+++ b/entry_types/scrolled/package/src/contentElements/infoTable/InfoTable.js
@@ -30,6 +30,7 @@ export function InfoTable({configuration, sectionProps}) {
                      labelPlaceholder={t('pageflow_scrolled.inline_editing.type_text')}
                      valuePlaceholder={t('pageflow_scrolled.inline_editing.type_text')}
                      value={configuration.value}
+                     stackedInPhoneLayout={configuration.singleColumnInPhoneLayout}
                      onChange={value => updateConfiguration({value})} />
     </div>
   );

--- a/entry_types/scrolled/package/src/contentElements/infoTable/InfoTable.module.css
+++ b/entry_types/scrolled/package/src/contentElements/infoTable/InfoTable.module.css
@@ -63,6 +63,19 @@
   border-top: solid 1px var(--table-border-color);
 }
 
+.table[data-stacked] tr td:last-child {
+  border-top: solid 1px color-mix(in srgb, transparent, var(--table-border-color));
+}
+
+.table[data-stacked] td:first-child {
+  border-right: none;
+  padding-right: 0;
+}
+
+.table[data-stacked] td:last-child {
+  padding-left: 0;
+}
+
 .selected {
   --table-border-color: color-mix(in srgb, transparent, currentColor);
 }

--- a/entry_types/scrolled/package/src/contentElements/infoTable/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/infoTable/editor.js
@@ -1,7 +1,7 @@
 import I18n from 'i18n-js';
 import {editor} from 'pageflow-scrolled/editor';
 import {InfoBoxView} from 'pageflow/editor';
-import {SeparatorView, SelectInputView} from 'pageflow/ui'
+import {CheckBoxInputView, SeparatorView, SelectInputView} from 'pageflow/ui';
 
 import pictogram from './pictogram.svg';
 
@@ -26,6 +26,8 @@ editor.contentElementTypes.register('infoTable', {
         propertyName: 'valueColor',
         entry
       });
+
+      this.input('singleColumnInPhoneLayout', CheckBoxInputView);
 
       this.view(SeparatorView);
 

--- a/entry_types/scrolled/package/src/contentElements/infoTable/stories.js
+++ b/entry_types/scrolled/package/src/contentElements/infoTable/stories.js
@@ -113,6 +113,49 @@ storiesOfContentElement(module, {
         labelColumnAlign: 'right',
         valueColumnAlign: 'center'
       }
+    },
+    {
+      name: 'Single column in phone layout',
+      configuration: {
+        singleColumnInPhoneLayout: true,
+        value: [
+          {
+            type: 'row',
+            children: [
+              {
+                type: 'label',
+                children: [
+                  {text: 'Very long label with lots of content'}
+                ]
+              },
+              {
+                type: 'value',
+                children: [
+                  {text: 'This is a very long value with lots of text that would be hard to read in narrow columns on mobile devices'}
+                ]
+              }
+            ]
+          },
+          {
+            type: 'row',
+            children: [
+              {
+                type: 'label',
+                children: [
+                  {text: 'Long technical term'}
+                ]
+              },
+              {
+                type: 'value',
+                children: [
+                  {text: 'supercalifragilisticexpialidocious'}
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      viewport: 'phone'
     }
   ]
 });

--- a/entry_types/scrolled/package/src/frontend/EditableTable.js
+++ b/entry_types/scrolled/package/src/frontend/EditableTable.js
@@ -11,6 +11,7 @@ import {
 } from './EditableText';
 
 import styles from './EditableTable.module.css';
+import {usePhoneLayout} from './usePhoneLayout';
 
 const defaultValue = [{
   type: 'row',
@@ -33,10 +34,15 @@ const defaultValue = [{
 export const EditableTable = withInlineEditingAlternative('EditableTable', function EditableTable({
   value, className,
   labelScaleCategory = 'body',
-  valueScaleCategory = 'body'
+  valueScaleCategory = 'body',
+  stackedInPhoneLayout = false
 }) {
+  const phoneLayout = usePhoneLayout();
+  const stacked = stackedInPhoneLayout && phoneLayout;
+
   return (
-    <table className={classNames(className, styles.table)}>
+    <table className={classNames(className, styles.table)}
+           data-stacked={stacked ? '' : undefined}>
       <tbody>
         {render(value || defaultValue, {
           labelScaleCategory,

--- a/entry_types/scrolled/package/src/frontend/EditableTable.module.css
+++ b/entry_types/scrolled/package/src/frontend/EditableTable.module.css
@@ -1,3 +1,8 @@
-.table {
+x.table {
   white-space: pre-line;
+}
+
+.table[data-stacked] tr,
+.table[data-stacked] td {
+  display: block;
 }

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/EditableTable/index.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/EditableTable/index.js
@@ -29,13 +29,16 @@ import {
 } from './placeholders';
 
 import {LinkTooltipProvider} from '../LinkTooltip';
+import {usePhoneLayout} from '../../usePhoneLayout';
+import tableStyles from '../../EditableTable.module.css';
 
 export const EditableTable = React.memo(function EditableTable({
   value, onChange, className,
   labelScaleCategory = 'body',
   valueScaleCategory = 'body',
   labelPlaceholder, valuePlaceholder,
-  floatingControlsPosition = 'below'
+  floatingControlsPosition = 'below',
+  stackedInPhoneLayout = false
 }) {
   const editor = useMemo(
     () => withFixedColumns(
@@ -53,6 +56,8 @@ export const EditableTable = React.memo(function EditableTable({
   );
 
   const {isSelected} = useContentElementEditorState();
+  const phoneLayout = usePhoneLayout();
+  const stacked = stackedInPhoneLayout && phoneLayout;
 
   const handleLineBreaks = useLineBreakHandler(editor);
   const handleShortcuts = useShortcutHandler(editor);
@@ -60,8 +65,8 @@ export const EditableTable = React.memo(function EditableTable({
   const handleKeyDown = useCallback(event => {
     handleLineBreaks(event);
     handleShortcuts(event);
-    handleTableNavigation(editor, event);
-  }, [editor, handleLineBreaks, handleShortcuts]);
+    handleTableNavigation(editor, event, stacked);
+  }, [editor, handleLineBreaks, handleShortcuts, stacked]);
 
   const [cachedValue, setCachedValue] = useCachedValue(value, {
     defaultValue: [{
@@ -106,7 +111,10 @@ export const EditableTable = React.memo(function EditableTable({
       <LinkTooltipProvider disabled={editor.selection && !Range.isCollapsed(editor.selection)}
                            position={floatingControlsPosition}>
         <HoveringToolbar position={floatingControlsPosition} />
-        <table className={classNames(className, {[selectedClassName]: isSelected})}>
+        <table className={classNames(className,
+                                     tableStyles.table,
+                                     {[selectedClassName]: isSelected})}
+               data-stacked={stacked ? '' : undefined}>
           <Editable
             as="tbody"
             decorate={decorateLineBreaks}

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/EditableTable/withFixedColumns/handleTableNavigation.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/EditableTable/withFixedColumns/handleTableNavigation.js
@@ -2,7 +2,11 @@ import {Editor, Node, Path, Range, Transforms} from 'slate';
 
 import {Cell} from './helpers';
 
-export function handleTableNavigation(editor, event) {
+export function handleTableNavigation(editor, event, stacked) {
+  if (stacked) {
+    return;
+  }
+
   const {selection} = editor;
 
   if (selection && Range.isCollapsed(selection)) {


### PR DESCRIPTION
With long words or cells with a lot of content, the two-column display can become too dense in phone layout. Offer an alternative.