### PR TITLE
Outline external link cards on title focus

### DIFF
--- a/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLink.module.css
+++ b/entry_types/scrolled/package/src/contentElements/externalLinkList/frontend/ExternalLink.module.css
@@ -75,6 +75,14 @@
   z-index: 1;
 }
 
+body > :global(#root) .titleLink:focus {
+  outline: none;
+}
+
+.card:has(.titleLink:focus) {
+  outline: var(--focus-outline);
+}
+
 .textPosition-below .cardWrapper,
 .textPosition-right .cardWrapper {
   height: 100%;

--- a/entry_types/scrolled/package/src/frontend/focusOutline.module.css
+++ b/entry_types/scrolled/package/src/frontend/focusOutline.module.css
@@ -1,11 +1,13 @@
+body > :global(#root) {
+  --focus-outline: 3px solid #518ad2;
+}
+
+.focusOutlineDisabled > :global(#root) {
+  --focus-outline: none;
+}
+
 body > :global(#root) a:focus,
 body > :global(#root) button:focus,
 body > :global(#root) [tabindex]:focus {
-  outline: 3px solid #518ad2;
-}
-
-.focusOutlineDisabled > :global(#root) [tabindex]:focus,
-.focusOutlineDisabled > :global(#root) button:focus,
-.focusOutlineDisabled > :global(#root) a:focus {
-  outline: none;
+  outline: var(--focus-outline);
 }


### PR DESCRIPTION
Card-link cards use the title as the link. The native focus ring around the title text doesn't communicate that the whole card is the click target, and in variants without inner padding it gets clipped by the card's border-radius overflow. Move the ring to the card itself so keyboard focus matches the activation surface.

Expose the project's focus-outline value as a CSS custom property so other components can opt into a custom focus surface while inheriting the same color and the existing disable-on-mouse behavior.