### PR TITLE
Let widgets contribute JavaScript-only packs

### DIFF
--- a/entry_types/scrolled/app/helpers/pageflow_scrolled/packs_helper.rb
+++ b/entry_types/scrolled/app/helpers/pageflow_scrolled/packs_helper.rb
@@ -16,7 +16,7 @@ module PageflowScrolled
     end
 
     def scrolled_frontend_stylesheet_packs(entry, entry_mode:, seed_options: {})
-      packs = scrolled_frontend_packs(entry, entry_mode: entry_mode)
+      packs = scrolled_frontend_packs(entry, entry_mode:, format: :css)
       packs += ['pageflow-scrolled-frontend-inlineEditing'] if seed_options[:load_inline_editing]
       packs += ['pageflow-scrolled-frontend-commenting'] if seed_options[:load_commenting]
       packs
@@ -36,10 +36,10 @@ module PageflowScrolled
       )
     end
 
-    def scrolled_frontend_packs(entry, entry_mode:)
+    def scrolled_frontend_packs(entry, entry_mode:, format: :js)
       ['pageflow-scrolled-frontend'] +
         scrolled_additional_frontend_packs(entry, entry_mode) +
-        scrolled_frontend_widget_type_packs(entry, entry_mode)
+        scrolled_frontend_widget_type_packs(entry, entry_mode, format)
     end
 
     def scrolled_editor_packs(entry)
@@ -70,10 +70,14 @@ module PageflowScrolled
       )
     end
 
-    def scrolled_frontend_widget_type_packs(entry, widget_scope)
+    def scrolled_frontend_widget_type_packs(entry, widget_scope, format = :js)
       scrolled_frontend_pack_widget_types(entry, widget_scope)
         .select { |widget_type| widget_type.respond_to?(:packs) }
         .flat_map { |widget_type| widget_type.packs(entry:, request:) }
+        .filter_map { |pack|
+          path, stylesheet = pack.is_a?(Hash) ? pack.values_at(:path, :stylesheet) : [pack, false]
+          path if format == :js || stylesheet
+        }
         .uniq
     end
 

--- a/entry_types/scrolled/lib/pageflow_scrolled/react_widget_type.rb
+++ b/entry_types/scrolled/lib/pageflow_scrolled/react_widget_type.rb
@@ -39,7 +39,7 @@ module PageflowScrolled
 
     # @api private
     def packs(**)
-      [pack]
+      [{path: pack, stylesheet: true}]
     end
   end
 end

--- a/entry_types/scrolled/spec/helpers/pageflow_scrolled/packs_helper_spec.rb
+++ b/entry_types/scrolled/spec/helpers/pageflow_scrolled/packs_helper_spec.rb
@@ -378,6 +378,52 @@ module PageflowScrolled
                                                     seed_options: {})
         ).not_to include('pageflow-scrolled-frontend-commenting')
       end
+
+      it 'excludes widget packs without stylesheet option' do
+        pageflow_configure do |config|
+          config.widget_types.register(
+            pack_widget_type(name: 'analyticsish',
+                             roles: ['analytics'],
+                             insert_point: :bottom_of_entry,
+                             packs: ['some/js-only-pack']),
+            default: true
+          )
+        end
+
+        entry = create(:published_entry, type_name: 'scrolled')
+
+        expect(
+          helper.scrolled_frontend_packs(entry, entry_mode: :published)
+        ).to include('some/js-only-pack')
+        expect(
+          helper.scrolled_frontend_stylesheet_packs(entry,
+                                                    entry_mode: :published,
+                                                    seed_options: {})
+        ).not_to include('some/js-only-pack')
+      end
+
+      it 'includes widget packs with stylesheet option' do
+        pageflow_configure do |config|
+          config.widget_types.register(
+            pack_widget_type(name: 'themed',
+                             roles: ['navigation'],
+                             insert_point: :bottom_of_entry,
+                             packs: [{path: 'some/themed-pack', stylesheet: true}]),
+            default: true
+          )
+        end
+
+        entry = create(:published_entry, type_name: 'scrolled')
+
+        expect(
+          helper.scrolled_frontend_packs(entry, entry_mode: :published)
+        ).to include('some/themed-pack')
+        expect(
+          helper.scrolled_frontend_stylesheet_packs(entry,
+                                                    entry_mode: :published,
+                                                    seed_options: {})
+        ).to include('some/themed-pack')
+      end
     end
 
     describe 'scrolled_editor_packs' do


### PR DESCRIPTION
Widgets can now declare which of their packs also ship a stylesheet, so a widget that only adds JavaScript no longer forces a missing stylesheet into the frontend stylesheet tag. Packs default to JavaScript only and opt into a stylesheet via {path:, stylesheet: true}, mirroring the existing additional pack registration.

REDMINE-21330