### PR TITLE
Allow configuring gradient shadow color

### DIFF
--- a/entry_types/scrolled/config/locales/de.yml
+++ b/entry_types/scrolled/config/locales/de.yml
@@ -1276,6 +1276,11 @@ de:
             label: Kartenhintergrundfarbe
             auto: "(Automatisch)"
             auto_color: "Automatische Farbe"
+          shadowColor:
+            inline_help: Farbe der Verläufe, die die Lesbarkeit des Inhalts vor dem Hintergrund verbessern.
+            label: Schattenfarbe
+            auto: "(Automatisch)"
+            auto_color: "Automatische Farbe"
           splitOverlayColor:
             inline_help: Farbe des Overlays hinter dem Inhalt.
             label: Overlay-Farbe

--- a/entry_types/scrolled/config/locales/en.yml
+++ b/entry_types/scrolled/config/locales/en.yml
@@ -1260,6 +1260,11 @@ en:
             label: Cards background color
             auto: "(Auto)"
             auto_color: "Auto color"
+          shadowColor:
+            inline_help: Color of the gradients that improve legibility of the content in front of the backdrop.
+            label: Shadow color
+            auto: "(Auto)"
+            auto_color: "Auto color"
           splitOverlayColor:
             inline_help: Color of the overlay behind the content.
             label: Overlay color

--- a/entry_types/scrolled/package/spec/editor/models/ScrolledEntry/getUsedSectionBackgroundColors-spec.js
+++ b/entry_types/scrolled/package/spec/editor/models/ScrolledEntry/getUsedSectionBackgroundColors-spec.js
@@ -73,6 +73,34 @@ describe('ScrolledEntry', () => {
       expect(colors).toEqual(['#600']);
     });
 
