### PR TITLE
Use polling for rollup watch mode

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -379,9 +379,19 @@ const pageflowScrolled = [
   )))
 ];
 
-export default [
+const allConfigs = [
   ...pageflow,
   ...pageflowScrolled,
   ...pageflowPaged,
   ...pageflowPagedReact
-]
+];
+
+export default allConfigs.map(config => ({
+  ...config,
+  watch: {
+    chokidar: {
+      usePolling: true,
+      interval: 500
+    }
+  }
+}))


### PR DESCRIPTION
Prevent rollup --watch from losing track of file changes when rebase replaces files in the working directory with new inodes.