### PR TITLE
Improve entry defaults

### DIFF
--- a/entry_types/scrolled/config/locales/de.yml
+++ b/entry_types/scrolled/config/locales/de.yml
@@ -1559,6 +1559,19 @@ de:
             inline_help: |-
               Standardmäßig Elemente auf kleineren Bildschirmen
               die gesamte Breite des Viewports nutzen lassen.
+          defaultCaptionVariant:
+            label: Beschriftungsvariante
+            inline_help: Standard-Darstellung der Beschriftungen neuer Elemente.
+          defaultFileRightsDisplay:
+            label: Rechteanzeige hochgeladener Dateien
+            inline_help: |-
+              Lege fest, ob die Rechteangabe neu hochgeladener Dateien in
+              der zusammenfassenden Liste in der Info-Box angezeigt werden
+              soll oder unmittelbar an der Stelle im Beitrag, wo die Datei
+              verwendet wird.
+            values:
+              credits: In der Info-Box
+              inline: Am verwendenden Element
       typography_sizes:
         xxxl: Riesig
         xxl: Extra groß

--- a/entry_types/scrolled/config/locales/en.yml
+++ b/entry_types/scrolled/config/locales/en.yml
@@ -1542,6 +1542,18 @@ en:
             inline_help: |-
               By default, make elements span the full width of the
               viewport on smaller screens.
+          defaultCaptionVariant:
+            label: Caption variant
+            inline_help: Default look of captions of newly added elements.
+          defaultFileRightsDisplay:
+            label: Display rights of uploaded files
+            inline_help: |-
+              Decide if the credit note of newly uploaded files should be
+              displayed in the summary list in the info box, or right at
+              the place in the entry where the file is used.
+            values:
+              credits: In the info box
+              inline: At the element where it is used
       typography_sizes:
         xxxl: Huge
         xxl: Extra large

--- a/entry_types/scrolled/package/spec/editor/models/ContentElement-spec.js
+++ b/entry_types/scrolled/package/spec/editor/models/ContentElement-spec.js
@@ -640,6 +640,65 @@ describe('ContentElement', () => {
         expect(contentElement.configuration.has('fullWidthInPhoneLayout')).toEqual(false);
       });
     });
