### PR TITLE
Let any present widget contribute frontend packs

### DIFF
--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/packs_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/packs_helper.rb
@@ -71,14 +71,17 @@ module PageflowScrolled
     end
 
     def scrolled_frontend_widget_type_packs(entry, widget_scope)
-      scrolled_frontend_pack_widget_types(entry, widget_scope).map(&:pack)
+      scrolled_frontend_pack_widget_types(entry, widget_scope)
+        .select { |widget_type| widget_type.respond_to?(:packs) }
+        .flat_map { |widget_type| widget_type.packs(entry:, request:) }
+        .uniq
     end
 
     def scrolled_frontend_pack_widget_types(entry, widget_scope)
       if widget_scope == :editor
-        ReactWidgetType.all_for(entry)
+        Pageflow.config_for(entry).widget_types.select(&:enabled_in_editor?)
       else
-        entry.resolve_widgets(insert_point: :react).map(&:widget_type)
+        entry.resolve_widgets.map(&:widget_type)
       end
     end
   end

--- a/entry_types/scrolled/lib/pageflow_scrolled/react_widget_type.rb
+++ b/entry_types/scrolled/lib/pageflow_scrolled/react_widget_type.rb
@@ -38,10 +38,8 @@ module PageflowScrolled
     end
 
     # @api private
-    def self.all_for(entry)
-      Pageflow.config_for(entry).widget_types.select do |widget_type|
-        widget_type.insert_point == :react
-      end
+    def packs(**)
+      [pack]
     end
   end
 end

--- a/entry_types/scrolled/spec/helpers/pageflow_scrolled/packs_helper_spec.rb
+++ b/entry_types/scrolled/spec/helpers/pageflow_scrolled/packs_helper_spec.rb
@@ -241,6 +241,99 @@ module PageflowScrolled
 
         expect(result).not_to include('pageflow-scrolled/widgets/test')
       end
+
+      it 'includes packs of a present pack-contributing widget outside of editor' do
+        pageflow_configure do |config|
+          config.widget_types.register(
+            pack_widget_type(name: 'analyticsish',
+                             roles: ['analytics'],
+                             insert_point: :bottom_of_entry,
+                             packs: ['some/analytics-pack']),
+            default: true
+          )
+        end
+
+        entry = create(:published_entry, type_name: 'scrolled')
+
+        result = helper.scrolled_frontend_packs(entry, entry_mode: :published)
+
+        expect(result).to include('some/analytics-pack')
+      end
+
+      it 'passes the entry to the widget packs method' do
+        received = nil
+        pageflow_configure do |config|
+          config.widget_types.register(
+            pack_widget_type(name: 'analyticsish',
+                             roles: ['analytics'],
+                             insert_point: :bottom_of_entry,
+                             packs: lambda { |entry|
+                               received = entry
+                               []
+                             }),
+            default: true
+          )
+        end
+
+        entry = create(:published_entry, type_name: 'scrolled')
+
+        helper.scrolled_frontend_packs(entry, entry_mode: :published)
+
+        expect(received).to eq(entry)
+      end
+
+      it 'passes the request to the widget packs method' do
+        received = :not_passed
+        widget_type = Class.new(Pageflow::TestWidgetType) {
+          define_method(:packs) do |request: :not_passed, **|
+            received = request
+            []
+          end
+        }.new(name: 'analyticsish', roles: ['analytics'], insert_point: :bottom_of_entry)
+
+        pageflow_configure do |config|
+          config.widget_types.register(widget_type, default: true)
+        end
+
+        entry = create(:published_entry, type_name: 'scrolled')
+
+        helper.scrolled_frontend_packs(entry, entry_mode: :published)
+
+        expect(received).to eq(helper.request)
+      end
+
+      it 'includes packs of a pack-contributing widget in editor' do
+        pageflow_configure do |config|
+          config.widget_types.register(
+            pack_widget_type(name: 'analyticsish',
+                             roles: ['analytics'],
+                             packs: ['some/analytics-pack'])
+          )
+        end
+
+        entry = create(:published_entry, type_name: 'scrolled')
+
+        result = helper.scrolled_frontend_packs(entry, entry_mode: :editor)
+
+        expect(result).to include('some/analytics-pack')
+      end
+
+      it 'does not include packs of an editor-disabled pack-contributing widget in editor' do
+        pageflow_configure do |config|
+          config.widget_types.register(
+            pack_widget_type(name: 'analyticsish',
+                             roles: ['analytics'],
+                             enabled_in_editor: false,
+                             packs: ['some/analytics-pack'])
+          )
+        end
+
+        entry = create(:published_entry, type_name: 'scrolled')
+
+        result = helper.scrolled_frontend_packs(entry, entry_mode: :editor)
+
+        expect(result).not_to include('some/analytics-pack')
+      end
     end
 
     describe 'scrolled_frontend_stylesheet_packs' do
@@ -531,6 +624,14 @@ module PageflowScrolled
         expect(result).not_to include('some/script/if-false')
         expect(result).not_to include('some/script/unless-true')
       end
+    end
+
+    def pack_widget_type(packs:, **options)
+      Class.new(Pageflow::TestWidgetType) {
+        define_method(:packs) do |entry:, **|
+          packs.respond_to?(:call) ? packs.call(entry) : packs
+        end
+      }.new(**options)
     end
   end
 end


### PR DESCRIPTION
Generalize the scrolled widget-to-pack mechanism: instead of only ReactWidgetType (insert_point :react) contributing a single pack, collect packs from any present widget whose type responds to packs(entry:, request:, **). This lets widgets at other insert points (e.g. the server-rendered analytics widget) selectively contribute packs, gated by widget presence, and threads the request so packs can depend on it.

ReactWidgetType now implements packs; the editor path collects from all editor-enabled widget types, the frontend path from the entry's present widgets.

REDMINE-21330