### PR TITLE
Add alignment options for narrow content elements

### DIFF
--- a/entry_types/scrolled/config/locales/de.yml
+++ b/entry_types/scrolled/config/locales/de.yml
@@ -221,6 +221,14 @@ de:
             anzupassen. Breitere Elemente unterbrechen den Textfluss
             und stehen prominent für sich alleine.
           label: Breite
+        alignment:
+          label: Ausrichtung
+          inline_help: |-
+            Richte schmale Elemente links, rechts oder zentriert zur Textbreite aus.
+          values:
+            center: Zentriert
+            left: Links
+            right: Rechts
         captionVariant:
           label: Beschriftungsvariante
           inline_help: Ändere die Darstellung der Beschriftung unterhalb des Element.

--- a/entry_types/scrolled/config/locales/en.yml
+++ b/entry_types/scrolled/config/locales/en.yml
@@ -213,6 +213,14 @@ en:
             elements interrupt the text flow and stand prominently on
             their own.
           label: Width
+        alignment:
+          label: Alignment
+          inline_help: |-
+            Align narrow elements relative to the content width.
+          values:
+            center: Center
+            left: Left
+            right: Right
         captionVariant:
           label: Caption Variant
           inline_help: Switch between different looks of the caption below the element.

--- a/entry_types/scrolled/package/spec/entryState/structure-spec.js
+++ b/entry_types/scrolled/package/spec/entryState/structure-spec.js
@@ -570,6 +570,29 @@ describe('useSectionForegroundContentElements', () => {
     ]);
   });
 
+  it('includes alignment of content elements', () => {
+    const {result} = renderHookInEntry(
+      () => useSectionForegroundContentElements({sectionId: 1}),
+      {
+        seed: {
+          chapters: chaptersSeed,
+          sections: sectionsSeed,
+          contentElements: [...contentElementsSeed,
+                            {id: 6,
+                             permaId: 1006,
+                             sectionId: 1,
+                             typeName: 'textBlock',
+                             configuration: {alignment: 'left', width: -1}}]
+        }
+      }
+    );
+
+    const contentElements = result.current;
+    expect(contentElements).toEqual(expect.arrayContaining([
+      expect.objectContaining({permaId: 1006, alignment: 'left'})
+    ]));
+  });
+
   it('filters out content elements with position backdrop', () => {
     const {result} = renderHookInEntry(
       () => useSectionForegroundContentElements({sectionId: 2}),

--- a/entry_types/scrolled/package/spec/frontend/Layout-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/Layout-spec.js
@@ -6,6 +6,7 @@ import {frontend} from 'pageflow-scrolled/frontend';
 
 import centerStyles from 'frontend/layouts/Center.module.css';
 import twoColumnStyles from 'frontend/layouts/TwoColumn.module.css';
+import alignmentStyles from 'frontend/layouts/alignment.module.css';
 
 import {widthName} from 'frontend/layouts/widths';
 
@@ -1264,6 +1265,88 @@ describe('Layout', () => {
       );
 
       expect(findParentWithClass(getByTestId('probe'), centerStyles['outer-full'])).not.toBeNull();
+    });
+  });
+
+  describe('alignment classes in two column variant', () => {
+    it('applies alignment class to inline box with negative width', () => {
+      const items = [
+        {id: 2, type: 'probe', position: 'inline', width: -2, alignment: 'left'}
+      ];
+      const {getByTestId} = renderInEntry(
+        <Layout sectionProps={{layout: 'left'}} items={items}>
+          {children => children}
+        </Layout>
+      );
+
+      expect(findParentWithClass(getByTestId('probe'), alignmentStyles.left)).not.toBeNull();
+    });
+
+    it('applies alignment class to sticky elements with negative width', () => {
+      const items = [
+        {id: 2, type: 'probe', position: 'sticky', width: -2, alignment: 'center'}
+      ];
+      const {getByTestId} = renderInEntry(
+        <Layout sectionProps={{layout: 'left'}} items={items}>
+          {children => children}
+        </Layout>
+      );
+
+      expect(findParentWithClass(getByTestId('probe'), alignmentStyles.center)).not.toBeNull();
+    });
+
+    it('does not apply alignment class to inline box with non-negative width', () => {
+      const items = [
+        {id: 2, type: 'probe', alignment: 'left'}
+      ];
+      const {getByTestId} = renderInEntry(
+        <Layout sectionProps={{layout: 'left'}} items={items}>
+          {children => children}
+        </Layout>
+      );
+
+      expect(findParentWithClass(getByTestId('probe'), alignmentStyles.left)).toBeNull();
+    });
+  });
+
+  describe('alignment classes in centered variant', () => {
+    it('applies alignment class to inline item', () => {
+      const items = [
+        {id: 2, type: 'probe', width: -2, alignment: 'left'}
+      ];
+      const {getByTestId} = renderInEntry(
+        <Layout sectionProps={{layout: 'center'}} items={items}>
+          {children => children}
+        </Layout>
+      );
+
+      expect(findParentWithClass(getByTestId('probe'), alignmentStyles.left)).not.toBeNull();
+    });
+
+    it('applies center alignment class', () => {
+      const items = [
+        {id: 2, type: 'probe', position: 'left', width: -2, alignment: 'center'}
+      ];
+      const {getByTestId} = renderInEntry(
+        <Layout sectionProps={{layout: 'center'}} items={items}>
+          {children => children}
+        </Layout>
+      );
+
+      expect(findParentWithClass(getByTestId('probe'), alignmentStyles.center)).not.toBeNull();
+    });
+
+    it('does not apply alignment class to elements with non-negative width', () => {
+      const items = [
+        {id: 2, type: 'probe', alignment: 'left'}
+      ];
+      const {getByTestId} = renderInEntry(
+        <Layout sectionProps={{layout: 'center'}} items={items}>
+          {children => children}
+        </Layout>
+      );
+
+      expect(findParentWithClass(getByTestId('probe'), alignmentStyles.left)).toBeNull();
     });
   });
 

