### PR TITLE
Allow skipping Percy snapshots via PR description

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,6 +18,8 @@ env:
 
 jobs:
   snapshot:
+    # Skip when PR description contains [skip percy] to reduce Percy usage
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip percy]')
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
Authors working on changes that touch the scrolled package but are known not to affect visual output (e.g. pure refactors or non-visual logic) can now opt out of the Percy snapshot run by including [skip percy] in the PR description. This conserves Percy usage quota without needing to further narrow the path filter.