### PR TITLE
Prevent URL fragment update from breaking deep linking

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/features/changeURLFragment-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/features/changeURLFragment-spec.js
@@ -32,6 +32,53 @@ const seedData = {
 }
 
 describe('change url fragment on section update', () => {
+  beforeEach(() => {
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      get() { return 'complete'; }
+    });
+  });
+
+  it('does not update fragment before window load event', () => {
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      get() { return 'loading'; }
+    });
+
+    const {getSectionByPermaId} = renderEntry({
+      seed: seedData
+    });
+    window.history.replaceState = jest.fn();
+
+    getSectionByPermaId(11).simulateScrollingIntoView();
+
+    expect(window.history.replaceState).not.toHaveBeenCalled();
+  });
+
+  it('updates fragment after window load event', () => {
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      get() { return 'loading'; }
+    });
+
+    const {getSectionByPermaId} = renderEntry({
+      seed: seedData
+    });
+    window.history.replaceState = jest.fn();
+
+    act(() => {
+      Object.defineProperty(document, 'readyState', {
+        configurable: true,
+        get() { return 'complete'; }
+      });
+      window.dispatchEvent(new Event('load'));
+    });
+
+    getSectionByPermaId(11).simulateScrollingIntoView();
+
+    expect(window.history.replaceState).toHaveBeenCalledWith(null, null, '#on-the-destination-of-species');
+  });
+
   it('resets fragment when scrolling back to top', () => {
     const {getSectionByPermaId} = renderEntry({
       seed: seedData

--- a/entry_types/scrolled/package/src/frontend/Content.js
+++ b/entry_types/scrolled/package/src/frontend/Content.js
@@ -10,6 +10,7 @@ import {usePostMessageListener} from './usePostMessageListener';
 import {useSectionChangeEvents} from './useSectionChangeEvents';
 import {sectionChangeMessagePoster} from './sectionChangeMessagePoster';
 import {useScrollToTarget} from './useScrollTarget';
+import {useChapterSlugUpdater} from './useChapterSlugUpdater';
 
 import {AtmoProvider} from './useAtmo';
 import {Widget} from './Widget';
@@ -26,35 +27,23 @@ export const Content = withInlineEditingDecorator('ContentDecorator', function C
   } = useActiveExcursion(entryStructure);
 
   const [currentSectionIndex, setCurrentSectionIndexState] = useCurrentSectionIndexState();
-
   const [currentExcursionSectionIndex, setCurrentExcursionSectionIndex] = useState(0);
 
+  const {updateChapterSlug, updateExcursionChapterSlug} = useChapterSlugUpdater();
+
   useSectionChangeEvents(currentSectionIndex);
-
-  let updateChapterSlug = (section) => {
-    if (section.sectionIndex > 0) {
-      window.history.replaceState(null, null, '#'+ section.chapter.chapterSlug);
-    }
-    else {
-      window.history.replaceState(null, null, window.location.href.split('#')[0]);
-    }
-  }
-
-  let updateExcursionChapterSlug = (section) => {
-    window.history.replaceState(null, null, '#'+ section.chapter.chapterSlug);
-  }
 
   const setCurrentSection = useCallback(section => {
     sectionChangeMessagePoster(section.sectionIndex);
     setCurrentSectionIndexState(section.sectionIndex);
     updateChapterSlug(section);
-  }, [setCurrentSectionIndexState]);
+  }, [setCurrentSectionIndexState, updateChapterSlug]);
 
   const setCurrentExcursionSection = useCallback(section => {
     sectionChangeMessagePoster(section.sectionIndex);
     setCurrentExcursionSectionIndex(section.sectionIndex);
     updateExcursionChapterSlug(section);
-  }, [setCurrentExcursionSectionIndex]);
+  }, [updateExcursionChapterSlug]);
 
   const scrollToTarget = useScrollToTarget();
 

--- a/entry_types/scrolled/package/src/frontend/useChapterSlugUpdater.js
+++ b/entry_types/scrolled/package/src/frontend/useChapterSlugUpdater.js
@@ -1,0 +1,46 @@
+import {useEffect, useRef, useCallback} from 'react';
+
+export function useChapterSlugUpdater() {
+  const windowLoadedRef = useRef(false);
+
+  useWindowLoadTracking(windowLoadedRef)
+
+  const updateChapterSlug = useCallback((section) => {
+    if (!windowLoadedRef.current) {
+      return;
+    }
+
+    if (section.sectionIndex > 0) {
+      window.history.replaceState(null, null, '#'+ section.chapter.chapterSlug);
+    }
+    else {
+      window.history.replaceState(null, null, window.location.href.split('#')[0]);
+    }
+  }, []);
+
+  const updateExcursionChapterSlug = useCallback((section) => {
+    if (!windowLoadedRef.current) {
+      return;
+    }
+
+    window.history.replaceState(null, null, '#'+ section.chapter.chapterSlug);
+  }, []);
+
+  return {updateChapterSlug, updateExcursionChapterSlug};
+}
+
+function useWindowLoadTracking(windowLoadedRef) {
+  useEffect(() => {
+    if (document.readyState === 'complete') {
+      windowLoadedRef.current = true;
+      return;
+    }
+
+    const handleLoad = () => {
+      windowLoadedRef.current = true;
+    };
+
+    window.addEventListener('load', handleLoad);
+    return () => window.removeEventListener('load', handleLoad);
+  }, [windowLoadedRef]);
+}


### PR DESCRIPTION
Do not already update the URL fragment based on the current section before the browser had time to scroll to the chapter/section referenced in the URL fragment.

This also keeps deep link fragments around and only updates the slug after the next chapter change.