### PR TITLE
Prevent sub/sup from stretching line height

### DIFF
--- a/entry_types/scrolled/package/src/frontend/EditableText.js
+++ b/entry_types/scrolled/package/src/frontend/EditableText.js
@@ -163,11 +163,11 @@ export function renderLeaf({attributes, children, leaf}) {
   }
 
   if (leaf.sub) {
-    children = <sub>{children}</sub>
+    children = <sub className={styles.sub}>{children}</sub>
   }
 
   if (leaf.sup) {
-    children = <sup>{children}</sup>
+    children = <sup className={styles.sup}>{children}</sup>
   }
 
   return <span {...attributes}>{children}</span>

--- a/entry_types/scrolled/package/src/frontend/EditableText.module.css
+++ b/entry_types/scrolled/package/src/frontend/EditableText.module.css
@@ -34,3 +34,20 @@ ol.justify {
 .bold {
   font-weight: var(--theme-editable-text-bold-font-weight, bold);
 }
+
+/* Prevent sup/sub elements from increasing the line height of their line. */
+.sub,
+.sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.sub {
+  bottom: -0.25em;
+}
+
+.sup {
+  top: -0.5em;
+}


### PR DESCRIPTION
Superscript and subscript text made its line taller than the surrounding ones, resulting in uneven line spacing. Sizing them relative to the surrounding text and offsetting them via positioning keeps the line height unaffected.