### PR TITLE
Anchor highlightOverlapsSelection to highlight start block

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableText/highlightOverlapsSelection-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableText/highlightOverlapsSelection-spec.js
@@ -39,7 +39,7 @@ describe('highlightOverlapsSelection', () => {
     expect(highlightOverlapsSelection(highlight, selection)).toBe(false);
   });
 
-  it('returns true when selection is in a block inside a multi-block highlight range', () => {
+  it('returns false when selection is in a middle block of a multi-block highlight', () => {
     const multiBlockHighlight = {
       range: {
         anchor: {path: [1, 0], offset: 0},
@@ -49,6 +49,21 @@ describe('highlightOverlapsSelection', () => {
     const selection = {
       anchor: {path: [2, 0], offset: 0},
       focus: {path: [2, 0], offset: 0}
+    };
+
+    expect(highlightOverlapsSelection(multiBlockHighlight, selection)).toBe(false);
+  });
+
+  it('returns true when selection is in the same block as a multi-block highlight start', () => {
+    const multiBlockHighlight = {
+      range: {
+        anchor: {path: [1, 0], offset: 0},
+        focus: {path: [3, 0], offset: 5}
+      }
+    };
+    const selection = {
+      anchor: {path: [1, 0], offset: 2},
+      focus: {path: [1, 0], offset: 2}
     };
 
     expect(highlightOverlapsSelection(multiBlockHighlight, selection)).toBe(true);

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/EditableText/highlightOverlapsSelection.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/EditableText/highlightOverlapsSelection.js
@@ -12,8 +12,7 @@ export function highlightOverlapsSelection(highlight, selection) {
     selEndBlock -= 1;
   }
 
-  const hlStart = Range.start(highlight.range).path[0];
-  const hlEnd = Range.end(highlight.range).path[0];
+  const hlStartBlock = Range.start(highlight.range).path[0];
 
-  return selStartBlock <= hlEnd && hlStart <= selEndBlock;
+  return selStartBlock <= hlStartBlock && hlStartBlock <= selEndBlock;
 }


### PR DESCRIPTION
Treats a multi-block thread as belonging to its first block only, so clicking a badge in a paragraph picks up threads that originate there instead of every thread that happens to extend into it. Keeps the existing badge active/dot decisions stable for single-block threads.

REDMINE-21261