### PR TITLE
Add useFakeFeatures test helper

### DIFF
--- a/entry_types/scrolled/package/spec/contentElements/externalLinkList/frontend/ExternalLink-spec.js
+++ b/entry_types/scrolled/package/spec/contentElements/externalLinkList/frontend/ExternalLink-spec.js
@@ -5,10 +5,9 @@ import React from 'react';
 
 import {renderInEntry} from 'support';
 import {renderInContentElement} from 'pageflow-scrolled/testHelpers';
-import {useFakeTranslations} from 'pageflow/testHelpers';
+import {useFakeFeatures, useFakeTranslations} from 'pageflow/testHelpers';
 import {screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import {features} from 'pageflow/frontend';
 
 describe('ExternalLink', () => {
   it('renders link with href', () => {
@@ -286,8 +285,7 @@ describe('ExternalLink', () => {
   });
 
   describe('srcset', () => {
-    beforeEach(() => features.enable('frontend', ['image_srcset']));
-    afterEach(() => features.enabledFeatureNames = []);
+    useFakeFeatures('frontend', ['image_srcset']);
 
     it('uses medium and large srcset for linkWidth m', () => {
       const {getByRole} = renderInEntry(

--- a/entry_types/scrolled/package/spec/contentElements/inlineImage/InlineImage-spec.js
+++ b/entry_types/scrolled/package/spec/contentElements/inlineImage/InlineImage-spec.js
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom/extend-expect'
 
 import {InlineImage} from 'contentElements/inlineImage/InlineImage';
 import {features} from 'pageflow/frontend';
+import {useFakeFeatures} from 'pageflow/testHelpers';
 import {usePortraitOrientation} from 'frontend/usePortraitOrientation';
 jest.mock('frontend/usePortraitOrientation');
 
@@ -239,8 +240,7 @@ describe('InlineImage', () => {
   });
 
   describe('srcset', () => {
-    beforeEach(() => features.enable('frontend', ['image_srcset']));
-    afterEach(() => features.enabledFeatureNames = []);
+    useFakeFeatures('frontend', ['image_srcset']);
 
     function renderInlineImage({contentElementWidth = 0, ...seedOptions} = {}) {
       const result = renderInContentElement(

--- a/entry_types/scrolled/package/spec/editor/models/ContentElement-spec.js
+++ b/entry_types/scrolled/package/spec/editor/models/ContentElement-spec.js
@@ -1,13 +1,13 @@
 import {editor} from 'pageflow-scrolled/editor';
 import {ScrolledEntry} from 'editor/models/ScrolledEntry';
 import {factories, normalizeSeed} from 'support';
-import {features} from 'pageflow/frontend';
+import {useFakeFeatures} from 'pageflow/testHelpers';
 
 describe('ContentElement', () => {
   describe('getAvailablePositions', () => {
-    beforeEach(() => {
-      features.enable('frontend', ['backdrop_content_elements']);
+    useFakeFeatures('frontend', ['backdrop_content_elements']);
 
+    beforeEach(() => {
       editor.contentElementTypes.register('inlineImage', {});
       editor.contentElementTypes.register('soundDisclaimer', {supportedPositions: ['inline']});
     });

--- a/entry_types/scrolled/package/spec/frontend/inlineEditing/features/commentBadges-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/inlineEditing/features/commentBadges-spec.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/extend-expect';
 import {act, waitFor} from '@testing-library/react';
-import {features} from 'pageflow/frontend';
+import {useFakeFeatures} from 'pageflow/testHelpers';
 
 import {useInlineEditingPageObjects, renderEntry} from 'support/pageObjects/inlineEditing';
 
@@ -8,10 +8,7 @@ import badgeStyles from 'review/Badge.module.css';
 
 describe('inline editing comment badges', () => {
   useInlineEditingPageObjects();
-
-  beforeEach(() => {
-    features.enable('frontend', ['commenting']);
-  });
+  useFakeFeatures('frontend', ['commenting']);
 
   it('does not display comment icon when element is not selected', () => {
     const {queryByRole} = renderEntry({

--- a/package/spec/testHelpers/useFakeFeatures-spec.js
+++ b/package/spec/testHelpers/useFakeFeatures-spec.js
@@ -1,0 +1,57 @@
+import {useFakeFeatures} from 'testHelpers/useFakeFeatures';
+
+import {features} from 'pageflow/frontend';
+
+describe('useFakeFeatures', () => {
+  describe('with one feature', () => {
+    useFakeFeatures('frontend', ['commenting']);
+
+    it('marks the feature as enabled', () => {
+      expect(features.isEnabled('commenting')).toBe(true);
+    });
+  });
+
+  describe('with multiple features', () => {
+    useFakeFeatures('frontend', ['commenting', 'image_srcset']);
+
+    it('enables all listed features', () => {
+      expect(features.isEnabled('commenting')).toBe(true);
+      expect(features.isEnabled('image_srcset')).toBe(true);
+    });
+  });
+
+  describe('with registered functions', () => {
+    const fn = jest.fn();
+    features.register('frontend', 'with_callback', fn);
+
+    useFakeFeatures('frontend', ['with_callback']);
+
+    it('invokes scope-registered callbacks for enabled features', () => {
+      expect(fn).toHaveBeenCalled();
+    });
+  });
+
+  describe('when called multiple times', () => {
+    useFakeFeatures('frontend', ['commenting']);
+    useFakeFeatures('editor', ['special_content_element']);
+
+    it('enables features from all calls', () => {
+      expect(features.isEnabled('commenting')).toBe(true);
+      expect(features.isEnabled('special_content_element')).toBe(true);
+    });
+  });
+
+  describe('cleanup', () => {
+    describe('inner describe enabling a feature', () => {
+      useFakeFeatures('frontend', ['scoped_feature']);
+
+      it('enables the feature inside', () => {
+        expect(features.isEnabled('scoped_feature')).toBe(true);
+      });
+    });
+
+    it('does not leak enabled features to sibling tests', () => {
+      expect(features.isEnabled('scoped_feature')).toBe(false);
+    });
+  });
+});

--- a/package/src/testHelpers/index.js
+++ b/package/src/testHelpers/index.js
@@ -3,5 +3,6 @@ export * from './dominos/ui';
 export * from './factories';
 export * from './fakeBrowserAgent';
 export * from './setupGlobals';
+export * from './useFakeFeatures';
 export * from './useFakeTranslations';
 export * from './renderBackboneView';

--- a/package/src/testHelpers/useFakeFeatures.js
+++ b/package/src/testHelpers/useFakeFeatures.js
@@ -1,0 +1,47 @@
+import {features} from 'pageflow/frontend';
+
+/**
+ * Enable feature flags for the surrounding describe block.
+ *
+ * Each `beforeEach` calls `features.enable(scope, names)`, which both
+ * flips `features.isEnabled` to true for the given names and runs any
+ * functions registered via `features.register` for them. Each
+ * `afterEach` restores the set of enabled features to whatever was
+ * enabled before the helper was invoked, so suites do not leak state
+ * into each other.
+ *
+ * Multiple calls within the same describe block (or across nested
+ * describes) compose: each call adds its own features on top of
+ * whatever previous `useFakeFeatures` calls already enabled.
+ *
+ * @param {String} scope -
+ *   Name of the scope to enable the features in (e.g. `'frontend'`,
+ *   `'editor'`).
+ * @param {String[]} names -
+ *   Feature names to enable in the given scope.
+ *
+ * @example
+ * import {useFakeFeatures} from 'pageflow/testHelpers';
+ * import {features} from 'pageflow/frontend';
+ *
+ * describe('...', () => {
+ *   useFakeFeatures('frontend', ['commenting']);
+ *
+ *   it('...', () => {
+ *     expect(features.isEnabled('commenting')).toBe(true);
+ *   });
+ * });
+ */
+export function useFakeFeatures(scope, names) {
+  let originalEnabledFeatureNames;
+
+  beforeEach(() => {
+    originalEnabledFeatureNames = features.enabledFeatureNames;
+
+    features.enable(scope, names);
+  });
+
+  afterEach(() => {
+    features.enabledFeatureNames = originalEnabledFeatureNames;
+  });
+}


### PR DESCRIPTION
Bundle the feature-flag enable + restore dance that several specs currently repeat (`beforeEach(() => features.enable(...))` paired with `afterEach(() => features.enabledFeatureNames = [])`) into a single hook taking the same `(scope, names)` signature as `features.enable`. The afterEach snapshots and restores the previous enabled set instead of clearing unconditionally, so multiple `useFakeFeatures` calls compose across nested describes the same way `useFakeTranslations` does.

Adopt the helper in the four specs (commentBadges, ContentElement, InlineImage, ExternalLink) that already followed the before-hook setup pattern.