### PR TITLE
Clear stale permalink redirect on slug change

### DIFF
--- a/app/models/pageflow/permalink.rb
+++ b/app/models/pageflow/permalink.rb
@@ -53,6 +53,7 @@ module Pageflow
 
     def create_redirect
       directory.redirects.where(slug:).delete_all
+      PermalinkRedirect.where(slug: slug_was, directory_id: directory_id_was).delete_all
       entry.permalink_redirects.create!(slug: slug_was,
                                         directory_id: directory_id_was)
     end

--- a/spec/models/concerns/pageflow/permalinkable_spec.rb
+++ b/spec/models/concerns/pageflow/permalinkable_spec.rb
@@ -326,6 +326,35 @@ module Pageflow
       expect(entry.permalink_redirects.reload).to be_empty
     end
 
+    it 'removes redirect left behind while unpublished entry took the slug' do
+      directory = create(:permalink_directory)
+      previous_entry = create(
+        :entry,
+        :published,
+        site: directory.site,
+        permalink_attributes: {
+          directory:,
+          slug: 'shared-slug'
+        }
+      )
+      draft_entry = create(
+        :entry,
+        site: directory.site,
+        permalink_attributes: {
+          directory:,
+          slug: 'draft-slug'
+        }
+      )
+
+      previous_entry.update(permalink_attributes: {slug: 'moved-slug'})
+      draft_entry.update(permalink_attributes: {slug: 'shared-slug'})
+      draft_entry.update_column(:first_published_at, 1.day.ago)
+
+      expect {
+        draft_entry.update!(permalink_attributes: {slug: 'another-slug'})
+      }.not_to raise_error
+    end
+
     it 'destroys permalink when entry is destroyed' do
       entry = create(
         :entry,


### PR DESCRIPTION
Previously, updating a permalink's slug or directory could fail with a duplicate-key error on the permalink_redirects unique index. This happened when a prior holder of the same slug had left a redirect behind: if this permalink then took that slug while its entry was still unpublished, the redirect-creation callback was skipped and the old redirect lingered. Once the entry was published and its slug was changed again, inserting the new redirect collided with the zombie.

Cleaning up any existing redirect for the old slug/directory before creating the new one ensures renaming published entries stays reliable, while unpublished slug changes still leave live redirects of other entries untouched.