--- a/entry_types/scrolled/package/spec/frontend/features/contentElementAlignment-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/features/contentElementAlignment-spec.js
@@ -1,0 +1,42 @@
+import {renderEntry, usePageObjects} from 'support/pageObjects';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('content element alignment', () => {
+  usePageObjects();
+
+  it('applies alignment class for narrow inline element', () => {
+    const {getContentElementByTestId} = renderEntry({
+      seed: {
+        sections: [{id: 1, permaId: 10, configuration: {layout: 'center'}}],
+        contentElements: [{
+          id: 1,
+          permaId: 100,
+          sectionId: 1,
+          typeName: 'withTestId',
+          configuration: {alignment: 'left', width: -1, testId: 'probe'}
+        }]
+      }
+    });
+
+    const contentElement = getContentElementByTestId('probe');
+    expect(contentElement.hasAlignment('left')).toBe(true);
+  });
+
+  it('ignores alignment class when width changes', () => {
+    const {getContentElementByTestId} = renderEntry({
+      seed: {
+        sections: [{id: 1, permaId: 10, configuration: {layout: 'left'}}],
+        contentElements: [{
+          id: 1,
+          permaId: 100,
+          sectionId: 1,
+          typeName: 'withTestId',
+          configuration: {alignment: 'left', width: 1, testId: 'probe'}
+        }]
+      }
+    });
+
+    const contentElement = getContentElementByTestId('probe');
+    expect(contentElement.hasAlignment('left')).toBe(false);
+  });
+});

--- a/entry_types/scrolled/package/spec/support/pageObjects.js
+++ b/entry_types/scrolled/package/spec/support/pageObjects.js
@@ -7,6 +7,7 @@ import contentElementBoxStyles from 'frontend/ContentElementBox.module.css';
 import contentElementMarginStyles from 'frontend/ContentElementMargin.module.css';
 import contentElementScrollSpaceStyles from 'frontend/ContentElementScrollSpace.module.css';
 import fitViewportStyles from 'frontend/FitViewport.module.css';
+import layoutAlignmentStyles from 'frontend/layouts/alignment.module.css';
 import {StaticPreview} from 'frontend/useScrollPositionLifecycle';
 import {loadInlineEditingComponents} from 'frontend/inlineEditing';
 import {api} from 'frontend/api';
