### PR TITLE
Fix server-side rendering of scrolled entries

### DIFF
--- a/entry_types/scrolled/package/package.json
+++ b/entry_types/scrolled/package/package.json
@@ -12,6 +12,7 @@
     "@headlessui/react": "^1.6.6",
     "classnames": "^2.3.2",
     "core-js": "^3.6.5",
+    "core-js-pure": "^3.0.0",
     "debounce": "^1.2.0",
     "deep-assign": "^3.0.0",
     "intersection-observer": "^0.7.0",

--- a/entry_types/scrolled/package/src/frontend/server.js
+++ b/entry_types/scrolled/package/src/frontend/server.js
@@ -1,10 +1,19 @@
 import 'core-js/stable';
 import 'core-js/features/typed-array/uint16-array';
+import URLPolyfill from 'core-js-pure/features/url';
 
 import React from 'react';
 import ReactRailsUJS from 'react_ujs';
 
 import {Root, setupI18n} from 'pageflow-scrolled/frontend';
+
+// The server-side rendering environment (ExecJS) lacks Web APIs like URL,
+// which `core-js/stable` no longer polyfills now that we target modern
+// browsers. Install it from core-js-pure (which the browser-targeted
+// transforms do not strip) so prerendering can use `new URL(...)`.
+if (typeof global.URL === 'undefined') {
+  global.URL = URLPolyfill;
+}
 
 ReactRailsUJS.getConstructor = function() {
   // Normally this function receives the name of a component, but we


### PR DESCRIPTION
Targeting modern browsers stopped core-js from polyfilling URL, but the server-side rendering runtime (ExecJS) has no native URL, so prerendering crashed with "URL is not defined". Provide it from core-js-pure, which the browser-targeted transforms leave intact.

REDMINE-21330