### PR TITLE
Allow theming figure caption padding, border and corners

### DIFF
--- a/entry_types/scrolled/doc/creating_themes/custom_colors_and_dimensions.md
+++ b/entry_types/scrolled/doc/creating_themes/custom_colors_and_dimensions.md
@@ -230,6 +230,21 @@ When editors select the "rounded" modifier for an image, they can
 choose from these predefined values, ensuring consistent styling across
 the story.
 
+### Figure Caption
+
+The following properties control the appearance of captions rendered
+below figures like inline images and videos.
+
+| Name | Description |
+| ---- | ----------- |
+| `figure_caption_padding_inline` | Space on the left and right inside the caption. |
+| `figure_caption_padding_top` | Space above the caption text. |
+| `figure_caption_padding_bottom` | Space below the caption text. |
+| `figure_caption_surface_color` | Background color of the caption. Defaults to `light_content_surface_color` (or `dark_content_surface_color` in inverted sections). |
+| `figure_caption_text_color` | Text color of the caption. Defaults to `dark_content_text_color` (or `light_content_text_color` in inverted sections). |
+| `figure_caption_border_bottom` | Border rendered below the caption using CSS `border-bottom` shorthand syntax (e.g. `2px solid #ccc`). |
+| `figure_caption_border_bottom_radius` | Rounds the bottom left and right corners of the caption. |
+
 ### Text Block Styles
 
 | Name | Description |

--- a/entry_types/scrolled/package/src/frontend/Figure.module.css
+++ b/entry_types/scrolled/package/src/frontend/Figure.module.css
@@ -10,9 +10,15 @@
 }
 
 .root > figcaption {
-  padding: 3px var(--theme-figure-caption-padding-inline, 10px) 5px;
+  padding:
+    var(--theme-figure-caption-padding-top, 3px)
+    var(--theme-figure-caption-padding-inline, 10px)
+    var(--theme-figure-caption-padding-bottom, 5px);
   background-color: var(--theme-figure-caption-surface-color, lightContentSurfaceColor);
   color: var(--theme-figure-caption-text-color, darkContentTextColor);
+  border-bottom: var(--theme-figure-caption-border-bottom, none);
+  border-bottom-left-radius: var(--theme-figure-caption-border-bottom-radius, 0);
+  border-bottom-right-radius: var(--theme-figure-caption-border-bottom-radius, 0);
 }
 
 .root > figcaption p {


### PR DESCRIPTION
Themes can now control figure caption padding (top, bottom and inline), give captions a bottom border and round the bottom corners, letting caption styling match a customer's design. Existing themes are unaffected: the new properties default to the previous values.

REDMINE-21325