### PR TITLE
Speed up CI with pre-built Docker image

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+# Build dependencies for Ruby and native gem extensions
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      autoconf bison build-essential ca-certificates curl git gnupg \
+      libffi-dev libgdbm-dev libmysqlclient-dev libncurses5-dev \
+      libreadline-dev libssl-dev libyaml-dev software-properties-common \
+      tzdata zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ruby
+ARG RUBY_VERSION=3.4.3
+RUN curl -fsSL "https://cache.ruby-lang.org/pub/ruby/${RUBY_VERSION%.*}/ruby-${RUBY_VERSION}.tar.gz" | tar xz \
+    && cd ruby-${RUBY_VERSION} \
+    && ./configure --disable-install-doc \
+    && make -j"$(nproc)" \
+    && make install \
+    && cd .. && rm -rf ruby-${RUBY_VERSION} \
+    && gem update --system && gem install bundler
+
+# Node.js 22
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Yarn
+RUN corepack enable && corepack prepare yarn@1 --activate
+
+# System packages for image processing and tests
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      imagemagick \
+      libvips-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# audiowaveform via PPA
+RUN add-apt-repository -y ppa:chris-needham/ppa \
+    && apt-get update \
+    && apt-get install -y audiowaveform \
+    && rm -rf /var/lib/apt/lists/*
+
+# Google Chrome for JS integration tests
+RUN curl -fsSL https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o /tmp/chrome.deb \
+    && apt-get update && apt-get install -y /tmp/chrome.deb \
+    && rm /tmp/chrome.deb && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -1,0 +1,39 @@
+name: build-test-image
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - .github/docker/Dockerfile
+  schedule:
+    # Rebuild weekly to pick up security updates
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}/test
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .github/docker
+        push: true
+        tags: |
+          ${{ env.IMAGE }}:latest
+          ${{ env.IMAGE }}:${{ github.sha }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,12 +3,13 @@ on: [push, pull_request]
 
 env:
   RAILS_ENV: test
-  PAGEFLOW_DB_HOST: 127.0.0.1
+  PAGEFLOW_DB_HOST: mysql
 
 jobs:
   rspec:
     name: ${{ matrix.job }} (Rails ${{ matrix.rails-version }})
     runs-on: ubuntu-latest
+    container: ghcr.io/${{ github.repository }}/test:latest
     env:
       PAGEFLOW_RAILS_VERSION: ${{ matrix.rails-version }}
 
@@ -25,34 +26,29 @@ jobs:
         include:
           - job: pageflow
             engine-name: pageflow
-            ruby-version: 3.4
             engine-directory: .
             rspec-command: bin/rspec --tag ~js
             install-audiowaveform: true
 
           - job: pageflow_js
             engine-name: pageflow
-            ruby-version: 3.4
             engine-directory: .
             rspec-command: bin/rspec-with-retry --tag js
 
           - job: pageflow_paged
             engine-name: pageflow_paged
-            ruby-version: 3.4
             engine-directory: entry_types/paged
             plugin-name: pageflow_paged
             rspec-command: bin/rspec
 
           - job: pageflow_scrolled
             engine-name: pageflow_scrolled
-            ruby-version: 3.4
             engine-directory: entry_types/scrolled
             plugin-name: pageflow_scrolled
             rspec-command: bin/rspec --tag ~js
 
           - job: pageflow_scrolled_js
             engine-name: pageflow_scrolled
-            ruby-version: 3.4
             engine-directory: entry_types/scrolled
             plugin-name: pageflow_scrolled
             rspec-command: bin/rspec-with-retry-on-timeout --tag js
@@ -64,7 +60,6 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
         ports:
           - 3306:3306
-        # Set health checks to wait until mysql has started
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s
@@ -73,7 +68,6 @@ jobs:
 
       redis:
         image: redis
-        # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -81,7 +75,7 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Caching
 
@@ -89,52 +83,19 @@ jobs:
       uses: actions/cache@v4
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-ruby-${{ matrix.ruby-version }}-rails-${{ matrix.rails-version }}-gems-${{ hashFiles('**/*.gemspec') }}-${{ hashFiles('**/Gemfile') }}
+        key: ${{ runner.os }}-gems-rails-${{ matrix.rails-version }}-${{ hashFiles('**/*.gemspec') }}-${{ hashFiles('**/Gemfile') }}
         restore-keys: |
-          ${{ runner.os }}-ruby-${{ matrix.ruby-version }}-rails-${{ matrix.rails-version }}-gems-
-
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          ${{ runner.os }}-gems-rails-${{ matrix.rails-version }}-
 
     - name: Set up cache for Yarn
       uses: actions/cache@v4
       with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        path: .yarn-cache
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
 
-    # Ruby/Node
-
-    - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-
-    - name: Use Node.js 22
-      uses: actions/setup-node@v1
-      with:
-        node-version: 22
-
     # Dependencies
-
-    - name: Install imagemagick package for image processing
-      run: |
-        sudo apt-get update
-        sudo apt-get install imagemagick
-
-    - name: Install libvips package for image processing
-      run: |
-        sudo apt-get update
-        sudo apt-get install libvips-dev
-
-    - name: Install audiowaveform package
-      if: ${{ matrix.install-audiowaveform == true}}
-      run: |
-        sudo add-apt-repository -y ppa:chris-needham/ppa
-        sudo apt-get update
-        sudo apt-get install audiowaveform
 
     - name: Bundle install
       run: |
@@ -143,7 +104,7 @@ jobs:
 
     - name: Yarn install
       run: |
-        yarn install
+        yarn install --cache-folder .yarn-cache
 
     # Build
 
@@ -171,6 +132,7 @@ jobs:
 
   jest:
     runs-on: ubuntu-latest
+    container: ghcr.io/${{ github.repository }}/test:latest
 
     strategy:
       fail-fast: false
@@ -186,29 +148,20 @@ jobs:
             package-directory: entry_types/scrolled/package
 
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+    - uses: actions/checkout@v4
 
     - name: Set up cache for Yarn
       uses: actions/cache@v4
       with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        path: .yarn-cache
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
 
-    - name: Set up Node.js 22
-      uses: actions/setup-node@v1
-      with:
-        node-version: 22
-
     - name: Yarn install
       run: |
-        yarn install
-        (cd entry_types/paged/packages/pageflow-paged-react; yarn install)
+        yarn install --cache-folder .yarn-cache
+        (cd entry_types/paged/packages/pageflow-paged-react; yarn install --cache-folder ../../../../.yarn-cache)
 
     - name: Build packages
       run: |

--- a/spec/support/pageflow/support/config/capybara.rb
+++ b/spec/support/pageflow/support/config/capybara.rb
@@ -11,6 +11,7 @@ Capybara.register_driver :selenium_chrome_headless_no_sandbox do |app|
 
   options.add_argument('--headless=new')
   options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
   options.add_argument('--disable-gpu') if Gem.win_platform?
 
   Capybara::Selenium::Driver.new(app,


### PR DESCRIPTION
Move system dependency installation (Ruby, Node, imagemagick, libvips, audiowaveform, Chrome) into a custom Docker image published to GHCR. Test workflows use this image via the container: directive, eliminating 15+ minutes of setup per job.

REDMINE-21261