### PR TITLE
Restore support for creating generated files without file name

### DIFF
--- a/spec/controllers/pageflow/editor/files_controller_spec.rb
+++ b/spec/controllers/pageflow/editor/files_controller_spec.rb
@@ -291,6 +291,39 @@ module Pageflow
         expect(response.status).to eq(200)
       end
 
+      it 'allows to create generated file without file_name attribute' do
+        pageflow_configure do |config|
+          TestFileType.register(config,
+                                model: Pageflow::TestGeneratedFile,
+                                custom_attributes: {
+                                  url: {
+                                    permitted_create_param: true
+                                  }
+                                })
+        end
+
+        user = create(:user)
+        entry = create(:entry, with_editor: user)
+
+        sign_in(user, scope: :user)
+        acquire_edit_lock(user, entry)
+        post(:create,
+             params: {
+               entry_id: entry,
+               collection_name: 'pageflow_test_generated_files',
+               test_generated_file: {
+                 url: 'http://example.com/generated'
+               },
+               no_upload: true
+             },
+             format: 'json')
+
+        file = entry.draft.find_files(Pageflow::TestGeneratedFile).last
+
+        expect(file.url).to eq('http://example.com/generated')
+        expect(response.status).to eq(200)
+      end
+
       it 'creates file for entry' do
         user = create(:user)
         entry = create(:entry, with_editor: user)

--- a/spec/models/pageflow/draft_entry_spec.rb
+++ b/spec/models/pageflow/draft_entry_spec.rb
@@ -164,6 +164,21 @@ module Pageflow
                                    related_image_file_id: image_file.id)
         }.not_to raise_error
       end
+
+      it 'creates generated file without requiring file_name attribute' do
+        pageflow_configure do |config|
+          TestFileType.register(config, model: Pageflow::TestGeneratedFile)
+        end
+        test_file_type = Pageflow.config.file_types.find_by_model!(TestGeneratedFile)
+
+        entry = create(:entry)
+        draft_entry = DraftEntry.new(entry)
+
+        used_file = draft_entry.create_file!(test_file_type,
+                                             url: 'http://example.com/generated')
+
+        expect(used_file.url).to eq('http://example.com/generated')
+      end
     end
 
     describe '#use_file' do

--- a/spec/support/helpers/test_file_type.rb
+++ b/spec/support/helpers/test_file_type.rb
@@ -1,11 +1,11 @@
 require 'pageflow/test_page_type'
 require 'pageflow/test_uploadable_file'
+require 'pageflow/test_generated_file'
 
 module Pageflow
   class TestFileType
-    def self.register(config, options = {})
-      file_type = FileType.new(model: 'Pageflow::TestUploadableFile', **options)
-
+    def self.register(config, model: 'Pageflow::TestUploadableFile', **)
+      file_type = FileType.new(model:, **)
       page_type = TestPageType.new(name: :test,
                                    file_types: [file_type])
 

--- a/spec/support/pageflow/dummy/rails_template.rb
+++ b/spec/support/pageflow/dummy/rails_template.rb
@@ -107,6 +107,7 @@ timestamp = (latest_migration || Time.now.utc.strftime('%Y%m%d%H%M%S').to_i) + 1
 [
   'create_test_uploadable_file.rb',
   'create_test_multi_attachment_file.rb',
+  'create_test_generated_file.rb',
   'create_test_revision_components.rb',
   'add_custom_fields.rb'
 ].each_with_index do |migration, index|

--- a/spec/support/pageflow/dummy/templates/create_test_generated_file.rb
+++ b/spec/support/pageflow/dummy/templates/create_test_generated_file.rb
@@ -1,0 +1,18 @@
+class CreateTestGeneratedFile < ActiveRecord::Migration[4.2]
+  def change
+    create_table :test_generated_files do |t|
+      t.belongs_to(:entry, index: true)
+      t.belongs_to(:uploader, index: true)
+
+      t.integer(:parent_file_id)
+      t.string(:parent_file_model_type)
+
+      t.string(:state)
+      t.string(:rights)
+
+      t.string(:url)
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/support/pageflow/test_generated_file.rb
+++ b/spec/support/pageflow/test_generated_file.rb
@@ -1,0 +1,28 @@
+module Pageflow
+  class TestGeneratedFile < ActiveRecord::Base
+    self.table_name = :test_generated_files
+    include ReusableFile
+
+    def retryable?
+      false
+    end
+
+    def ready?
+      true
+    end
+
+    def failed?
+      false
+    end
+
+    def publish!; end
+
+    def url
+      read_attribute(:url)
+    end
+
+    def original_url
+      url
+    end
+  end
+end


### PR DESCRIPTION
Broke when we added editable display names in #2274.

REDMINE-85872