### PR TITLE
Allow autoplaying inline videos only if entry is unmuted

### DIFF
--- a/entry_types/scrolled/config/locales/de.yml
+++ b/entry_types/scrolled/config/locales/de.yml
@@ -672,10 +672,11 @@ de:
             id:
               label: Video
             playbackMode:
-              inline_help_html: Bestimme, wie das Video gestartet wird:<ul><li><strong>Manuell:</strong> Durch einen Klick des Benutzers.</li><li><strong>Automatisch:</strong> Wenn es die Mitte des Browser-Viewports erreicht.</li><li><strong>Loop:</strong> In Endlosschleife sobald es sichtbar wird.</li></ul>
+              inline_help_html: Bestimme, wie das Video gestartet wird:<ul><li><strong>Manuell:</strong> Durch einen Klick des Benutzers.</li><li><strong>Automatisch:</strong> Wenn es die Mitte des Browser-Viewports erreicht.</li><li><strong>Automatisch falls Stummschaltung aufgehoben:</strong> Wenn es die Mitte des Viewports erreicht, aber nur wenn der Ton des Beitrags bereits aktiviert wurde, z.B. über das Lautsprecher-Icon in der Navigationsleiste.</li><li><strong>Loop:</strong> In Endlosschleife sobald es sichtbar wird.</li></ul>
               label: Wiedergabe-Modus
               values:
                 autoplay: Automatisch
+                autoplayIfUnmuted: Automatisch falls Stummschaltung aufgehoben
                 loop: Loop
                 manual: Manuell
             portraitId:

--- a/entry_types/scrolled/config/locales/en.yml
+++ b/entry_types/scrolled/config/locales/en.yml
@@ -655,10 +655,11 @@ en:
             id:
               label: Video
             playbackMode:
-              inline_help_html: Determines how the video starts:<ul><li><strong>Manual:</strong> When the user clicks the video.</li><li><strong>Autoplay:</strong> When the video is scrolled to the center of the browser viewport.</li><li><strong>Loop:</strong> In an endless loop soon as it becomes visible.</li></ul>
+              inline_help_html: Determines how the video starts:<ul><li><strong>Manual:</strong> When the user clicks the video.</li><li><strong>Autoplay:</strong> When the video is scrolled to the center of the browser viewport.</li><li><strong>Autoplay if entry unmuted:</strong> When scrolled to center, but only if sound for the entry has been unmuted, for example via the unmute button in the navigation bar.</li><li><strong>Loop:</strong> In an endless loop soon as it becomes visible.</li></ul>
               label: Playback Mode
               values:
                 autoplay: Autoplay
+                autoplayIfUnmuted: Autoplay if entry unmuted
                 loop: Loop
                 manual: Manual
             portraitId:

--- a/entry_types/scrolled/package/spec/contentElements/inlineVideo/handlers-spec.js
+++ b/entry_types/scrolled/package/spec/contentElements/inlineVideo/handlers-spec.js
@@ -13,7 +13,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {};
       const playerActions = getPlayerActions();
 
-      const {onVisible} = getLifecycleHandlers(configuration, playerActions);
+      const {onVisible} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onVisible();
 
       expect(playerActions.calls).toEqual([]);
@@ -23,7 +23,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'manual'};
       const playerActions = getPlayerActions();
 
-      const {onVisible} = getLifecycleHandlers(configuration, playerActions);
+      const {onVisible} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onVisible();
 
       expect(playerActions.calls).toEqual([]);
@@ -33,7 +33,17 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'autoplay'};
       const playerActions = getPlayerActions();
 
