### PR TITLE
Ignore empty palette color

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/paletteColor-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/paletteColor-spec.js
@@ -9,6 +9,10 @@ describe('paletteColor', () => {
     expect(paletteColor(undefined)).toBeUndefined();
   });
 
+  it('returns undefined if name is empty string', () => {
+    expect(paletteColor('')).toBeUndefined();
+  });
+
   it('returns hard coded color if value start with #', () => {
     expect(paletteColor('#454545')).toEqual('#454545');
   });

--- a/entry_types/scrolled/package/src/frontend/paletteColor.js
+++ b/entry_types/scrolled/package/src/frontend/paletteColor.js
@@ -5,7 +5,13 @@
  * <div style={{backgroundColor: paletteColor(configuration.backgroundColor)}}>
  */
 export function paletteColor(value) {
-  return !value || value[0] === '#' ?
-         value :
-         `var(--theme-palette-color-${value})`;
+  if (!value) {
+    return undefined;
+  }
+
+  if (value[0] === '#') {
+    return value;
+  }
+
+  return `var(--theme-palette-color-${value})`;
 }


### PR DESCRIPTION
Custom properties set to empty strings in React component inline styles (e.g., `style={{'--something': ''}}`) are ignored in client side rendering, but result in properties with empty values in SSR. When a palette color option has been reset to the automatic value this can cause unwanted overrides of properties (e.g., invisible hotspot indicators). Make empty string result in undefined property value.