+
+    describe('with defaultCaptionVariant', () => {
+      beforeEach(() => {
+        editor.contentElementTypes.register('elementSupportingCaption', {
+          supportedCaptions: true
+        });
+        editor.contentElementTypes.register('elementNotSupportingCaption', {});
+      });
+
+      it('sets captionVariant if element supports captions', () => {
+        const entry = factories.entry(
+          ScrolledEntry,
+          {
+            metadata: {
+              configuration: {
+                defaultCaptionVariant: 'inverted'
+              }
+            }
+          },
+          {
+            entryTypeSeed: normalizeSeed({
+              contentElements: []
+            })
+          }
+        );
+
+        const contentElement = new entry.contentElements.model({
+          typeName: 'elementSupportingCaption'
+        });
+        contentElement.applyDefaultConfiguration({entry});
+
+        expect(contentElement.configuration.get('captionVariant')).toEqual('inverted');
+      });
+
+      it('does not set captionVariant if element does not support captions', () => {
+        const entry = factories.entry(
+          ScrolledEntry,
+          {
+            metadata: {
+              configuration: {
+                defaultCaptionVariant: 'inverted'
+              }
+            }
+          },
+          {
+            entryTypeSeed: normalizeSeed({
+              contentElements: []
+            })
+          }
+        );
+
+        const contentElement = new entry.contentElements.model({
+          typeName: 'elementNotSupportingCaption'
+        });
+        contentElement.applyDefaultConfiguration({entry});
+
+        expect(contentElement.configuration.has('captionVariant')).toEqual(false);
+      });
+    });
   });
 
   describe('#getEditorPath', () => {

--- a/entry_types/scrolled/package/spec/editor/views/EditDefaultsView-spec.js
+++ b/entry_types/scrolled/package/spec/editor/views/EditDefaultsView-spec.js
@@ -24,6 +24,9 @@ describe('EditDefaultsView', () => {
     'pageflow_scrolled.editor.edit_defaults.attributes.defaultSectionPaddingBottom.label': 'Default bottom padding',
     'pageflow_scrolled.editor.edit_defaults.attributes.defaultContentElementEnableFullscreen.label': 'Enable fullscreen',
     'pageflow_scrolled.editor.edit_defaults.attributes.defaultContentElementFullWidthInPhoneLayout.label': 'Full width in phone layout',
+    'pageflow_scrolled.editor.edit_defaults.attributes.defaultCaptionVariant.label': 'Default caption variant',
+    'pageflow_scrolled.editor.edit_defaults.attributes.defaultFileRightsDisplay.label': 'Default rights display',
+    'pageflow_scrolled.editor.common_content_element_attributes.captionVariant.blank': '(Default)',
     'pageflow_scrolled.editor.edit_defaults.content_elements_info': 'Changes to these settings have no effect on existing elements.',
     'pageflow_scrolled.editor.section_padding_visualization.top_padding': 'TopPadding',
     'pageflow_scrolled.editor.section_padding_visualization.bottom_padding': 'Bottom'
@@ -82,6 +85,55 @@ describe('EditDefaultsView', () => {
     const configurationEditor = ConfigurationEditor.find(view);
 
     expect(configurationEditor.inputPropertyNames()).toContain('defaultContentElementFullWidthInPhoneLayout');
+  });
+
+  it('contains defaultFileRightsDisplay select input', () => {
+    const entry = createEntry({});
+
+    const view = new EditDefaultsView({
+      model: entry.metadata,
+      entry
+    });
+
+    const {getByRole} = renderBackboneView(view);
+    fireEvent.click(getByRole('tab', {name: 'New Elements'}));
+    const configurationEditor = ConfigurationEditor.find(view);
+
+    expect(configurationEditor.inputPropertyNames()).toContain('defaultFileRightsDisplay');
+  });
+
+  it('contains defaultCaptionVariant select input if theme defines caption variants', () => {
+    const entry = createEntry({
+      themeOptions: {
+        properties: {'figureCaption-inverted': {}}
+      }
+    });
+
+    const view = new EditDefaultsView({
+      model: entry.metadata,
+      entry
+    });
+
+    const {getByRole} = renderBackboneView(view);
+    fireEvent.click(getByRole('tab', {name: 'New Elements'}));
+    const configurationEditor = ConfigurationEditor.find(view);
+
+    expect(configurationEditor.inputPropertyNames()).toContain('defaultCaptionVariant');
+  });
+
+  it('omits defaultCaptionVariant select input if theme has no caption variants', () => {
+    const entry = createEntry({});
+
+    const view = new EditDefaultsView({
+      model: entry.metadata,
+      entry
+    });
+
+    const {getByRole} = renderBackboneView(view);
+    fireEvent.click(getByRole('tab', {name: 'New Elements'}));
+    const configurationEditor = ConfigurationEditor.find(view);
+
+    expect(configurationEditor.inputPropertyNames()).not.toContain('defaultCaptionVariant');
   });
 
   it('shows info box in content elements tab', () => {

--- a/entry_types/scrolled/package/spec/editor/views/defineEntryDefaultsInputs-spec.js
+++ b/entry_types/scrolled/package/spec/editor/views/defineEntryDefaultsInputs-spec.js
@@ -1,0 +1,94 @@
+import '@testing-library/jest-dom/extend-expect';
+import {fireEvent} from '@testing-library/react';
+import Backbone from 'backbone';
+
+import {ConfigurationEditorView, CheckBoxInputView} from 'pageflow/ui';
+import {InfoBoxView} from 'pageflow/editor';
+import {ConfigurationEditor, useFakeTranslations, renderBackboneView} from 'pageflow/testHelpers';
+
+import {defineEntryDefaultsInputs} from 'editor/views/EditDefaultsView';
+import {createDefaultsEntry} from 'editor/models/createDefaultsEntry';
+import {editor} from 'editor/api';
+
+import {useEditorGlobals} from 'support';
+
+describe('defineEntryDefaultsInputs', () => {
+  useEditorGlobals();
+
+  useFakeTranslations({
+    'pageflow_scrolled.editor.edit_defaults.tabs.sections': 'Sections',
+    'pageflow_scrolled.editor.edit_defaults.tabs.content_elements': 'New Elements'
+  });
+
+  function renderWithDefaultsEntry() {
+    editor.contentElementTypes.register('testElement', {
+      defaultsInputs() {
+        this.input('enableFullscreen', CheckBoxInputView);
+      }
+    });
+
+    const configurationEditor = new ConfigurationEditorView({
+      model: new Backbone.Model(),
+      tabTranslationKeyPrefix: 'pageflow_scrolled.editor.edit_defaults.tabs',
+      attributeTranslationKeyPrefixes: ['pageflow_scrolled.editor.edit_defaults.attributes']
+    });
+
+    const entry = createDefaultsEntry({
+      seed: {config: {theme: {options: {properties: {'figureCaption-inverted': {}}}}}},
+      themeName: 'default'
+    });
+
+    defineEntryDefaultsInputs(configurationEditor, {entry});
+
+    return {
+      ...renderBackboneView(configurationEditor),
+      configurationEditor
+    };
+  }
+
+  it('builds section defaults from the shallow entry theme scales', () => {
+    const {configurationEditor} = renderWithDefaultsEntry();
+
+    expect(new ConfigurationEditor(configurationEditor.$el).inputPropertyNames())
+      .toEqual(expect.arrayContaining([
+        'defaultSectionPaddingTop',
+        'defaultSectionPaddingBottom'
+      ]));
+  });
+
+  it('renders the tab info box via the given renderInfoBox', () => {
+    const configurationEditor = new ConfigurationEditorView({
+      model: new Backbone.Model(),
+      tabTranslationKeyPrefix: 'pageflow_scrolled.editor.edit_defaults.tabs',
+      attributeTranslationKeyPrefixes: ['pageflow_scrolled.editor.edit_defaults.attributes']
+    });
+
+    const entry = createDefaultsEntry({
+      seed: {config: {theme: {options: {properties: {}}}}},
+      themeName: 'default'
+    });
+
+    defineEntryDefaultsInputs(configurationEditor, {
+      entry,
+      renderInfoBox: (tab, name) => tab.view(InfoBoxView, {text: `Info for ${name}`, level: 'info'})
+    });
+
+    const {getByText} = renderBackboneView(configurationEditor);
+
+    expect(getByText('Info for sections')).toBeInTheDocument();
+  });
+
+  it('builds all-elements and per-type defaults from the shallow entry', () => {
+    const {getByRole, configurationEditor} = renderWithDefaultsEntry();
+
+    fireEvent.click(getByRole('tab', {name: 'New Elements'}));
+
+    expect(new ConfigurationEditor(configurationEditor.$el).inputPropertyNames())
+      .toEqual(expect.arrayContaining([
+        'defaultContentElementFullWidthInPhoneLayout',
+        'defaultCaptionVariant',
+        'defaultFileRightsDisplay',
+        'default-testElement-enableFullscreen'
+      ]));
+  });
+});

--- a/entry_types/scrolled/package/src/contentElements/dataWrapperChart/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/dataWrapperChart/editor.js
@@ -10,6 +10,7 @@ editor.contentElementTypes.register('dataWrapperChart', {
   pictogram,
   supportedPositions: ['inline', 'side', 'sticky', 'standAlone', 'left', 'right'],
   supportedWidthRange: ['xxs', 'full'],
+  supportedCaptions: true,
   supportedStyles: ['boxShadow', 'outline'],
 
   configurationEditor({entry}) {

--- a/entry_types/scrolled/package/src/contentElements/heading/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/heading/editor.js
@@ -13,6 +13,12 @@ editor.contentElementTypes.register('heading', {
 
   defaultConfig: {width: contentElementWidths.xl, marginTop: 'none'},
 
+  defaultsInputs() {
+    this.input('hyphens', SelectInputView, {
+      values: ['auto', 'manual']
+    });
+  },
+
   configurationEditor({entry}) {
     this.listenTo(this.model, 'change:hyphens', this.refresh);
 

--- a/entry_types/scrolled/package/src/contentElements/hotspots/editor/index.js
+++ b/entry_types/scrolled/package/src/contentElements/hotspots/editor/index.js
@@ -20,6 +20,7 @@ editor.contentElementTypes.register('hotspots', {
   category: 'interactive',
   supportedPositions: ['inline', 'side', 'sticky', 'standAlone', 'left', 'right', 'backdrop'],
   supportedWidthRange: ['xxs', 'full'],
+  supportedCaptions: true,
   supportedStyles: ['boxShadow', 'outline'],
 
   editorPath(contentElement) {

--- a/entry_types/scrolled/package/src/contentElements/iframeEmbed/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/iframeEmbed/editor.js
@@ -13,6 +13,7 @@ editor.contentElementTypes.register('iframeEmbed', {
   featureName: 'iframe_embed_content_element',
   supportedPositions: ['inline', 'side', 'sticky', 'standAlone', 'left', 'right'],
   supportedWidthRange: ['xxs', 'full'],
+  supportedCaptions: true,
   supportedStyles: ['boxShadow', 'outline'],
 
   configurationEditor({entry}) {

--- a/entry_types/scrolled/package/src/contentElements/imageGallery/editor/index.js
+++ b/entry_types/scrolled/package/src/contentElements/imageGallery/editor/index.js
@@ -20,6 +20,7 @@ editor.contentElementTypes.register('imageGallery', {
   category: 'media',
   supportedPositions: ['inline', 'side', 'sticky', 'standAlone', 'left', 'right'],
   supportedWidthRange: ['xxs', 'full'],
+  supportedCaptions: {disableWhenNoCaption: false},
   supportedStyles: ['boxShadow', 'outline'],
 
   configurationEditor({entry, contentElement}) {

--- a/entry_types/scrolled/package/src/contentElements/inlineAudio/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/inlineAudio/editor.js
@@ -18,6 +18,7 @@ editor.contentElementTypes.register('inlineAudio', {
   category: 'media',
   supportedPositions: ['inline', 'side', 'sticky', 'standAlone', 'left', 'right'],
   supportedWidthRange: ['xxs', 'full'],
+  supportedCaptions: true,
   supportedStyles: [
     {
       name: 'boxShadow',

--- a/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/inlineBeforeAfter/editor.js
@@ -9,6 +9,7 @@ editor.contentElementTypes.register('inlineBeforeAfter', {
   category: 'interactive',
   supportedPositions: ['inline', 'side', 'sticky', 'standAlone', 'left', 'right', 'backdrop'],
   supportedWidthRange: ['xxs', 'full'],
+  supportedCaptions: true,
   supportedStyles: ['boxShadow', 'outline'],
 
   configurationEditor({entry}) {

--- a/entry_types/scrolled/package/src/contentElements/inlineImage/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/inlineImage/editor.js
@@ -10,6 +10,7 @@ editor.contentElementTypes.register('inlineImage', {
   category: 'media',
   supportedPositions: ['inline', 'side', 'sticky', 'standAlone', 'left', 'right'],
   supportedWidthRange: ['xxs', 'full'],
+  supportedCaptions: true,
   supportedStyles: ['boxShadow', 'outline'],
 
   defaultsInputs() {

--- a/entry_types/scrolled/package/src/contentElements/inlineVideo/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/inlineVideo/editor.js
@@ -38,6 +38,7 @@ editor.contentElementTypes.register('inlineVideo', {
   category: 'media',
   supportedPositions: ['inline', 'side', 'sticky', 'standAlone', 'left', 'right', 'backdrop'],
   supportedWidthRange: ['xxs', 'full'],
+  supportedCaptions: true,
   supportedStyles: ['boxShadow', 'outline'],
 
   defaultsInputs() {

--- a/entry_types/scrolled/package/src/contentElements/videoEmbed/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/videoEmbed/editor.js
@@ -9,6 +9,7 @@ editor.contentElementTypes.register('videoEmbed', {
   category: 'media',
   supportedPositions: ['inline', 'side', 'sticky', 'standAlone', 'left', 'right'],
   supportedWidthRange: ['xxs', 'full'],
+  supportedCaptions: true,
   supportedStyles: ['boxShadow', 'outline'],
 
   configurationEditor({entry}) {

--- a/entry_types/scrolled/package/src/contentElements/vrImage/editor.js
+++ b/entry_types/scrolled/package/src/contentElements/vrImage/editor.js
@@ -10,6 +10,7 @@ editor.contentElementTypes.register('vrImage', {
   category: 'interactive',
   supportedPositions: ['inline', 'side', 'sticky', 'standAlone', 'left', 'right', 'backdrop'],
   supportedWidthRange: ['xxs', 'full'],
+  supportedCaptions: true,
   supportedStyles: ['boxShadow', 'outline'],
 
   configurationEditor({entry}) {

--- a/entry_types/scrolled/package/src/editor/index.js
+++ b/entry_types/scrolled/package/src/editor/index.js
@@ -23,4 +23,6 @@ export {EditMotifAreaDialogView} from './views/EditMotifAreaDialogView';
 export {ImageModifierListInputView} from './views/inputs/ImageModifierListInputView';
 export {InlineFileRightsMenuItem} from './models/InlineFileRightsMenuItem';
 
+export {defineEntryDefaultsInputsFromSeed} from './views/EditDefaultsView';
+
 Object.assign(pageflow, globalInterop);

--- a/entry_types/scrolled/package/src/editor/models/ContentElement.js
+++ b/entry_types/scrolled/package/src/editor/models/ContentElement.js
@@ -113,6 +113,10 @@ export const ContentElement = Backbone.Model.extend({
       mapping.defaultContentElementFullWidthInPhoneLayout = 'fullWidthInPhoneLayout';
     }
 
+    if (this.supportsCaption()) {
+      mapping.defaultCaptionVariant = 'captionVariant';
+    }
+
     return mapping;
   },
 
@@ -173,6 +177,10 @@ export const ContentElement = Backbone.Model.extend({
   supportsFullWidthInPhoneLayout() {
     return !this.getType().customMargin &&
            this.getType().supportedWidthRange?.[1] === 'full';
+  },
+
+  supportsCaption() {
+    return !!this.getType().supportedCaptions;
   },
 
   getEditorPath() {

--- a/entry_types/scrolled/package/src/editor/models/createDefaultsEntry.js
+++ b/entry_types/scrolled/package/src/editor/models/createDefaultsEntry.js
@@ -1,0 +1,25 @@
+import Backbone from 'backbone';
+
+import {ScrolledEntry} from './ScrolledEntry';
+
+// Builds a minimal stand-in entry for use with `defineEntryDefaultsInputs`
+// outside the editor (e.g. per-site entry template defaults in the admin),
+// where no full entry has been booted.
+//
+// It reuses `ScrolledEntry`'s real `getScale` and `getComponentVariants`
+// but bypasses the constructor, which requires a running editor (state
+// collections, file types). Only the theme-derived accessors are
+// available; anything else throws, which is what lets the accompanying spec
+// verify that `defineEntryDefaultsInputs` depends on nothing more.
+//
+// `seed` is a scrolled entry seed as produced by the `scrolled_entry_json_seed`
+// helper (only its `config.theme` is read). `themeName` is used to look up
+// theme-specific variant labels (with a generic fallback), so it is optional.
+export function createDefaultsEntry({seed, themeName}) {
+  const entry = Object.create(ScrolledEntry.prototype);
+
+  entry.scrolledSeed = seed;
+  entry.metadata = new Backbone.Model({theme_name: themeName});
+
+  return entry;
+}

--- a/entry_types/scrolled/package/src/editor/views/EditDefaultsView.js
+++ b/entry_types/scrolled/package/src/editor/views/EditDefaultsView.js
@@ -2,6 +2,7 @@ import I18n from 'i18n-js';
 import {EditConfigurationView, InfoBoxView} from 'pageflow/editor';
 import {CheckBoxInputView, SelectInputView, SliderInputView} from 'pageflow/ui';
 import {editor} from '../api';
+import {createDefaultsEntry} from '../models/createDefaultsEntry';
 import {ContentElementTypeSeparatorView} from './ContentElementTypeSeparatorView';
 import {SectionPaddingVisualizationView} from './inputs/SectionPaddingVisualizationView';
 
@@ -14,95 +15,123 @@ export const EditDefaultsView = EditConfigurationView.extend({
   goBackPath: '/meta_data/widgets',
 
   configure: function(configurationEditor) {
-    const entry = this.options.entry;
-
-    configurationEditor.tab('sections', function() {
-      this.view(InfoBoxView, {
-        text: I18n.t('pageflow_scrolled.editor.edit_defaults.sections_info'),
-        level: 'info'
-      });
-
-      this.input('defaultSectionLayout', SelectInputView, {
-        values: ['left', 'right', 'center', 'centerRagged']
-      });
-
-      this.input('defaultSectionAppearance', SelectInputView, {
-        values: ['shadow', 'cards', 'transparent']
-      });
-
-      const paddingTopScale = entry.getScale('sectionPaddingTop');
-      const paddingBottomScale = entry.getScale('sectionPaddingBottom');
-
-      this.input('topPaddingVisualization', SectionPaddingVisualizationView, {
-        variant: 'topPadding'
-      });
-      this.input('defaultSectionPaddingTop', SliderInputView, {
-        hideLabel: true,
-        icon: paddingTopIcon,
-        values: paddingTopScale.values,
-        texts: paddingTopScale.texts,
-        defaultValue: paddingTopScale.defaultValue
-      });
-
-      this.input('bottomPaddingVisualization', SectionPaddingVisualizationView, {
-        variant: 'bottomPadding'
-      });
-      this.input('defaultSectionPaddingBottom', SliderInputView, {
-        hideLabel: true,
-        icon: paddingBottomIcon,
-        values: paddingBottomScale.values,
-        texts: paddingBottomScale.texts,
-        defaultValue: paddingBottomScale.defaultValue
-      });
-    });
-
-    configurationEditor.tab('content_elements', function() {
-      this.view(InfoBoxView, {
-        text: I18n.t('pageflow_scrolled.editor.edit_defaults.content_elements_info'),
-        level: 'info'
-      });
-
-      this.view(ContentElementTypeSeparatorView, {
-        typeName: I18n.t('pageflow_scrolled.editor.edit_defaults.all_elements')
-      });
-
-      this.input('defaultContentElementFullWidthInPhoneLayout', CheckBoxInputView);
-
-      const [captionVariants, captionVariantTexts] =
-        entry.getComponentVariants({name: 'figureCaption'});
-
-      if (captionVariants.length) {
-        this.input('defaultCaptionVariant', SelectInputView, {
-          includeBlank: true,
-          blankTranslationKey: 'pageflow_scrolled.editor.' +
-                               'common_content_element_attributes.' +
-                               'captionVariant.blank',
-          values: captionVariants,
-          texts: captionVariantTexts
-        });
-      }
-
-      if (editor.entryType.supportsExtendedFileRights) {
-        this.input('defaultFileRightsDisplay', SelectInputView, {
-          values: ['credits', 'inline']
-        });
-      }
-
-      const tabView = this;
-      editor.contentElementTypes.toArray().forEach(contentElementType => {
-        if (contentElementType.defaultsInputs) {
-          tabView.view(ContentElementTypeSeparatorView, {
-            pictogram: contentElementType.pictogram || defaultPictogram,
-            typeName: contentElementType.displayName
-          });
-
-          const context = editor.contentElementTypes.createDefaultsInputContext(
-            tabView,
-            contentElementType.typeName
-          );
-          contentElementType.defaultsInputs.call(context);
-        }
-      });
+    defineEntryDefaultsInputs(configurationEditor, {
+      entry: this.options.entry,
+      renderInfoBox
     });
   }
 });
+
+// Also used for per-site entry template defaults in the admin, via
+// defineEntryDefaultsInputsFromSeed. `model` lets the tabs bind to a
+// configuration model other than the editor's default.
+export function defineEntryDefaultsInputs(configurationEditor, {
+  entry,
+  model,
+  renderInfoBox = () => {}
+}) {
+  configurationEditor.tab('sections', {model}, function() {
+    renderInfoBox(this, 'sections');
+
+    this.input('defaultSectionLayout', SelectInputView, {
+      values: ['left', 'right', 'center', 'centerRagged']
+    });
+
+    this.input('defaultSectionAppearance', SelectInputView, {
+      values: ['shadow', 'cards', 'transparent']
+    });
+
+    const paddingTopScale = entry.getScale('sectionPaddingTop');
+    const paddingBottomScale = entry.getScale('sectionPaddingBottom');
+
+    this.input('topPaddingVisualization', SectionPaddingVisualizationView, {
+      variant: 'topPadding'
+    });
+    this.input('defaultSectionPaddingTop', SliderInputView, {
+      hideLabel: true,
+      icon: paddingTopIcon,
+      values: paddingTopScale.values,
+      texts: paddingTopScale.texts,
+      defaultValue: paddingTopScale.defaultValue
+    });
+
+    this.input('bottomPaddingVisualization', SectionPaddingVisualizationView, {
+      variant: 'bottomPadding'
+    });
+    this.input('defaultSectionPaddingBottom', SliderInputView, {
+      hideLabel: true,
+      icon: paddingBottomIcon,
+      values: paddingBottomScale.values,
+      texts: paddingBottomScale.texts,
+      defaultValue: paddingBottomScale.defaultValue
+    });
+  });
+
+  configurationEditor.tab('content_elements', {model}, function() {
+    renderInfoBox(this, 'content_elements');
+
+    this.view(ContentElementTypeSeparatorView, {
+      typeName: I18n.t('pageflow_scrolled.editor.edit_defaults.all_elements')
+    });
+
+    this.input('defaultContentElementFullWidthInPhoneLayout', CheckBoxInputView);
+
+    const [captionVariants, captionVariantTexts] =
+      entry.getComponentVariants({name: 'figureCaption'});
+
+    if (captionVariants.length) {
+      this.input('defaultCaptionVariant', SelectInputView, {
+        includeBlank: true,
+        blankTranslationKey: 'pageflow_scrolled.editor.' +
+                             'common_content_element_attributes.' +
+                             'captionVariant.blank',
+        values: captionVariants,
+        texts: captionVariantTexts
+      });
+    }
+
+    if (editor.entryType.supportsExtendedFileRights) {
+      this.input('defaultFileRightsDisplay', SelectInputView, {
+        values: ['credits', 'inline']
+      });
+    }
+
+    const tabView = this;
+    editor.contentElementTypes.toArray().forEach(contentElementType => {
+      if (contentElementType.defaultsInputs) {
+        tabView.view(ContentElementTypeSeparatorView, {
+          pictogram: contentElementType.pictogram || defaultPictogram,
+          typeName: contentElementType.displayName
+        });
+
+        const context = editor.contentElementTypes.createDefaultsInputContext(
+          tabView,
+          contentElementType.typeName
+        );
+        contentElementType.defaultsInputs.call(context);
+      }
+    });
+  });
+}
+
+// For consumers without a full entry (e.g. the admin): builds a theme-only
+// stand-in entry from a scrolled entry seed.
+export function defineEntryDefaultsInputsFromSeed(configurationEditor, {
+  seed,
+  themeName,
+  model,
+  renderInfoBox
+}) {
+  defineEntryDefaultsInputs(configurationEditor, {
+    entry: createDefaultsEntry({seed, themeName}),
+    model,
+    renderInfoBox
+  });
+}
+
+function renderInfoBox(tab, name) {
+  tab.view(InfoBoxView, {
+    text: I18n.t(`pageflow_scrolled.editor.edit_defaults.${name}_info`),
+    level: 'info'
+  });
+}

--- a/entry_types/scrolled/package/src/editor/views/EditDefaultsView.js
+++ b/entry_types/scrolled/package/src/editor/views/EditDefaultsView.js
@@ -68,6 +68,26 @@ export const EditDefaultsView = EditConfigurationView.extend({
 
       this.input('defaultContentElementFullWidthInPhoneLayout', CheckBoxInputView);
 
+      const [captionVariants, captionVariantTexts] =
+        entry.getComponentVariants({name: 'figureCaption'});
+
+      if (captionVariants.length) {
+        this.input('defaultCaptionVariant', SelectInputView, {
+          includeBlank: true,
+          blankTranslationKey: 'pageflow_scrolled.editor.' +
+                               'common_content_element_attributes.' +
+                               'captionVariant.blank',
+          values: captionVariants,
+          texts: captionVariantTexts
+        });
+      }
+
+      if (editor.entryType.supportsExtendedFileRights) {
+        this.input('defaultFileRightsDisplay', SelectInputView, {
+          values: ['credits', 'inline']
+        });
+      }
+
       const tabView = this;
       editor.contentElementTypes.toArray().forEach(contentElementType => {
         if (contentElementType.defaultsInputs) {

--- a/package/spec/editor/models/FileUploader-spec.js
+++ b/package/spec/editor/models/FileUploader-spec.js
@@ -142,6 +142,62 @@ describe('FileUploader', () => {
           fileUploader.add(nonNestedUpload, {editor: editor});
         }).toThrowError(InvalidNestedTypeError);
       });
+
+      it('seeds rights_display from defaultFileRightsDisplay entry metadata', () => {
+        testContext.entry.metadata.configuration.set('defaultFileRightsDisplay', 'inline');
+        var editor = new EditorApi();
+        editor.registerEntryType('test', {supportsExtendedFileRights: true});
+        var fileUploader = new FileUploader({
+          entry: testContext.entry,
+          fileTypes: testContext.fileTypes
+        });
+        var upload = {name: 'image.png', type: 'image/png'};
+        var result;
+
+        fileUploader.add(upload, {editor: editor}).then(function(file) {
+          result = file;
+        });
+        fileUploader.submit();
+
+        expect(result.configuration.get('rights_display')).toBe('inline');
+      });
+
+      it('does not seed rights_display without a default', () => {
+        var editor = new EditorApi();
+        editor.registerEntryType('test', {supportsExtendedFileRights: true});
+        var fileUploader = new FileUploader({
+          entry: testContext.entry,
+          fileTypes: testContext.fileTypes
+        });
+        var upload = {name: 'image.png', type: 'image/png'};
+        var result;
+
+        fileUploader.add(upload, {editor: editor}).then(function(file) {
+          result = file;
+        });
+        fileUploader.submit();
+
+        expect(result.configuration.has('rights_display')).toBe(false);
+      });
+
+      it('does not seed rights_display when entry type lacks extended file rights', () => {
+        testContext.entry.metadata.configuration.set('defaultFileRightsDisplay', 'inline');
+        var editor = new EditorApi();
+        editor.registerEntryType('test', {});
+        var fileUploader = new FileUploader({
+          entry: testContext.entry,
+          fileTypes: testContext.fileTypes
+        });
+        var upload = {name: 'image.png', type: 'image/png'};
+        var result;
+
+        fileUploader.add(upload, {editor: editor}).then(function(file) {
+          result = file;
+        });
+        fileUploader.submit();
+
+        expect(result.configuration.has('rights_display')).toBe(false);
+      });
     });
 
     describe('nested file', () => {

--- a/package/src/editor/models/FileUploader.js
+++ b/package/src/editor/models/FileUploader.js
@@ -23,7 +23,8 @@ export const FileUploader = Object.extend({
       file_name: upload.name,
       display_name: upload.name,
       content_type: upload.type,
-      file_size: upload.size
+      file_size: upload.size,
+      configuration: this.defaultConfiguration(fileType, editor)
     }, {
       fileType: fileType
     });
@@ -66,6 +67,22 @@ export const FileUploader = Object.extend({
       function() {
         file.destroy();
       });
+  },
+
+  defaultConfiguration: function(fileType, editor) {
+    var configuration = {};
+
+    if (editor.entryType && editor.entryType.supportsExtendedFileRights &&
+        !fileType.noExtendedFileRights) {
+      var rightsDisplay = this.entry.metadata &&
+                          this.entry.metadata.configuration.get('defaultFileRightsDisplay');
+
+      if (rightsDisplay) {
+        configuration.rights_display = rightsDisplay;
+      }
+    }
+
+    return configuration;
   },
 
   submit: function() {


### PR DESCRIPTION
Let editors preconfigure additional settings that apply when new
content elements are created or files are uploaded, so common
choices no longer have to be repeated by hand:

- hyphenation for new headings
- caption variant, shared across all elements that support captions
- rights display for newly uploaded files

The shared caption and file-rights defaults live under "All
elements" but only take effect where they actually apply.