-      const {onVisible} = getLifecycleHandlers(configuration, playerActions);
+      const {onVisible} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
+      onVisible();
+
+      expect(playerActions.calls).toEqual([]);
+    });
+
+    it('is no-op for autoplayIfUnmuted playbackMode', () => {
+      const configuration = {playbackMode: 'autoplayIfUnmuted'};
+      const playerActions = getPlayerActions();
+
+      const {onVisible} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onVisible();
 
       expect(playerActions.calls).toEqual([]);
@@ -43,7 +53,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'loop'};
       const playerActions = getPlayerActions();
 
-      const {onVisible} = getLifecycleHandlers(configuration, playerActions);
+      const {onVisible} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onVisible();
 
       expect(playerActions.play).toHaveBeenCalledWith();
@@ -55,7 +65,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {};
       const playerActions = getPlayerActions();
 
-      const {onActivate} = getLifecycleHandlers(configuration, playerActions);
+      const {onActivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onActivate();
 
       expect(playerActions.calls).toEqual([]);
@@ -65,7 +75,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'loop'};
       const playerActions = getPlayerActions();
 
-      const {onActivate} = getLifecycleHandlers(configuration, playerActions);
+      const {onActivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onActivate();
 
       expect(playerActions.calls).toEqual([]);
@@ -75,7 +85,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'manual'};
       const playerActions = getPlayerActions();
 
-      const {onActivate} = getLifecycleHandlers(configuration, playerActions);
+      const {onActivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onActivate();
 
       expect(playerActions.calls).toEqual([]);
@@ -85,7 +95,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'autoplay'};
       const playerActions = getPlayerActions();
 
-      const {onActivate} = getLifecycleHandlers(configuration, playerActions);
+      const {onActivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onActivate();
 
       expect(playerActions.play).toHaveBeenCalledWith({via: 'autoplay'});
@@ -95,7 +105,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {autoplay: true};
       const playerActions = getPlayerActions();
 
-      const {onActivate} = getLifecycleHandlers(configuration, playerActions);
+      const {onActivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onActivate();
 
       expect(playerActions.play).toHaveBeenCalledWith({via: 'autoplay'});
@@ -105,10 +115,30 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'manual', autoplay: true};
       const playerActions = getPlayerActions();
 
-      const {onActivate} = getLifecycleHandlers(configuration, playerActions);
+      const {onActivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onActivate();
 
       expect(playerActions.calls).toEqual([]);
+    });
+
+    it('is no-op for autoplayIfUnmuted playbackMode when muted', () => {
+      const configuration = {playbackMode: 'autoplayIfUnmuted'};
+      const playerActions = getPlayerActions();
+
+      const {onActivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: true});
+      onActivate();
+
+      expect(playerActions.calls).toEqual([]);
+    });
+
+    it('calls play for autoplayIfUnmuted playbackMode when unmuted', () => {
+      const configuration = {playbackMode: 'autoplayIfUnmuted'};
+      const playerActions = getPlayerActions();
+
+      const {onActivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
+      onActivate();
+
+      expect(playerActions.play).toHaveBeenCalledWith({via: 'autoplay'});
     });
   });
 
@@ -117,7 +147,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {};
       const playerActions = getPlayerActions();
 
-      const {onDeactivate} = getLifecycleHandlers(configuration, playerActions);
+      const {onDeactivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onDeactivate();
 
       expect(playerActions.fadeOutAndPause).toHaveBeenCalled();
@@ -127,7 +157,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'manual'};
       const playerActions = getPlayerActions();
 
-      const {onDeactivate} = getLifecycleHandlers(configuration, playerActions);
+      const {onDeactivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onDeactivate();
 
       expect(playerActions.fadeOutAndPause).toHaveBeenCalled();
@@ -137,7 +167,17 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'autoplay'};
       const playerActions = getPlayerActions();
 
