### PR TITLE
Target modern browsers and drop redundant polyfills

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,7 @@
+# Pageflow targets modern browsers (ES modules, CSS custom properties),
+# so builds avoid ES5 transpilation and the corresponding core-js
+# polyfills. `defaults` on its own still includes browsers like Opera
+# Mini that force Babel into legacy output; intersecting it with
+# `supports es6-module` drops those while keeping the usual
+# market-share/recency floor.
+defaults and supports es6-module

--- a/entry_types/scrolled/package/package.json
+++ b/entry_types/scrolled/package/package.json
@@ -37,8 +37,7 @@
     "striptags": "^3.2.0",
     "use-context-selector": "^1.2.11",
     "video.js": "https://github.com/tf/video.js#pageflow-scrolled-8",
-    "wavesurfer.js": "6.1.0",
-    "whatwg-fetch": "^3.0.0"
+    "wavesurfer.js": "6.1.0"
   },
   "peerDependencies": {
     "pageflow": "15.1.0",

--- a/entry_types/scrolled/package/spec/editor/controllers/PreviewMessageController-spec.js
+++ b/entry_types/scrolled/package/spec/editor/controllers/PreviewMessageController-spec.js
@@ -15,6 +15,9 @@ import {
 } from 'frontend/inlineEditing/postMessage';
 import {setupGlobals} from 'pageflow/testHelpers';
 import {normalizeSeed, factories, createIframeWindow, useFakeXhr} from 'support';
+import {enableFetchMocks} from 'jest-fetch-mock';
+
+enableFetchMocks();
 
 describe('PreviewMessageController', () => {
   beforeAll(() => editor.contentElementTypes.register('textBlock', {}));
@@ -51,10 +54,7 @@ describe('PreviewMessageController', () => {
 
   it('sends REVIEW_STATE_RESET to iframe after READY when commenting enabled', () => {
     features.enable('frontend', ['commenting']);
-    jest.spyOn(window, 'fetch').mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({currentUser: {id: 1}, commentThreads: []})
-    });
+    fetch.mockResponse(JSON.stringify({currentUser: {id: 1}, commentThreads: []}));
 
     const entry = factories.entry(ScrolledEntry, {}, {entryTypeSeed: normalizeSeed()});
     const iframeWindow = createIframeWindow();

--- a/entry_types/scrolled/package/spec/frontend/commenting/features/commentingBadges-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/commenting/features/commentingBadges-spec.js
@@ -1,21 +1,21 @@
 import '@testing-library/jest-dom/extend-expect';
 import {fireEvent, waitFor} from '@testing-library/react';
+import {enableFetchMocks} from 'jest-fetch-mock';
 
 import {renderEntry, useCommentingPageObjects} from 'support/pageObjects/commenting';
+
+enableFetchMocks();
 
 describe('commenting badges', () => {
   useCommentingPageObjects();
 
   it('fetches threads from API and displays badge', async () => {
-    jest.spyOn(window, 'fetch').mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({
-        currentUser: {id: 42, name: 'Alice'},
-        commentThreads: [
-          {id: 1, subjectType: 'ContentElement', subjectId: 1, comments: []}
-        ]
-      })
-    });
+    fetch.mockResponse(JSON.stringify({
+      currentUser: {id: 42, name: 'Alice'},
+      commentThreads: [
+        {id: 1, subjectType: 'ContentElement', subjectId: 1, comments: []}
+      ]
+    }));
 
     const entry = renderEntry({
       seed: {

--- a/entry_types/scrolled/package/spec/support/fakeIntersectionObserver.js
+++ b/entry_types/scrolled/package/spec/support/fakeIntersectionObserver.js
@@ -2,7 +2,7 @@ import {act} from '@testing-library/react';
 
 export const fakeIntersectionObserver = {
   byRoot(root) {
-    return this.instances.find(intersectionObserver =>
+    return [...this.instances].find(intersectionObserver =>
       intersectionObserver.root === root
     );
   }

--- a/entry_types/scrolled/package/src/editor/config.js
+++ b/entry_types/scrolled/package/src/editor/config.js
@@ -26,7 +26,10 @@ import {BrowserNotSupportedView} from './views/BrowserNotSupportedView';
 editor.registerEntryType('scrolled', {
   entryModel: ScrolledEntry,
 
-  previewView(options) {
+  // Defined as a plain function (not a concise method) because the core
+  // editor constructs it with `new editor.entryType.previewView(...)`,
+  // and concise methods are not constructable.
+  previewView: function(options) {
     return new EntryPreviewView({
       ...options,
       editor

--- a/entry_types/scrolled/package/src/frontend/polyfills.js
+++ b/entry_types/scrolled/package/src/frontend/polyfills.js
@@ -1,16 +1,3 @@
-import 'core-js/features/array/fill';
-import 'core-js/features/array/find';
-import 'core-js/features/array/from'
-import 'core-js/features/object/assign';
-import 'core-js/features/promise';
-import 'core-js/features/map';
-import 'core-js/features/string/starts-with';
-import 'core-js/features/set';
-import 'core-js/features/symbol';
-import 'core-js/features/symbol/iterator';
-
-import 'regenerator-runtime/runtime.js';
-
 import {browser} from 'pageflow/frontend';
 
 // Safari does not handle positive root margin correctly inside
@@ -21,9 +8,9 @@ if (browser.agent.matchesSafari() && window.parent !== window) {
 
 require('intersection-observer');
 
-// Make sure we're in a Browser-like environment before importing polyfills
-// This prevents `fetch()` from being imported in a Node test environment
+// Make sure we're in a Browser-like environment before importing the
+// polyfill. This prevents it from being imported in a Node test
+// environment.
 if (typeof window !== 'undefined') {
-  require('whatwg-fetch');
   require('scroll-timeline');
 }

--- a/package/src/frontend/index.js
+++ b/package/src/frontend/index.js
@@ -1,4 +1,3 @@
-import './polyfills';
 import {Consent} from './Consent';
 
 export {log, debugMode} from './base';

--- a/package/src/frontend/polyfills.js
+++ b/package/src/frontend/polyfills.js
@@ -1,9 +1,0 @@
-import 'core-js/features/array/from';
-import 'core-js/features/array/includes';
-import 'core-js/features/object/assign';
-import 'core-js/features/object/entries';
-import 'core-js/features/object/keys';
-import 'core-js/features/promise';
-
-// Make second parameter of `toggle` work in IE 11
-import 'classlist.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,9 +4423,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001580:
-  version "1.0.30001581"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz#0dfd4db9e94edbdca67d57348ebc070dece279f4"
-  integrity sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==
+  version "1.0.30001805"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz"
+  integrity sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"
@@ -13170,11 +13170,6 @@ whatwg-fetch@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
   integrity sha512-DIuh7/cloHxHYwS/oRXGgkALYAntijL63nsgMQsNSnBj825AysosAqA2ZbYXGRqpPRiNH7335dTqV364euRpZw==
-
-whatwg-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Add a .browserslistrc with `defaults and supports es6-module` so Babel stops transpiling to ES5 and injecting core-js polyfills for features modern browsers support natively. This eliminates the legacy JavaScript reported by Lighthouse.

Trim now-unneeded frontend polyfills: regenerator-runtime (native async/await), core-js feature imports, classlist.js (IE 11) and whatwg-fetch (native fetch). Keep intersection-observer (Safari iframe root-margin workaround) and scroll-timeline (not native in Safari). Refresh caniuse-lite.