### PR TITLE
Remember collapsed state of comment toolbar

### DIFF
--- a/entry_types/scrolled/package/spec/frontend/commenting/features/commentVisibility-spec.js
+++ b/entry_types/scrolled/package/spec/frontend/commenting/features/commentVisibility-spec.js
@@ -56,6 +56,29 @@ describe('comment visibility', () => {
     expect(entry.queryShowCommentsButton()).toBeNull();
   });
 
+  it('stays collapsed when the entry is rendered again', () => {
+    const entry = renderEntryWithComments();
+    fireEvent.click(entry.getHideCommentsButton());
+    entry.unmount();
+
+    const reopenedEntry = renderEntryWithComments();
+
+    expect(reopenedEntry.queryCommentToolbar()).toBeNull();
+    expect(reopenedEntry.getShowCommentsButton()).toBeInTheDocument();
+  });
+
+  it('stays expanded after being restored when the entry is rendered again', () => {
+    const entry = renderEntryWithComments();
+    fireEvent.click(entry.getHideCommentsButton());
+    fireEvent.click(entry.getShowCommentsButton());
+    entry.unmount();
+
+    const reopenedEntry = renderEntryWithComments();
+
+    expect(reopenedEntry.getCommentToolbar()).toBeInTheDocument();
+    expect(reopenedEntry.queryShowCommentsButton()).toBeNull();
+  });
+
   it('hides comment badges while hidden and restores them when shown', () => {
     const entry = renderEntry({
       seed: {

--- a/entry_types/scrolled/package/spec/support/pageObjects/commenting.js
+++ b/entry_types/scrolled/package/spec/support/pageObjects/commenting.js
@@ -50,6 +50,10 @@ export function useCommentingPageObjects() {
     act(() => clearExtensions());
   });
 
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   useFakeTranslations({
     'pageflow_scrolled.review.add_comment': 'Add comment',
     'pageflow_scrolled.review.cancel_add_comment': 'Cancel add comment',

--- a/entry_types/scrolled/package/src/frontend/commenting/CommentingVisibilityProvider.js
+++ b/entry_types/scrolled/package/src/frontend/commenting/CommentingVisibilityProvider.js
@@ -1,16 +1,19 @@
 import React, {createContext, useCallback, useContext, useMemo, useState} from 'react';
 import {flushSync} from 'react-dom';
 
+const storageKey = 'pageflow.scrolled.commentingVisible';
+
 const CommentingVisibilityContext = createContext({
   visible: true,
   toggle: () => {}
 });
 
 export function CommentingVisibilityProvider({children}) {
-  const [visible, setVisible] = useState(true);
+  const [visible, setVisible] = useState(readStoredVisibility);
 
   const toggle = useCallback(() => {
-    const flip = () => setVisible(previous => !previous);
+    const next = !visible;
+    const flip = () => setVisible(next);
 
     // Morph the toolbar and its collapsed puck into each other where the
     // browser supports it. flushSync forces React to commit synchronously so
@@ -21,7 +24,9 @@ export function CommentingVisibilityProvider({children}) {
     else {
       flip();
     }
-  }, []);
+
+    storeVisibility(next);
+  }, [visible]);
 
   const value = useMemo(() => ({visible, toggle}), [visible, toggle]);
 
@@ -34,4 +39,27 @@ export function CommentingVisibilityProvider({children}) {
 
 export function useCommentingVisibility() {
   return useContext(CommentingVisibilityContext);
+}
+
+function readStoredVisibility() {
+  return getLocalStorage()?.[storageKey] !== 'false';
+}
+
+function storeVisibility(visible) {
+  const storage = getLocalStorage();
+
+  if (storage) {
+    storage[storageKey] = visible;
+  }
+}
+
+function getLocalStorage() {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage;
+  }
+  catch(e) {
+    // Safari throws SecurityError when accessing window.localStorage
+    // if cookies/website data are disabled.
+    return null;
+  }
 }


### PR DESCRIPTION
Reviewers who collapse the comment toolbar to get an unobstructed view of the entry had to collapse it again on every page load. The choice is now persisted and restored on the next visit.

REDMINE-21261