### PR TITLE
Only render homepage entry for HTML requests

### DIFF
--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -15,7 +15,9 @@ module Pageflow
       )
 
       if entry
-        handle_public_entry_request(entry)
+        respond_to do |format|
+          format.html { handle_public_entry_request(entry) }
+        end
       elsif site.home_url.present?
         redirect_to(site.home_url, allow_other_host: true)
       else

--- a/spec/requests/pageflow/entries_index_request_spec.rb
+++ b/spec/requests/pageflow/entries_index_request_spec.rb
@@ -56,6 +56,22 @@ module Pageflow
           .to include('Root Story published rendered by entry type frontend app')
       end
 
+      it 'responds with not found for non-html format' do
+        site = create(:site, cname: 'pageflow.example.com')
+        create(:entry,
+               :published,
+               site:,
+               type_name: 'test',
+               title: 'Root Story',
+               permalink_attributes: {slug: '', allow_root_path: true})
+
+        get('/',
+            params: {},
+            headers: {'HTTP_HOST' => 'pageflow.example.com', 'HTTP_ACCEPT' => 'text/plain'})
+
+        expect(response.status).to eq(404)
+      end
+
       it 'responds with not found if no site matches cname' do
         get('/', params: {}, headers: {'HTTP_HOST' => 'unknown.example.com'})
 


### PR DESCRIPTION
Requests to a site's homepage entry with a non-HTML Accept header (e.g. text/plain from crawlers) were delegated to the entry type frontend app, which then failed to render and raised ActionView::MissingTemplate, producing 500 errors. Mirror the show action and only delegate for HTML requests, so other formats respond with not found instead.