### PR TITLE
Do not pause background video when clicking in section margin

### DIFF
--- a/entry_types/scrolled/package/src/frontend/MediaPlayer.module.css
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer.module.css
@@ -1,3 +1,7 @@
+.wrapper {
+  pointer-events: none;
+}
+
 .wrapper,
 .wrapper > div,
 .wrapper > div > div,


### PR DESCRIPTION
Toggling play/pause via click is handled by `BigPlayPauseButton` component in video element. Click handler on `video` element is not used intentionally anywhere. Prevent triggering it in background case.