### PR TITLE
Fix unstyled link flash in external link cards

### DIFF
--- a/entry_types/scrolled/package/spec/contentElements/externalLinkList/frontend/ExternalLink-spec.js
+++ b/entry_types/scrolled/package/spec/contentElements/externalLinkList/frontend/ExternalLink-spec.js
@@ -1,8 +1,11 @@
 import {ExternalLink} from 'contentElements/externalLinkList/frontend/ExternalLink';
+import styles from 'contentElements/externalLinkList/frontend/ExternalLink.module.css';
 
 import React from 'react';
 
 import {renderInEntry} from 'support';
+import {renderInContentElement} from 'pageflow-scrolled/testHelpers';
+import {useFakeTranslations} from 'pageflow/testHelpers';
 import {screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import {features} from 'pageflow/frontend';
@@ -359,6 +362,159 @@ describe('ExternalLink', () => {
 
       expect(getByRole('img')).toHaveAttribute('src', expect.stringContaining('linkThumbnailLarge'));
       expect(getByRole('img')).not.toHaveAttribute('srcset');
+    });
+  });
+
+  describe('card link', () => {
+    useFakeTranslations({
+      'pageflow_scrolled.public.more': 'More'
+    });
+
+    it('wraps title in a link when title is present and href is set', () => {
+      const configuration = {
+        itemLinks: {1: {href: 'http://example.com'}},
+        itemTexts: {1: {title: value('Title')}}
+      };
+
+      renderInEntry(<ExternalLink id={1} configuration={configuration} />);
+
+      expect(screen.getByRole('link', {name: 'Title'}))
+        .toHaveAttribute('href', 'http://example.com');
+    });
+
+    it('wraps thumbnail image in a link named by its alt when textPosition is none', () => {
+      const configuration = {
+        itemLinks: {1: {href: 'http://example.com'}}
+      };
+
+      renderInEntry(
+        <ExternalLink id={1}
+                      configuration={configuration}
+                      textPosition="none"
+                      thumbnail={5}
+                      loadImages={true} />,
+        {
+          seed: {
+            imageFiles: [{permaId: 5, configuration: {alt: 'Vendor logo'}}],
+            imageFileUrlTemplates: {
+              linkThumbnailLarge: ':id_partition/linkThumbnailLarge/image.jpg'
+            }
+          }
+        }
+      );
+
+      expect(screen.getByRole('link', {name: 'Vendor logo'}))
+        .toHaveAttribute('href', 'http://example.com');
+    });
+
+    it('keeps lifted file rights outside the image link when textPosition is none', () => {
+      const configuration = {
+        itemLinks: {1: {href: 'http://example.com'}}
+      };
+
+      const {container} = renderInEntry(
+        <ExternalLink id={1}
+                      configuration={configuration}
+                      textPosition="none" />
+      );
+
+      const link = screen.getByRole('link');
+      container.querySelectorAll(`.${styles.liftedFileRights}`).forEach(el => {
+        expect(link.contains(el)).toBe(false);
+      });
+    });
+
+    it('renders a visually-hidden More fallback link when no title or description', () => {
+      const configuration = {
+        itemLinks: {1: {href: 'http://example.com'}}
+      };
+
+      renderInEntry(<ExternalLink id={1} configuration={configuration} />);
+
+      expect(screen.getByRole('link', {name: 'More'}))
+        .toHaveAttribute('href', 'http://example.com');
+    });
+
+    it('references description from More link via aria-describedby', () => {
+      const configuration = {
+        itemLinks: {1: {href: 'http://example.com'}},
+        itemTexts: {1: {description: value('Some description')}}
+      };
+
+      const {container} = renderInEntry(
+        <ExternalLink id={1} configuration={configuration} />
+      );
+
+      const link = screen.getByRole('link', {name: 'More'});
+      const describedById = link.getAttribute('aria-describedby');
+      expect(describedById).toBeTruthy();
+      expect(container.querySelector(`[id="${describedById}"]`))
+        .toHaveTextContent('Some description');
+    });
+
+    it('omits aria-describedby when no description is present', () => {
+      const configuration = {
+        itemLinks: {1: {href: 'http://example.com'}}
+      };
+
+      renderInEntry(<ExternalLink id={1} configuration={configuration} />);
+
+      expect(screen.getByRole('link', {name: 'More'}))
+        .not.toHaveAttribute('aria-describedby');
+    });
+
+    it('does not nest a description inner link inside the card link', () => {
+      const configuration = {
+        itemLinks: {1: {href: 'http://example.com'}},
+        itemTexts: {
+          1: {
+            description: [{
+              type: 'paragraph',
+              children: [
+                {text: 'See '},
+                {type: 'link',
+                 href: 'https://inner.example.com',
+                 children: [{text: 'here'}]}
+              ]
+            }]
+          }
+        }
+      };
+
+      renderInEntry(<ExternalLink id={1} configuration={configuration} />);
+
+      const cardLink = screen.getByRole('link', {name: 'More'});
+      const innerLink = screen.getByRole('link', {name: 'here'});
+      expect(cardLink.contains(innerLink)).toBe(false);
+    });
+
+    describe('in editor mode', () => {
+      it('does not render inner title link', () => {
+        const configuration = {
+          itemLinks: {1: {href: 'http://example.com'}},
+          itemTexts: {1: {title: value('Title')}}
+        };
+
+        const {container} = renderInContentElement(
+          <ExternalLink id={1} configuration={configuration} />,
+          {editorState: {isEditable: true}}
+        );
+
+        expect(container.querySelector(`.${styles.titleLink}`)).toBeNull();
+      });
+
+      it('does not render More fallback link', () => {
+        const configuration = {
+          itemLinks: {1: {href: 'http://example.com'}}
+        };
+
+        const {container} = renderInContentElement(
+          <ExternalLink id={1} configuration={configuration} />,
+          {editorState: {isEditable: true}}
+        );
+
+        expect(container.querySelector(`.${styles.moreLink}`)).toBeNull();
+      });
     });
   });
 });

