### PR TITLE
Rename loadXxxComponents to loadXxxExtensions

### DIFF
--- a/entry_types/scrolled/package/spec/contentElements/externalLinkList/frontend/ExternalLinkList/editorSelection-spec.js
+++ b/entry_types/scrolled/package/spec/contentElements/externalLinkList/frontend/ExternalLinkList/editorSelection-spec.js
@@ -3,14 +3,14 @@ import React from 'react';
 import {ExternalLinkList} from 'contentElements/externalLinkList/frontend/ExternalLinkList';
 import linkStyles from 'contentElements/externalLinkList/frontend/ExternalLink.module.css';
 
-import {loadInlineEditingComponents} from 'frontend/inlineEditing';
+import {loadInlineEditingExtensions} from 'frontend/inlineEditing';
 import {renderInContentElement} from 'pageflow-scrolled/testHelpers';
 import {screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect'
 
 describe('ExternalLinkList', () => {
-  beforeAll(loadInlineEditingComponents);
+  beforeAll(loadInlineEditingExtensions);
 
   it('sets selected item id in transient state in editor', async () => {
     const configuration = {

--- a/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableInlineText-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableInlineText-spec.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import {EditableInlineText} from 'frontend';
-import {loadInlineEditingComponents} from 'frontend/inlineEditing';
+import {loadInlineEditingExtensions} from 'frontend/inlineEditing';
 
 import {render} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect'
 
 describe('EditableInlineText', () => {
-  beforeAll(loadInlineEditingComponents);
+  beforeAll(loadInlineEditingExtensions);
 
   it('renders text from value', () => {
     const value = [{

--- a/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableLink-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableLink-spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {loadInlineEditingComponents} from 'frontend/inlineEditing';
+import {loadInlineEditingExtensions} from 'frontend/inlineEditing';
 import {useSelectLinkDestination} from 'frontend/inlineEditing/useSelectLinkDestination';
 import {EditableLink} from 'frontend';
 import {useFakeTranslations} from 'pageflow/testHelpers';
@@ -26,7 +26,7 @@ describe('EditableLink', () => {
     'pageflow_scrolled.inline_editing.remove_link': 'Remove link'
   });
 
-  beforeAll(loadInlineEditingComponents);
+  beforeAll(loadInlineEditingExtensions);
 
   it('renders children with className', () => {
     const {getByText} = render(

--- a/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableTable-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/inlineEditing/EditableTable-spec.js
@@ -1,14 +1,14 @@
 import React from 'react';
 
 import {EditableTable} from 'frontend';
-import {loadInlineEditingComponents} from 'frontend/inlineEditing';
+import {loadInlineEditingExtensions} from 'frontend/inlineEditing';
 import * as phoneLayout from 'frontend/usePhoneLayout';
 
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect'
 
 describe('EditableText', () => {
-  beforeAll(loadInlineEditingComponents);
+  beforeAll(loadInlineEditingExtensions);
 
   it('renders class name on table', () => {
     render(<EditableTable value={[]}

--- a/entry_types/scrolled/package/spec/frontend/useContentElementCommandSubscription/inEditorPreview-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/useContentElementCommandSubscription/inEditorPreview-spec.js
@@ -4,10 +4,10 @@ import {renderInEntry, fakeParentWindow, tick} from 'support';
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect'
 
-import {loadInlineEditingComponents} from 'frontend/inlineEditing';
+import {loadInlineEditingExtensions} from 'frontend/inlineEditing';
 
 describe('useContentElementEditorCommandSubscription in editor preview', () => {
-  beforeAll(loadInlineEditingComponents);
+  beforeAll(loadInlineEditingExtensions);
 
   it('invokes callback for content element commands sent via post message', async () => {
     fakeParentWindow();

--- a/entry_types/scrolled/package/spec/frontend/useContentElementEditorState/inEditorPreview-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/useContentElementEditorState/inEditorPreview-spec.js
@@ -7,10 +7,10 @@ import React, {useEffect} from 'react';
 import {act, fireEvent} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect'
 
-import {loadInlineEditingComponents} from 'frontend/inlineEditing';
+import {loadInlineEditingExtensions} from 'frontend/inlineEditing';
 
 describe('useContentElementEditorState in editor preview', () => {
-  beforeAll(loadInlineEditingComponents);
+  beforeAll(loadInlineEditingExtensions);
   useFakeParentWindow();
 
   it('lets content elements determine whether they are selected', () => {

--- a/entry_types/scrolled/package/spec/frontend/usePhonePlatform/inEditorPreview-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/usePhonePlatform/inEditorPreview-spec.js
@@ -1,5 +1,5 @@
 import {usePhonePlatform} from 'frontend/usePhonePlatform';
-import {loadInlineEditingComponents} from 'frontend/inlineEditing';
+import {loadInlineEditingExtensions} from 'frontend/inlineEditing';
 
 import {renderHookInEntry} from 'support';
 import {asyncHandlingOf} from 'support/asyncHandlingOf';
@@ -7,7 +7,7 @@ import {asyncHandlingOf} from 'support/asyncHandlingOf';
 import '@testing-library/jest-dom/extend-expect'
 
 describe('usePhonePlatform', () => {
-  beforeAll(loadInlineEditingComponents);
+  beforeAll(loadInlineEditingExtensions);
 
   it('sets value when emulation mode is mobile', async () => {
     const {result} = renderHookInEntry(() => usePhonePlatform());

--- a/entry_types/scrolled/package/spec/support/pageObjects/commenting.js
+++ b/entry_types/scrolled/package/spec/support/pageObjects/commenting.js
@@ -1,7 +1,7 @@
 import {act, within} from '@testing-library/react';
 import {useFakeTranslations} from 'pageflow/testHelpers';
 
-import {loadCommentingComponents} from 'frontend/commenting';
+import {loadCommentingExtensions} from 'frontend/commenting';
 import {clearExtensions} from 'frontend/extensionRegistry';
 import contentElementDecoratorStyles from 'frontend/commenting/ContentElementDecorator.module.css';
 
@@ -34,7 +34,7 @@ export function renderEntry({
 
 export function useCommentingPageObjects() {
   beforeAll(async () => {
-    await loadCommentingComponents();
+    await loadCommentingExtensions();
   });
 
   afterAll(() => {

--- a/entry_types/scrolled/package/spec/support/pageObjects/inlineEditing.js
+++ b/entry_types/scrolled/package/spec/support/pageObjects/inlineEditing.js
@@ -1,7 +1,7 @@
 import {act, fireEvent} from '@testing-library/react';
 import {useFakeTranslations} from 'pageflow/testHelpers';
 
-import {loadInlineEditingComponents} from 'frontend/inlineEditing';
+import {loadInlineEditingExtensions} from 'frontend/inlineEditing';
 import {clearExtensions} from 'frontend/extensionRegistry';
 import badgeStyles from 'review/Badge.module.css';
 
@@ -28,7 +28,7 @@ export function useInlineEditingPageObjects() {
   useFakeParentWindow();
 
   beforeAll(async () => {
-    await loadInlineEditingComponents();
+    await loadInlineEditingExtensions();
   });
 
   afterAll(() => {

--- a/entry_types/scrolled/package/src/frontend/commenting/index.js
+++ b/entry_types/scrolled/package/src/frontend/commenting/index.js
@@ -1,6 +1,6 @@
 import {provideExtensions} from '../extensionRegistry';
 
-export function loadCommentingComponents() {
+export function loadCommentingExtensions() {
   return import(/* webpackPreload: true */ './extensions').then(({extensions}) => {
     provideExtensions(extensions);
   });

--- a/entry_types/scrolled/package/src/frontend/index.js
+++ b/entry_types/scrolled/package/src/frontend/index.js
@@ -14,8 +14,8 @@ import './properties.module.css';
 import styles from './foregroundBoxes/GradientBox.module.css';
 
 import {RootProviders} from './RootProviders';
-import {loadInlineEditingComponents} from './inlineEditing';
-import {loadCommentingComponents} from './commenting';
+import {loadInlineEditingExtensions} from './inlineEditing';
+import {loadCommentingExtensions} from './commenting';
 import {loadDashUnlessHlsSupported} from './dash';
 import {registerConsentVendors} from './thirdPartyConsent';
 
@@ -160,7 +160,7 @@ global.pageflowScrolledRender = async function(seed) {
   await loadDashUnlessHlsSupported(seed);
 
   if (seed.config.loadInlineEditing) {
-    await loadInlineEditingComponents();
+    await loadInlineEditingExtensions();
   }
   else {
     registerConsentVendors({
@@ -173,7 +173,7 @@ global.pageflowScrolledRender = async function(seed) {
   render(seed);
 
   if (seed.config.loadCommenting) {
-    loadCommentingComponents();
+    loadCommentingExtensions();
   }
 }
 

--- a/entry_types/scrolled/package/src/frontend/inlineEditing/index.js
+++ b/entry_types/scrolled/package/src/frontend/inlineEditing/index.js
@@ -1,6 +1,6 @@
 import {provideExtensions} from '../extensionRegistry';
 
-export function loadInlineEditingComponents() {
+export function loadInlineEditingExtensions() {
   return import('./extensions').then(({extensions}) => {
     provideExtensions(extensions);
   });


### PR DESCRIPTION
The functions dynamically import an `extensions` module and call `provideExtensions(...)` on the extension registry. "Components" was a holdover from when the inline-editing payload lived in `components.js`; both files are now `extensions.js`, and the function names should match what they actually do.

[skip percy]