### PR TITLE
Skip unavailable locales in i18n fallback chain

### DIFF
--- a/app/helpers/pageflow/public_i18n_helper.rb
+++ b/app/helpers/pageflow/public_i18n_helper.rb
@@ -11,7 +11,8 @@ module Pageflow
         value.presence || fallback
       end
 
-      locales = [I18n.default_locale, *I18n.fallbacks[entry.locale].reverse].uniq
+      locales = [I18n.default_locale, *I18n.fallbacks[entry.locale].reverse].uniq &
+                I18n.available_locales
 
       translations = locales.reduce({}) do |result, locale|
         result.deep_merge(I18n.t('pageflow.public', locale:, default: {}),

--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/i18n_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/i18n_helper.rb
@@ -32,7 +32,8 @@ module PageflowScrolled
     end
 
     def scrolled_i18n_public_translations(entry)
-      locales = [I18n.default_locale, *I18n.fallbacks[entry.locale].reverse].uniq
+      locales = [I18n.default_locale, *I18n.fallbacks[entry.locale].reverse].uniq &
+                I18n.available_locales
 
       translations = locales.reduce({}) do |result, locale|
         result.deep_merge(

--- a/entry_types/scrolled/spec/helpers/pageflow_scrolled/i18n_helper_spec.rb
+++ b/entry_types/scrolled/spec/helpers/pageflow_scrolled/i18n_helper_spec.rb
@@ -103,6 +103,23 @@ module PageflowScrolled
                                        })
       end
 
+      it 'skips fallback parents that are not in I18n.available_locales' do
+        translation(I18n.default_locale, 'pageflow_scrolled.public.shared', 'en_text')
+        translation(:'pt-BR', 'pageflow_scrolled.public.regional', 'br_text')
+        entry = create(:published_entry, revision_attributes: {locale: 'pt-BR'})
+
+        result = helper.scrolled_i18n_translations(entry)
+
+        expect(result).to include_json('pt-BR': {
+                                         pageflow_scrolled: {
+                                           public: {
+                                             shared: 'en_text',
+                                             regional: 'br_text'
+                                           }
+                                         }
+                                       })
+      end
+
       it 'supports including inline_editing translations in current locale' do
         translation(I18n.locale, 'pageflow_scrolled.inline_editing.some', 'text')
         entry = create(:published_entry, revision_attributes: {locale: 'fr'})

--- a/spec/helpers/pageflow/public_i18n_helper_spec.rb
+++ b/spec/helpers/pageflow/public_i18n_helper_spec.rb
@@ -83,6 +83,20 @@ module Pageflow
         expect(result[:pageflow][:public][:from_parent]).to eq('nl_text')
         expect(result[:pageflow][:public][:from_regional]).to eq('be_text')
       end
+
+      it 'skips fallback parents that are not in I18n.available_locales' do
+        translation(I18n.default_locale, 'pageflow.public.shared', 'en_text')
+        translation(:'pt-BR', 'pageflow.public.regional', 'br_text')
+
+        entry = PublishedEntry.new(create(:entry,
+                                          :published,
+                                          published_revision_attributes: {locale: 'pt-BR'}))
+
+        result = helper.public_i18n_translations(entry)
+
+        expect(result[:pageflow][:public][:shared]).to eq('en_text')
+        expect(result[:pageflow][:public][:regional]).to eq('br_text')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes regression: entries with regional locales like pt-BR raised `:pt is not a valid locale` because the parent locale walked by I18n.fallbacks is not part of I18n.available_locales for PublicI18n. Intersect the chain with the configured available locales so unrecognized intermediates are quietly skipped.

REDMINE-21282