--- a/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLink.js
+++ b/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLink.js
@@ -7,6 +7,7 @@ import {
   EditableInlineText,
   EditableText,
   InlineFileRights,
+  Link,
   Text,
   useFileWithInlineRights,
   useContentElementConfigurationUpdate,
@@ -100,6 +101,19 @@ export function ExternalLink({id, configuration, contentElementId, ...props}) {
             utils.isBlankEditableTextValue(itemTexts[id]?.description || legacyTexts.description));
   }
 
+  function getCardLinkMode() {
+    if (isEditable || !href || displayButtons) {
+      return 'none';
+    }
+    if (props.textPosition === 'none') {
+      return 'image';
+    }
+    if (titlePresent) {
+      return 'title';
+    }
+    return 'more';
+  }
+
   const href = itemLinks[id] ? itemLinks[id]?.href : ensureAbsolute(props.url);
   const openInNewTab = itemLinks[id] ? itemLinks[id]?.openInNewTab : props.open_in_new_tab;
 
@@ -111,6 +125,12 @@ export function ExternalLink({id, configuration, contentElementId, ...props}) {
                                     props.textPosition === 'none';
 
   const inlineFileRightsItems = [{file: thumbnailImageFile, label: 'image'}];
+
+  const titlePresent = presentOrEditing('title');
+  const descriptionPresent = presentOrEditing('description');
+  const cardLinkMode = getCardLinkMode();
+  const descriptionElementId = `external-link-${contentElementId}-${id}-description`;
+
   return (
     <li className={classNames(styles.item,
                               styles[`textPosition-${props.textPosition}`],
@@ -119,18 +139,21 @@ export function ExternalLink({id, configuration, contentElementId, ...props}) {
                               {[styles.highlighted]: props.highlighted},
                               {[styles.selected]: props.selected})}
         onClick={props.onClick}>
-      <Link isEnabled={!displayButtons}
-            isEditable={isEditable}
-            linkPreviewDisabled={props.selected && configuration.backfaces}
-            actionButtonVisible={props.selected}
-            actionButtonPortal={true}
-            href={href}
-            openInNewTab={openInNewTab}
-            onChange={handleLinkChange}>
+      <EditorLinkWrapper isEditable={isEditable}
+                         linkPreviewDisabled={props.selected && configuration.backfaces}
+                         actionButtonVisible={props.selected}
+                         actionButtonPortal={true}
+                         href={href}
+                         openInNewTab={openInNewTab}
+                         onChange={handleLinkChange}>
         <div className={styles.cardWrapper}>
           {renderItemContent()}
+          {cardLinkMode === 'more' &&
+           <MoreLink href={href}
+                     openInNewTab={openInNewTab}
+                     describedBy={descriptionPresent ? descriptionElementId : undefined} />}
         </div>
-      </Link>
+      </EditorLinkWrapper>
     </li>
   );
 
@@ -167,7 +190,14 @@ export function ExternalLink({id, configuration, contentElementId, ...props}) {
                        fit={props.thumbnailFit}
                        linkWidth={props.linkWidth}
                        load={props.loadImages}
-                       showPlaceholder={isEditable}>
+                       showPlaceholder={isEditable}
+                       renderImageLink={cardLinkMode === 'image'
+                         ? (image) => (
+                             <Link href={href} openInNewTab={openInNewTab}>
+                               {image}
+                             </Link>
+                           )
+                         : undefined}>
               <InlineFileRights configuration={configuration}
                                 context="insideElement"
                                 position={props.textPosition === 'overlay' ? 'top': 'bottom'}
@@ -189,17 +219,23 @@ export function ExternalLink({id, configuration, contentElementId, ...props}) {
                                      placeholder={t('pageflow_scrolled.inline_editing.type_tagline')}
                                      onChange={value => handleTextChange('tagline', value)} />
                </Text>}
-              {presentOrEditing('title') &&
+              {titlePresent &&
                <Text scaleCategory={`teaserTitle-${scaleCategorySuffix}`}>
-                 <EditableInlineText value={itemTexts[id]?.title || legacyTexts.title}
-                                     placeholder={t('pageflow_scrolled.inline_editing.type_heading')}
-                                     onChange={value => handleTextChange('title', value)} />
+                 <TitleLink isEnabled={cardLinkMode === 'title'}
+                            href={href}
+                            openInNewTab={openInNewTab}>
+                   <EditableInlineText value={itemTexts[id]?.title || legacyTexts.title}
+                                       placeholder={t('pageflow_scrolled.inline_editing.type_heading')}
+                                       onChange={value => handleTextChange('title', value)} />
+                 </TitleLink>
                </Text>}
-              {presentOrEditing('description') &&
-               <EditableText value={itemTexts[id]?.description || legacyTexts.description}
-                             scaleCategory={`teaserDescription-${scaleCategorySuffix}`}
-                             placeholder={t('pageflow_scrolled.inline_editing.type_text')}
-                             onChange={value => handleTextChange('description', value)} />}
+              {descriptionPresent &&
+               <div className={styles.description} id={descriptionElementId}>
+                 <EditableText value={itemTexts[id]?.description || legacyTexts.description}
+                               scaleCategory={`teaserDescription-${scaleCategorySuffix}`}
+                               placeholder={t('pageflow_scrolled.inline_editing.type_text')}
+                               onChange={value => handleTextChange('description', value)} />
+               </div>}
               {configuration.displayButtons && !configuration.backfaces &&
                presentOrEditing('link') &&
                <div className={styles.button}>
@@ -261,8 +297,40 @@ export function ExternalLink({id, configuration, contentElementId, ...props}) {
   }
 }
 
-function Link({isEnabled, isEditable, ...props}) {
-  if ((isEnabled && props.href) || isEditable) {
+function TitleLink({isEnabled, href, openInNewTab, children}) {
+  if (isEnabled) {
+    return (
+      <Link href={href}
+            openInNewTab={openInNewTab}
+            attributes={{className: styles.titleLink}}>
+        {children}
+      </Link>
+    );
+  }
+  else {
+    return children;
+  }
+}
+
+function MoreLink({href, openInNewTab, describedBy}) {
+  const {t: translateWithEntryLocale} = useI18n();
+
+  return (
+    <Link href={href}
+          openInNewTab={openInNewTab}
+          attributes={{
+            className: styles.moreLink,
+            'aria-describedby': describedBy
+          }}>
+      <span className={styles.moreLinkLabel}>
+        {translateWithEntryLocale('pageflow_scrolled.public.more')}
+      </span>
+    </Link>
+  );
+}
+
+function EditorLinkWrapper({isEditable, ...props}) {
+  if (isEditable) {
     return (
       <EditableLink {...props}
                     allowRemove={true} />

--- a/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLink.module.css
+++ b/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLink.module.css
@@ -33,20 +33,72 @@
   opacity: 1;
 }
 
+.cardWrapper {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr auto;
+  will-change: transform;
+}
+
+.cardWrapper > .card,
+.moreLink {
+  grid-row: 1;
+  grid-column: 1;
+}
+
+.moreLink {
+  z-index: 1;
+  text-decoration: none;
+}
+
+.moreLinkLabel {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.titleLink {
+  color: inherit;
+  text-decoration: none;
+}
+
+.titleLink::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
 .textPosition-below .cardWrapper,
 .textPosition-right .cardWrapper {
   height: 100%;
-  display: flex;
-  flex-direction: column;
   transition: transform 0.3s;
+}
+
+.link.textPosition-below .cardWrapper {
+  --hover-scale: var(--theme-external-links-card-hover-scale, 1.05);
+}
+
+.link.textPosition-right .cardWrapper {
+  --hover-scale: var(--theme-external-links-card-hover-scale, 1.02);
+}
+
+.link:not(.outlined):hover .cardWrapper {
+  transform: scale(calc(1 + (var(--hover-scale) - 1) * var(--hover-scale-adjustment, 1)));
 }
 
 .card {
   display: flex;
+  position: relative;
   border-radius: var(--theme-content-element-box-border-radius);
   box-shadow: var(--content-element-box-box-shadow);
   overflow: hidden;
-  will-change: transform;
   flex: 1;
 }
 
@@ -69,18 +121,6 @@
 
 .textPosition-title {
   composes: textPosition-none;
-}
-
-.link.textPosition-below .cardWrapper {
-  --hover-scale: var(--theme-external-links-card-hover-scale, 1.05);
-}
-
-.link.textPosition-right .cardWrapper {
-  --hover-scale: var(--theme-external-links-card-hover-scale, 1.02);
-}
-
-.link:not(.outlined):hover .cardWrapper {
-  transform: scale(calc(1 + (var(--hover-scale) - 1) * var(--hover-scale-adjustment, 1)));
 }
 
 .textPosition-right .thumbnail {
@@ -130,23 +170,19 @@
 }
 
 .textPosition-overlay .front .background {
-  position: relative;
   align-self: end;
-  background: transparent;
+  padding-top: 2rem;
+  margin-top: -2rem;
   z-index: 1;
-}
-
-.textPosition-overlay .front .background::after {
-  content: "";
-  position: absolute;
-  z-index: -1;
-  top: -2rem;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(0deg, var(--card-surface-color), transparent);
-  opacity: calc(0.9 * var(--overlay-opacity, 0.7));
-  pointer-events: none;
+  background: linear-gradient(
+    0deg,
+    color-mix(
+      in srgb,
+      var(--card-surface-color) calc(0.9 * var(--overlay-opacity, 0.7) * 100%),
+      transparent
+    ),
+    transparent
+  );
 }
 
 .textPosition-none .front .background {
@@ -184,6 +220,11 @@
 
 .details > :first-child p:first-child {
   margin-top: 0;
+}
+
+.description a {
+  position: relative;
+  z-index: 2;
 }
 
 .button {

--- a/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/Thumbnail.js
+++ b/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/Thumbnail.js
@@ -7,7 +7,7 @@ import {Image, FilePlaceholder} from 'pageflow-scrolled/frontend';
 import styles from './Thumbnail.module.css';
 
 export function Thumbnail({imageFile, aspectRatio, cropPosition, fit, linkWidth,
-                           load, showPlaceholder, children}) {
+                           load, showPlaceholder, renderImageLink, children}) {
   imageFile = {
     ...imageFile,
     cropPosition
@@ -16,17 +16,19 @@ export function Thumbnail({imageFile, aspectRatio, cropPosition, fit, linkWidth,
   const aspectRatioPadding = getAspectRatioPadding(aspectRatio, imageFile);
   const {variant, sizes} = variantAndSizes({aspectRatio, cropPosition, fit, linkWidth});
 
+  const image = <Image imageFile={imageFile}
+                       load={load}
+                       preferSvg={true}
+                       variant={variant}
+                       sizes={sizes}
+                       fit={fit} />;
+
   return (
     <div className={classNames(styles.thumbnail,
                                {[styles.cover]: fit === 'cover'})}
          style={{paddingTop: aspectRatioPadding}}>
       {showPlaceholder && <FilePlaceholder file={imageFile} />}
-      <Image imageFile={imageFile}
-             load={load}
-             preferSvg={true}
-             variant={variant}
-             sizes={sizes}
-             fit={fit} />
+      {renderImageLink ? renderImageLink(image) : image}
       {children}
     </div>
   );

--- a/entry_types/scrolled/package/src/frontend/index.js
+++ b/entry_types/scrolled/package/src/frontend/index.js
@@ -112,6 +112,7 @@ export {EditableTable} from './EditableTable';
 export {EditableText} from './EditableText';
 export {EditableInlineText} from './EditableInlineText';
 export {EditableLink} from './EditableLink';
+export {Link} from './Link';
 export {ActionButton} from './ActionButton';
 export {FilePlaceholder} from './FilePlaceholderDecorator';
 export {Placeholder} from './Placeholder';

--- a/entry_types/scrolled/package/src/widgets/textInlineFileRights/TextInlineFileRights.module.css
+++ b/entry_types/scrolled/package/src/widgets/textInlineFileRights/TextInlineFileRights.module.css
@@ -7,7 +7,7 @@
 .text {
   font-size: 14px;
   position: relative;
-  z-index: 1;
+  z-index: 2;
   color: var(--content-text-color);
 }
 


### PR DESCRIPTION
Wrapping the whole card in an anchor broke SSR hydration when the card contained other links (file-rights credits or inline description links): the HTML parser auto-closes the outer anchor when it sees a nested one, producing a different DOM than React renders, so cards briefly appeared without link styling until hydration completed.

Replace the outer anchor with one of three inner links chosen by card content: the title when present, the image when the card shows only a thumbnail, or a visually hidden "More" fallback otherwise. Each inner link is a sibling of any other anchor, so the markup is valid and hydration is seamless.

Inline description links now work without the outer anchor hijacking drags or forcing nested anchors. Editor mode keeps the outer EditableLink wrapper so the link action button behaves as before.