### PR TITLE
Fix storybook workflow by dropping deprecated Percy action

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -125,10 +125,8 @@ jobs:
         bundle exec rake pageflow_scrolled:storybook:seed:setup[package/.storybook]
 
     - name: Snapshot
-      uses: percy/storybook-action@v0.1.6
-      with:
-        working-directory: entry_types/scrolled/package
-        custom-command: yarn run snapshot
+      working-directory: entry_types/scrolled/package
+      run: yarn run snapshot
 
     - name: Publish
       working-directory: entry_types/scrolled/package


### PR DESCRIPTION
The percy/storybook-action repository was archived in 2022 and has now been removed entirely, breaking the workflow with an unresolvable action error. The action is only needed for legacy Storybook SDKs; since this project already runs Percy via the CLI in the snapshot script, the step can invoke it directly.