+    it('includes shadowColor of shadow sections', () => {
+      const entry = factories.entry(
+        ScrolledEntry,
+        {},
+        {
+          entryTypeSeed: normalizeSeed({
+            sections: [
+              {
+                configuration: {
+                  appearance: 'shadow',
+                  shadowColor: '#700'
+                }
+              },
+              {
+                configuration: {
+                  shadowColor: '#070'
+                }
+              }
+            ]
+          })
+        }
+      );
+
+      const colors = entry.getUsedSectionBackgroundColors();
+
+      expect(colors).toEqual(['#700', '#070']);
+    });
+
     it('ignores blank colors', () => {
       const entry = factories.entry(
         ScrolledEntry,

--- a/entry_types/scrolled/package/spec/frontend/appearance-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/appearance-spec.js
@@ -11,6 +11,22 @@ describe('useAppearanceOverlayStyle', () => {
     expect(result.current).toEqual({});
   });
 
+  it('returns shadow color custom property for shadow appearance', () => {
+    const {result} = renderHook(() =>
+      useAppearanceOverlayStyle({appearance: 'shadow', shadowColor: '#f00'})
+    );
+
+    expect(result.current).toEqual({'--shadow-color': '#f00'});
+  });
+
+  it('returns shadow color custom property for default appearance', () => {
+    const {result} = renderHook(() =>
+      useAppearanceOverlayStyle({shadowColor: '#f00'})
+    );
+
+    expect(result.current).toEqual({'--shadow-color': '#f00'});
+  });
+
   it('returns empty object for transparent appearance', () => {
     const {result} = renderHook(() =>
       useAppearanceOverlayStyle({appearance: 'transparent'})

--- a/entry_types/scrolled/package/src/editor/models/ScrolledEntry/index.js
+++ b/entry_types/scrolled/package/src/editor/models/ScrolledEntry/index.js
@@ -404,16 +404,22 @@ export const ScrolledEntry = Entry.extend({
     const colors = new Set();
 
     this.sections.forEach(section => {
+      const appearance = section.configuration.get('appearance');
+
       if (section.configuration.get('backdropType') === 'color') {
         colors.add(section.configuration.get('backdropColor'));
       }
 
-      if (section.configuration.get('appearance') === 'cards') {
+      if (appearance === 'cards') {
         colors.add(section.configuration.get('cardSurfaceColor'));
       }
 
-      if (section.configuration.get('appearance') === 'split') {
+      if (appearance === 'split') {
         colors.add(section.configuration.get('splitOverlayColor'));
+      }
+
+      if (!appearance || appearance === 'shadow') {
+        colors.add(section.configuration.get('shadowColor'));
       }
     });
 

--- a/entry_types/scrolled/package/src/editor/views/EditSectionView.js
+++ b/entry_types/scrolled/package/src/editor/views/EditSectionView.js
@@ -192,6 +192,15 @@ export const EditSectionView = EditConfigurationView.extend({
       });
       this.input('invert', CheckBoxInputView);
 
+      this.input('shadowColor', ColorInputView, {
+        visibleBinding: 'appearance',
+        visible: appearance => !appearance || appearance === 'shadow',
+        placeholder: I18n.t('pageflow_scrolled.editor.edit_section.attributes.shadowColor.auto'),
+        placeholderColorBinding: 'invert',
+        placeholderColor: invert => invert ? '#ffffff' : '#000000',
+        placeholderColorDescription: I18n.t('pageflow_scrolled.editor.edit_section.attributes.shadowColor.auto_color'),
+        swatches: backgroundColorSwatches
+      });
       this.input('staticShadowOpacity', SliderInputView, {
         defaultValue: 70,
         visibleBinding: 'appearance',

--- a/entry_types/scrolled/package/src/frontend/__stories__/appearance-stories.js
+++ b/entry_types/scrolled/package/src/frontend/__stories__/appearance-stories.js
@@ -231,9 +231,21 @@ storiesOf(`Frontend/Section Appearance`, module)
     }
   )
 
+storiesOf(`Frontend/Section Appearance`, module)
+  .add(
+    'Custom Shadow Color',
+    () => {
+      return (
+        <RootProviders seed={exampleSeed('shadow', {shadowColor: '#012a4a', short: true})}>
+          <Entry />
+        </RootProviders>
+      );
+    }
+  )
+
 function exampleSeed(
   appearance,
-  {short, invert, width, cardSurfaceColor,
+  {short, invert, width, cardSurfaceColor, shadowColor,
    themeOptions, positionedElementTypeName, includeWidths} = {}
 ) {
   const sectionBaseConfiguration = {
@@ -241,6 +253,7 @@ function exampleSeed(
     transition: 'reveal',
     fullHeight: true,
     cardSurfaceColor,
+    shadowColor,
     invert,
     width
   };

--- a/entry_types/scrolled/package/src/frontend/appearance/useAppearanceOverlayStyle.js
+++ b/entry_types/scrolled/package/src/frontend/appearance/useAppearanceOverlayStyle.js
@@ -3,7 +3,7 @@ import {useMemo} from 'react';
 import {isTranslucentColor} from '../utils/isTranslucentColor';
 
 export function useAppearanceOverlayStyle(section) {
-  const {appearance, cardSurfaceColor, splitOverlayColor, overlayBackdropBlur} = section;
+  const {appearance, cardSurfaceColor, splitOverlayColor, shadowColor, overlayBackdropBlur} = section;
 
   return useMemo(() => {
     if (appearance === 'cards') {
@@ -12,9 +12,12 @@ export function useAppearanceOverlayStyle(section) {
     else if (appearance === 'split') {
       return overlayStyle(splitOverlayColor, overlayBackdropBlur, true);
     }
+    else if (!appearance || appearance === 'shadow') {
+      return shadowColor ? {'--shadow-color': shadowColor} : {};
+    }
 
     return {};
-  }, [appearance, cardSurfaceColor, splitOverlayColor, overlayBackdropBlur]);
+  }, [appearance, cardSurfaceColor, splitOverlayColor, shadowColor, overlayBackdropBlur]);
 }
 
 function overlayStyle(color, backdropBlur, blurByDefault) {

--- a/entry_types/scrolled/package/src/frontend/foregroundBoxes/GradientBox.js
+++ b/entry_types/scrolled/package/src/frontend/foregroundBoxes/GradientBox.js
@@ -10,7 +10,7 @@ export default function GradientBox(props) {
                                  [styles.gradient]: props.motifAreaState.isContentPadded,
                                  [styles.long]: props.coverInvisibleNextSection
                                })}
-         style={{paddingTop: props.motifAreaState.paddingTop}}>
+         style={{...props.overlayStyle, paddingTop: props.motifAreaState.paddingTop}}>
       <div className={styles.wrapper}>
         <div className={classNames(styles.shadow,
                                    props.inverted ? styles.shadowLight : styles.shadowDark,

--- a/entry_types/scrolled/package/src/frontend/foregroundBoxes/GradientBox.module.css
+++ b/entry_types/scrolled/package/src/frontend/foregroundBoxes/GradientBox.module.css
@@ -32,11 +32,11 @@
 }
 
 .shadowDark {
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0px,rgba(0, 0, 0, 0.5) 100px,rgba(0, 0, 0, 0.5) 100%);
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0px,color-mix(in srgb, var(--shadow-color, #000), transparent 50%) 100px,color-mix(in srgb, var(--shadow-color, #000), transparent 50%) 100%);
 }
 
 .shadowLight {
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0px,rgba(255, 255, 255, 0.5) 100px,rgba(255, 255, 255, 0.5) 100%);
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0px,color-mix(in srgb, var(--shadow-color, #fff), transparent 50%) 100px,color-mix(in srgb, var(--shadow-color, #fff), transparent 50%) 100%);
 }
 
 @media print {

--- a/entry_types/scrolled/package/src/frontend/shadows/GradientShadow.js
+++ b/entry_types/scrolled/package/src/frontend/shadows/GradientShadow.js
@@ -23,7 +23,8 @@ export default function GradientShadow(props) {
 
   return (
     <div className={classNames(styles[`align-${props.align}`],
-                               props.inverted ? styles.light : styles.dark)}>
+                               props.inverted ? styles.light : styles.dark)}
+         style={props.overlayStyle}>
       <div className={styles.dynamic}
            style={{opacity: props.dynamicShadowOpacity * opacityFactor}}>
         <Fullscreen />

--- a/entry_types/scrolled/package/src/frontend/shadows/GradientShadow.module.css
+++ b/entry_types/scrolled/package/src/frontend/shadows/GradientShadow.module.css
@@ -22,37 +22,37 @@
 /* dark shadow */
 .align-right.dark .static,
 .align-left.dark .static {
-  background: linear-gradient(to right, #000 0%,rgba(0, 0, 0, 0) 100%);
+  background: linear-gradient(to right, var(--shadow-color, #000) 0%,rgba(0, 0, 0, 0) 100%);
 }
 
 @media (min-width: 950px) {
   .align-right.dark .static {
-    background: linear-gradient(to left, #000 0%,rgba(0, 0, 0, 0) 100%);
+    background: linear-gradient(to left, var(--shadow-color, #000) 0%,rgba(0, 0, 0, 0) 100%);
   }
 }
 
 .dark .dynamic,
 .align-center.dark .static,
 .align-centerRagged.dark .static {
-  background: rgba(0, 0, 0, 0.9);
+  background: color-mix(in srgb, var(--shadow-color, #000), transparent 10%);
 }
 
 /* light shadow */
 .align-right.light .static,
 .align-left.light .static {
-  background: linear-gradient(to right, #fff 0%,rgba(255, 255, 255, 0) 100%);
+  background: linear-gradient(to right, var(--shadow-color, #fff) 0%,rgba(255, 255, 255, 0) 100%);
 }
 
 @media (min-width: 950px) {
   .align-right.light .static {
-    background: linear-gradient(to left, #fff 0%,rgba(255, 255, 255, 0) 100%);
+    background: linear-gradient(to left, var(--shadow-color, #fff) 0%,rgba(255, 255, 255, 0) 100%);
   }
 }
 
 .light .dynamic,
 .align-center.light .static,
 .align-centerRagged.light .static {
-  background: rgba(255, 255, 255, 0.9);
+  background: color-mix(in srgb, var(--shadow-color, #fff), transparent 10%);
 }
 
 @media print {


### PR DESCRIPTION
Editors can now choose a custom color for the legibility gradients of sections using the shadow appearance, instead of being limited to the automatic black or white. This makes it possible to tint the shadows to match a story's design while the opacity sliders keep controlling their strength.

REDMINE-21334