### PR TITLE
Configure when counter animation should start

### DIFF
--- a/entry_types/scrolled/config/locales/de.yml
+++ b/entry_types/scrolled/config/locales/de.yml
@@ -288,6 +288,12 @@ de:
             startValue:
               inline_help: Bei diesem Wert beginnt die Zählanimation.
               label: Startwert
+            startAnimationTrigger:
+              inline_help: Lege fest, wann die Animation starten soll.
+              label: Animation starten
+              values:
+                onActivate: Bei Erreichen der Viewport-Mitte
+                onVisible: Sobald das Element sichtbar wird
             targetValue:
               inline_help: Zahlenwert, der angezeigt werden soll. Die Zählanimation endet bei diesem Wert.
               label: Zielwert

--- a/entry_types/scrolled/config/locales/en.yml
+++ b/entry_types/scrolled/config/locales/en.yml
@@ -279,6 +279,12 @@ en:
             startValue:
               inline_help: The counting animation starts with this value
               label: Start value
+            startAnimationTrigger:
+              inline_help: Determine when the animation should start.
+              label: Start animation
+              values:
+                onActivate: When scrolled to center of viewport
+                onVisible: When first scrolled into view
             targetValue:
               inline_help: Value to display. Final value for counting animation.
               label: Target value

--- a/entry_types/scrolled/package/spec/frontend/Counter-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/Counter-spec.js
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import {Counter} from 'contentElements/counter/Counter';
+
+import {renderInContentElement} from 'pageflow-scrolled/testHelpers';
+import {contentElementWidths} from 'pageflow-scrolled/frontend';
+
+import '@testing-library/jest-dom/extend-expect';
+
+describe('Counter', () => {
+  function renderCounter(configuration = {}) {
+    const baseConfiguration = {
+      targetValue: 10,
+      startValue: 0,
+      countingSpeed: 'none',
+      entranceAnimation: 'fadeIn',
+      ...configuration
+    };
+
+    return renderInContentElement(
+      <Counter
+        configuration={baseConfiguration}
+        contentElementId={5}
+        contentElementWidth={contentElementWidths.md}
+        sectionProps={{}}
+      />, {
+        editorState: {isEditable: false}
+      }
+    );
+  }
+
+  it('starts animation on activate by default', () => {
+    const {getByText, simulateScrollPosition} = renderCounter();
+
+    expect(getByText('10').className).not.toContain('animation-fadeIn-active');
+
+    simulateScrollPosition('in viewport');
+
+    expect(getByText('10').className).not.toContain('animation-fadeIn-active');
+
+    simulateScrollPosition('center of viewport');
+
+    expect(getByText('10').className).toContain('animation-fadeIn-active');
+  });
+
+  it('starts animation on visible when configured', () => {
+    const {getByText, simulateScrollPosition} = renderCounter({startAnimationTrigger: 'onVisible'});
+
+    expect(getByText('10').className).not.toContain('animation-fadeIn-active');
+
+    simulateScrollPosition('in viewport');
+
+    expect(getByText('10').className).toContain('animation-fadeIn-active');
+  });
+});

--- a/entry_types/scrolled/package/src/contentElements/counter/Counter.js
+++ b/entry_types/scrolled/package/src/contentElements/counter/Counter.js
@@ -23,6 +23,7 @@ export function Counter({configuration, contentElementId, contentElementWidth, s
   const decimalPlaces = configuration.decimalPlaces || 0;
   const startValue = configuration.startValue || 0;
   const countingDuration = countingDurations[configuration.countingSpeed];
+  const startAnimationTrigger = configuration.startAnimationTrigger || 'onActivate';
 
   const [currentValue, setCurrentValue] = useState(
     countingDuration > 0 ? startValue : targetValue
@@ -75,9 +76,8 @@ export function Counter({configuration, contentElementId, contentElementWidth, s
   }, [animate, resetAnimation, isEditable]);
 
   useContentElementLifecycle({
-    onActivate() {
-      animate();
-    },
+    onActivate: startAnimationTrigger === 'onActivate' ? animate : undefined,
+    onVisible: startAnimationTrigger === 'onVisible' ? animate : undefined,
 
     onInvisible() {
       if (isEditable) {

--- a/entry_types/scrolled/package/src/contentElements/counter/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/counter/editor.js
@@ -48,6 +48,12 @@ editor.contentElementTypes.register('counter', {
         visibleBinding: 'countingSpeed',
         visible: countingSpeed => countingSpeed !== 'none'
       });
+      this.input('startAnimationTrigger', SelectInputView, {
+        values: ['onActivate', 'onVisible'],
+        visibleBinding: ['entranceAnimation', 'countingSpeed'],
+        visible: ([entranceAnimation, countingSpeed]) =>
+          (entranceAnimation || 'none') !== 'none' || countingSpeed !== 'none'
+      });
       this.view(SeparatorView);
       this.input('textSize', SelectInputView, {
         values: ['large', 'medium', 'small', 'verySmall']


### PR DESCRIPTION
Allow controlling whether entrance/counting animations begin when the element first becomes visible or when it reaches the center of the viewport. Defaults to center (onActivate) for backwards compatibility.