### PR TITLE
Fix default text tracks on iOS

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/MediaPlayer/textTracks-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/MediaPlayer/textTracks-spec.js
@@ -185,4 +185,33 @@ describe('MediaPlayer', () => {
 
     expect(getPlayer().textTracks()[0].mode).toEqual('showing');
   });
+
+  it('keeps configured text track active when another track becomes showing', () => {
+    const sampleTextTrack = {
+      id: 1,
+      configuration: {
+        srclang: 'de',
+        kind: 'caption'
+      }
+    };
+    const {getPlayer} =
+      render(<MediaPlayer {...requiredProps()}
+                          sources={getAudioSources()}
+                          textTracks={getTextTracks({sampleTextTrack})} />);
+
+    const player = getPlayer();
+    const configuredTrack = player.textTracks()[0];
+    const injectedTrack = {mode: 'disabled'};
+    player.textTracks().push(injectedTrack);
+
+    configuredTrack.mode = 'disabled';
+    injectedTrack.mode = 'showing';
+
+    act(() => {
+      player.trigger('play');
+    });
+
+    expect(configuredTrack.mode).toEqual('showing');
+    expect(injectedTrack.mode).toEqual('disabled');
+  });
 });

--- a/entry_types/scrolled/package/spec/frontend/PlayerContainer-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/PlayerContainer-spec.js
@@ -42,12 +42,19 @@ describe('PlayerContainer', () => {
     render(<PlayerContainer type={'video'} onSetup={onSetup} sources={getVideoSources()} />);
   });
 
-  it('calls onDispose on player unmount', () => {
-    let onDispose = jest.fn();
-    let {unmount} = render(<PlayerContainer type={'video'} onDispose={onDispose} sources={getVideoSources()} />);
-    expect(onDispose).not.toHaveBeenCalled();
+  it('calls cleanup returned from onSetup on player unmount', () => {
+    const cleanup = jest.fn();
+    const onSetup = jest.fn(() => cleanup);
+    const {unmount} = render(
+      <PlayerContainer type={'video'} onSetup={onSetup} sources={getVideoSources()} />
+    );
+
+    expect(cleanup).not.toHaveBeenCalled();
+
     unmount();
-    expect(onDispose).toHaveBeenCalledTimes(1);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(onSetup).toHaveBeenCalledTimes(1);
   });
 
   it('calls media.getPlayer with new sources, when sources are changed', () => {

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/PlayerContainer.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/PlayerContainer.js
@@ -7,7 +7,7 @@ import './videojsBase.module.css';
 function PlayerContainer({
   filePermaId, sources, textTrackSources, type,
   playsInline, loop, controls, altText,
-  mediaEventsContextData, atmoDuringPlayback, onSetup, onDispose
+  mediaEventsContextData, atmoDuringPlayback, onSetup
 }){
   const playerWrapperRef = useRef(null);
   let atmo = useAtmo();
@@ -16,6 +16,8 @@ function PlayerContainer({
     let playerWrapper = playerWrapperRef.current;
 
     if (sources) {
+      let disposeHandler;
+
       let player = media.getPlayer(sources, {
         textTrackSources,
         filePermaId,
@@ -31,15 +33,15 @@ function PlayerContainer({
           playerWrapper.removeChild(player.el());
           player = null;
 
-          if (onDispose) {
-            onDispose();
+          if (disposeHandler) {
+            disposeHandler();
           }
         }
       });
       playerWrapper.appendChild(player.el());
 
       if (onSetup) {
-        onSetup(player);
+        disposeHandler = onSetup(player);
       }
 
       return () => {

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/textTracks.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/textTracks.js
@@ -9,6 +9,22 @@ export function updateTextTracksMode(player, activeTextTrackFileId) {
   });
 }
 
+export function watchTextTracks(player, getActiveTextTrackFileId) {
+  function handleTextTracksUpdate() {
+    updateTextTracksMode(player, getActiveTextTrackFileId());
+  }
+
+  player.on('play', handleTextTracksUpdate);
+  player.on('texttrackchange', handleTextTracksUpdate);
+
+  handleTextTracksUpdate();
+
+  return () => {
+    player.off('play', handleTextTracksUpdate);
+    player.off('texttrackchange', handleTextTracksUpdate);
+  };
+}
+
 export function getTextTrackSources(textTrackFiles, textTracksDisabled) {
   if (textTracksDisabled) {
     return [];

--- a/entry_types/scrolled/package/src/frontend/MediaPlayer/usePlayerTextTracks.js
+++ b/entry_types/scrolled/package/src/frontend/MediaPlayer/usePlayerTextTracks.js
@@ -1,0 +1,23 @@
+import {useCallback, useEffect, useRef} from 'react';
+
+import {updateTextTracksMode, watchTextTracks} from './textTracks';
+
+export function usePlayerTextTracks({playerRef, activeTextTrackFileId}) {
+  const activeTextTrackFileIdRef = useRef(activeTextTrackFileId);
+
+  useEffect(() => {
+    activeTextTrackFileIdRef.current = activeTextTrackFileId;
+
+    if (playerRef.current) {
+      updateTextTracksMode(playerRef.current, activeTextTrackFileId);
+    }
+  }, [activeTextTrackFileId, playerRef]);
+
+  return useCallback((player) => {
+    const unwatchTextTracks = watchTextTracks(player, () => activeTextTrackFileIdRef.current);
+
+    return () => {
+      unwatchTextTracks();
+    };
+  }, []);
+}


### PR DESCRIPTION
When playing HLS video, iOS injects a captions text track with blank properties and sets it to showing. This overrides the default text track controlled by Pageflow. More aggressively update the showing text track when on play or when text tracks change.

REDMINE-19924