### PR TITLE
Ignore text nodes with types

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/EditableText-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/EditableText-spec.js
@@ -458,4 +458,20 @@ describe('EditableText', () => {
 
     expect(container.querySelector('.typography-question-lg')).toBeInTheDocument()
   });
+
+  it('ignores arbitrary types in text nodes that can sometimes occur when pasting content', () => {
+    const value = [{
+      type: 'paragraph',
+      children: [
+        {
+          type: 'word',
+          text: 'Something'
+        }
+      ]
+    }];
+
+    const {getByText} = render(<EditableText value={value} />);
+
+    expect(getByText('Something')).toBeInTheDocument()
+  });
 });

--- a/entry_types/scrolled/package/src/frontend/EditableText.js
+++ b/entry_types/scrolled/package/src/frontend/EditableText.js
@@ -30,7 +30,7 @@ export const EditableText = withInlineEditingAlternative('EditableText', functio
 
 function render(children) {
   return children.map((element, index) => {
-    if (element.type) {
+    if (element.type && element.children) {
       return renderElement({attributes: {key: index}, element, children: render(element.children)});
     }
     else {


### PR DESCRIPTION
Pasting text from Microsoft Word sometimes leads to text nodes with types `"word"` or `"whitespace"`. We probably should prevent this via normalization. For now, we want to prevent rendering errors by simply treating these nodes as text.