-      const {onDeactivate} = getLifecycleHandlers(configuration, playerActions);
+      const {onDeactivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
+      onDeactivate();
+
+      expect(playerActions.fadeOutAndPause).toHaveBeenCalled();
+    });
+
+    it('calls fadeOutAndPause for autoplayIfUnmuted playbackMode', () => {
+      const configuration = {playbackMode: 'autoplayIfUnmuted'};
+      const playerActions = getPlayerActions();
+
+      const {onDeactivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onDeactivate();
 
       expect(playerActions.fadeOutAndPause).toHaveBeenCalled();
@@ -147,7 +187,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'loop'};
       const playerActions = getPlayerActions();
 
-      const {onDeactivate} = getLifecycleHandlers(configuration, playerActions);
+      const {onDeactivate} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onDeactivate();
 
       expect(playerActions.calls).toEqual([]);
@@ -159,7 +199,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {};
       const playerActions = getPlayerActions();
 
-      const {onInvisible} = getLifecycleHandlers(configuration, playerActions);
+      const {onInvisible} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onInvisible();
 
       expect(playerActions.calls).toEqual([]);
@@ -169,7 +209,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'manual'};
       const playerActions = getPlayerActions();
 
-      const {onInvisible} = getLifecycleHandlers(configuration, playerActions);
+      const {onInvisible} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onInvisible();
 
       expect(playerActions.calls).toEqual([]);
@@ -179,7 +219,17 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'autoplay'};
       const playerActions = getPlayerActions();
 
-      const {onInvisible} = getLifecycleHandlers(configuration, playerActions);
+      const {onInvisible} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
+      onInvisible();
+
+      expect(playerActions.calls).toEqual([]);
+    });
+
+    it('is no-op for autoplayIfUnmuted playbackMode', () => {
+      const configuration = {playbackMode: 'autoplayIfUnmuted'};
+      const playerActions = getPlayerActions();
+
+      const {onInvisible} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onInvisible();
 
       expect(playerActions.calls).toEqual([]);
@@ -189,7 +239,7 @@ describe('getLifecycleHandlers', () => {
       const configuration = {playbackMode: 'loop'};
       const playerActions = getPlayerActions();
 
-      const {onInvisible} = getLifecycleHandlers(configuration, playerActions);
+      const {onInvisible} = getLifecycleHandlers({configuration, playerActions, mediaMuted: false});
       onInvisible();
 
       expect(playerActions.fadeOutAndPause).toHaveBeenCalled();

--- a/entry_types/scrolled/package/src/contentElements/inlineVideo/InlineVideo.js
+++ b/entry_types/scrolled/package/src/contentElements/inlineVideo/InlineVideo.js
@@ -177,7 +177,7 @@ function PlayerWithControlBar({
   const {isEditable, isSelected} = useContentElementEditorState();
 
   const {shouldLoad, shouldPrepare} = useContentElementLifecycle(
-    getLifecycleHandlers(configuration, playerActions)
+    getLifecycleHandlers({configuration, playerActions, mediaMuted: media.muted})
   );
 
   useAudioFocus({

--- a/entry_types/scrolled/package/src/contentElements/inlineVideo/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/inlineVideo/editor.js
@@ -75,7 +75,7 @@ editor.contentElementTypes.register('inlineVideo', {
       this.view(SeparatorView);
 
       this.input('playbackMode', SelectInputView, {
-        values: ['manual', 'autoplay', 'loop']
+        values: ['manual', 'autoplay', 'autoplayIfUnmuted', 'loop']
       });
 
       this.input('hideControlBar', CheckBoxInputView, {

--- a/entry_types/scrolled/package/src/contentElements/inlineVideo/handlers.js
+++ b/entry_types/scrolled/package/src/contentElements/inlineVideo/handlers.js
@@ -1,4 +1,4 @@
-export function getLifecycleHandlers(configuration, playerActions) {
+export function getLifecycleHandlers({configuration, playerActions, mediaMuted}) {
   return {
     onVisible() {
       if (configuration.playbackMode === 'loop') {
@@ -8,7 +8,8 @@ export function getLifecycleHandlers(configuration, playerActions) {
 
     onActivate() {
       if (configuration.playbackMode === 'autoplay' ||
-          (!configuration.playbackMode && configuration.autoplay)) {
+          (!configuration.playbackMode && configuration.autoplay) ||
+          (configuration.playbackMode === 'autoplayIfUnmuted' && !mediaMuted)) {
         playerActions.play({via: 'autoplay'});
       }
     },


### PR DESCRIPTION
If the entry is not yet unmuted, it can make sense to offer a play button to let the user intentionally play the video with sound. If sound has already been enabled, it can still make sense to auto-player subsequent videos in the story.