### PR TITLE
Let overridden readers supply locale fallback

### DIFF
--- a/app/models/concerns/pageflow/translated_attributes.rb
+++ b/app/models/concerns/pageflow/translated_attributes.rb
@@ -1,7 +1,9 @@
 module Pageflow
   # Store per locale overrides for a set of attributes in an
   # `attribute_translations` column. The attribute itself keeps holding
-  # the value used for locales without translation.
+  # the value used for locales without translation. Since that value is
+  # read via the attribute's reader, overriding the reader also changes
+  # the value locales without translation fall back to.
   #
   # Not to be confused with {Translatable}, which groups entries that
   # are translations of each other.
@@ -39,11 +41,16 @@ module Pageflow
       self[:attribute_translations] || {}
     end
 
+    # Returns the translation for the given locale, or the value of the
+    # attribute itself if there is none. The fallback goes through the
+    # attribute's reader, so models can override it to compute a
+    # default. Such an override must not call `translated` itself, since
+    # that would recurse.
     def translated(attribute, locale:)
       locale_chain(locale)
         .lazy
         .map { |candidate| attribute_translations.dig(candidate, attribute.to_s) }
-        .find(&:present?) || self[attribute]
+        .find(&:present?) || public_send(attribute)
     end
 
     private

--- a/spec/models/concerns/pageflow/translated_attributes_spec.rb
+++ b/spec/models/concerns/pageflow/translated_attributes_spec.rb
@@ -23,6 +23,14 @@ module Pageflow
     end
 
     describe '#translated' do
+      let(:model_with_reader_override) do
+        Class.new(model) do
+          def imprint_link_label
+            super.presence || 'Computed'
+          end
+        end
+      end
+
       it 'returns attribute value if there are no translations' do
         record = model.new(imprint_link_label: 'Impressum')
 
@@ -91,6 +99,22 @@ module Pageflow
                            })
 
         expect(record.translated(:imprint_link_label, locale: :en)).to eq('Legal notice')
+      end
+
+      it 'falls back to overridden attribute reader' do
+        record = model_with_reader_override.new
+
+        expect(record.translated(:imprint_link_label, locale: 'en')).to eq('Computed')
+      end
+
+      it 'prefers translation over overridden attribute reader' do
+        record = model_with_reader_override.new(attribute_translations: {
+                                                  'en' => {
+                                                    'imprint_link_label' => 'Legal notice'
+                                                  }
+                                                })
+
+        expect(record.translated(:imprint_link_label, locale: 'en')).to eq('Legal notice')
       end
     end
 


### PR DESCRIPTION
Resolving a translated attribute for a locale without translation read the raw column, so host apps that override such an attribute's reader to compute a default lost that default everywhere. Sites without an explicitly configured privacy URL, for instance, rendered no privacy link at all. Reading through the reader instead restores that extension point for all consumers at once; an explicit per locale translation still takes precedence.

An overridden reader must not call `translated` itself, since that would recurse.