@@ -228,6 +229,10 @@ function createContentElementPageObject(el) {
 
     hasFitViewport() {
       return !!el.querySelector(`.${fitViewportStyles.container}`);
+    },
+
+    hasAlignment(alignment) {
+      return !!(el.closest(`.${layoutAlignmentStyles[alignment]}`));
     },
 
     getFitViewportAspectRatio() {

--- a/entry_types/scrolled/package/src/editor/views/configurationEditors/groups/CommonContentElementAttributes.js
+++ b/entry_types/scrolled/package/src/editor/views/configurationEditors/groups/CommonContentElementAttributes.js
@@ -53,6 +53,14 @@ ConfigurationEditorTabView.groups.define('ContentElementPosition', function({ent
       0
   });
 
+  this.input('alignment', SelectInputView, {
+    attributeTranslationKeyPrefixes: ['pageflow_scrolled.editor.common_content_element_attributes'],
+    values: ['center', 'left', 'right'],
+    defaultValue: 'center',
+    visibleBinding: 'width',
+    visible: () => contentElement.getWidth() < 0
+  });
+
   if (contentElement.supportsFullWidthInPhoneLayout()) {
     this.input('fullWidthInPhoneLayout', CheckBoxInputView, {
       attributeTranslationKeyPrefixes: ['pageflow_scrolled.editor.common_content_element_attributes'],

--- a/entry_types/scrolled/package/src/entryState/structure.js
+++ b/entry_types/scrolled/package/src/entryState/structure.js
@@ -204,6 +204,7 @@ function contentElementData(contentElement, layout, phoneLayout) {
     position,
     width: getWidth(contentElement, position, phoneLayout),
     standAlone: contentElement.configuration.position === 'standAlone',
+    alignment: contentElement.configuration.alignment,
     props: contentElement.configuration
   };
 }

--- a/entry_types/scrolled/package/src/frontend/__stories__/contentElementAlignment-stories.js
+++ b/entry_types/scrolled/package/src/frontend/__stories__/contentElementAlignment-stories.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import Measure from 'react-measure';
+
+import {Entry, RootProviders, ContentElementFigure, frontend} from 'pageflow-scrolled/frontend';
+
+import {
+  normalizeAndMergeFixture,
+  exampleHeading,
+  exampleTextBlock,
+  examplePositionedElement
+} from 'pageflow-scrolled/spec/support/stories';
+
+import {storiesOf} from '@storybook/react';
+
+frontend.contentElementTypes.register('measuringProbe', {
+  component: function({configuration}) {
+    const outer = {
+      background: 'green',
+      aspectRatio: '4 / 3',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center'
+    };
+
+    return (
+      <Measure bounds>
+        {({measureRef, contentRect}) =>
+          <ContentElementFigure configuration={configuration}>
+            <div ref={measureRef} style={outer}>
+              {contentRect.bounds.width}px
+            </div>
+          </ContentElementFigure>
+        }
+      </Measure>
+    );
+  }
+});
+
+['left', 'center'].forEach(layout => {
+  storiesOf(`Frontend/Content Element Alignment`, module)
+    .add(`Layout ${layout}`, () =>
+      <RootProviders seed={exampleSeed({layout})}>
+        <Entry />
+      </RootProviders>
+    );
+});
+
+function exampleSeed({layout}) {
+  return normalizeAndMergeFixture({
+    sections: [
+      {
+        id: 1,
+        configuration: {
+          layout,
+          transition: 'reveal',
+          fullHeight: true,
+          backdrop: {
+            color: '#cad2c5'
+          }
+        }
+      }
+    ],
+    contentElements: exampleContentElements(1, layout)
+  });
+
+  function exampleContentElements(sectionId, layout) {
+    const elements = [
+      exampleHeading({sectionId, text: 'Content element alignment'}),
+      examplePositionedElement({sectionId,
+                                typeName: 'measuringProbe',
+                                width: -1,
+                                configuration: {alignment: 'left'},
+                                caption: 'Left'}),
+      examplePositionedElement({sectionId,
+                                typeName: 'measuringProbe',
+                                width: -1,
+                                caption: 'Center'}),
+      examplePositionedElement({sectionId,
+                                typeName: 'measuringProbe',
+                                width: -1,
+                                configuration: {alignment: 'right'},
+                                caption: 'Right'})
+    ];
+
+    if (layout === 'left') {
+      elements.push(
+        examplePositionedElement({sectionId,
+                                  typeName: 'measuringProbe',
+                                  position: 'sticky',
+                                  width: -1,
+                                  configuration: {alignment: 'left'},
+                                  caption: 'Sticky Left'}),
+        examplePositionedElement({sectionId,
+                                  typeName: 'measuringProbe',
+                                  position: 'sticky',
+                                  width: -1,
+                                  configuration: {alignment: 'center'},
+                                  caption: 'Sticky Center'}),
+        examplePositionedElement({sectionId,
+                                  typeName: 'measuringProbe',
+                                  position: 'sticky',
+                                  width: -1,
+                                  configuration: {alignment: 'right'},
+                                  caption: 'Sticky Right'}),
+        exampleTextBlock({sectionId})
+      );
+    }
+    else {
+      elements.push(
+        exampleTextBlock({sectionId}),
+        examplePositionedElement({sectionId,
+                                  typeName: 'measuringProbe',
+                                  position: 'left',
+                                  width: -1,
+                                  configuration: {alignment: 'right'},
+                                  caption: 'Floated (alignment ignored)'})
+      );
+    }
+
+    elements.push(
+      exampleTextBlock({sectionId})
+    );
+
+    return elements;
+  }
+}

--- a/entry_types/scrolled/package/src/frontend/layouts/Center.js
+++ b/entry_types/scrolled/package/src/frontend/layouts/Center.js
@@ -7,6 +7,7 @@ import {ContentElements} from '../ContentElements';
 import {widths, widthName} from './widths';
 
 import styles from './Center.module.css';
+import alignmentStyles from './alignment.module.css';
 
 const floatedPositions = ['left', 'right'];
 
@@ -18,7 +19,10 @@ export function Center(props) {
       {props.items.map((item, index) => {
         const customMargin = hasCustomMargin(item);
         const position = item.position;
-        const width = widthName(getWidth(item));
+        const widthValue = getWidth(item);
+        const width = widthName(widthValue);
+        const alignmentClass = widthValue < 0 ?
+                               alignmentStyles[item.alignment || 'center'] : null;
 
         return (
           <ContentElements key={item.id} sectionProps={props.sectionProps} items={[item]} customMargin={customMargin}>
@@ -29,6 +33,7 @@ export function Center(props) {
                   {props.children(
                     <div className={classNames(styles[`inner-${item.position}`],
                                                styles[`inner-${width}`],
+                                               alignmentClass,
                                                {[styles[`sideBySide`]]: sideBySideFloat(props.items, index)})}>
                       {child}
                     </div>,

--- a/entry_types/scrolled/package/src/frontend/layouts/Center.module.css
+++ b/entry_types/scrolled/package/src/frontend/layouts/Center.module.css
@@ -47,12 +47,6 @@
   clear: both;
 }
 
-.inner-xxs,
-.inner-xs,
-.inner-sm {
-  margin: 0 auto;
-}
-
 .inner-xxs {
   width: 30%;
 }

--- a/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.js
+++ b/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.js
@@ -8,6 +8,7 @@ import {useTheme} from '../../entryState';
 import {widths, widthName} from './widths';
 
 import styles from './TwoColumn.module.css';
+import alignmentStyles from './alignment.module.css';
 
 export function TwoColumn(props) {
   const shouldInline = useShouldInlineSticky();
@@ -69,7 +70,7 @@ function renderItemGroup(props, box, key) {
                                            styles[`width-${widthName(box.width)}`],
                                            {[styles.customMargin]: box.customMargin})}>
         {props.children(
-          <RestrictWidth width={box.width}>
+          <RestrictWidth width={box.width} alignment={box.alignment}>
             <ContentElements sectionProps={props.sectionProps}
                              customMargin={box.customMargin}
                              items={box.items} />
@@ -87,13 +88,14 @@ function renderItemGroup(props, box, key) {
   }
 }
 
-function RestrictWidth({width, children}) {
+function RestrictWidth({width, alignment, children}) {
   if (width >= 0) {
     return children;
   }
   else {
     return (
-      <div className={styles[`restrict-${widthName(width)}`]}>
+      <div className={classNames(styles[`restrict-${widthName(width)}`],
+                                 alignmentStyles[alignment])}>
         {children}
       </div>
     );
@@ -117,6 +119,8 @@ function groupItemsByPosition(items, shouldInline) {
     let width = item.width || 0;
     const position = onTheSide(item.position) && !shouldInline(width) ? item.position : 'inline';
     const customMargin = !!elementSupportsCustomMargin && width < widths.full;
+    const alignment = width < 0 ?
+                      (item.alignment || 'center') : null;
 
     if (onTheSide(item.position) && position === 'inline' && width > widths.md) {
       width -= 1;
@@ -137,11 +141,12 @@ function groupItemsByPosition(items, shouldInline) {
       }
     }
 
-    if (!currentBox || currentBox.customMargin !== customMargin) {
+    if (!currentBox || currentBox.customMargin !== customMargin || currentBox.alignment !== alignment) {
       currentBox = {
         customMargin,
         position,
         width,
+        alignment,
         items: []
       };
 

--- a/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.module.css
+++ b/entry_types/scrolled/package/src/frontend/layouts/TwoColumn.module.css
@@ -39,12 +39,6 @@
   --content-max-width: unset;
 }
 
-.restrict-xxs,
-.restrict-xs,
-.restrict-sm {
-  margin: 0 auto;
-}
-
 .restrict-xxs {
   width: 30%;
 }

--- a/entry_types/scrolled/package/src/frontend/layouts/alignment.module.css
+++ b/entry_types/scrolled/package/src/frontend/layouts/alignment.module.css
@@ -1,0 +1,12 @@
+.center {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.left {
+  margin-right: auto;
+}
+
+.right {
+  margin-left: auto;
+}


### PR DESCRIPTION
Content creators can now align inline elements with negative widths (narrow, small, extra small) left, right, or centered relative to the text width. This provides better visual control for images, videos, and other content elements that don't span the full content area.

The alignment setting appears in the editor only when width is set to a narrow option.

REDMINE-21131