### PR TITLE
Add alt text support for Lottie animations

### DIFF
--- a/entry_types/scrolled/package/spec/contentElements/lottieAnimation/LottieAnimation-spec.js
+++ b/entry_types/scrolled/package/spec/contentElements/lottieAnimation/LottieAnimation-spec.js
@@ -54,6 +54,25 @@ describe('LottieAnimation', () => {
     expect(players[0].config.src).toEqual('000/000/001/animation.lottie');
   });
 
+  it('exposes animation as image named after alt text of file', () => {
+    const {getByRole} = renderLottieAnimation({
+      lottieFiles: [
+        {
+          id: 1, permaId: 100, basename: 'animation', extension: 'lottie',
+          configuration: {alt: 'Dancing robot'}
+        }
+      ]
+    });
+
+    expect(getByRole('img', {name: 'Dancing robot'})).not.toBeNull();
+  });
+
+  it('hides animation from screen readers if file has no alt text', () => {
+    const {container} = renderLottieAnimation();
+
+    expect(container.querySelector('canvas')).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('does not create player before element is near viewport', () => {
     renderLottieAnimation({scrollPosition: 'outside viewport'});
 

--- a/entry_types/scrolled/package/spec/contentElements/lottieAnimation/editor/index-spec.js
+++ b/entry_types/scrolled/package/spec/contentElements/lottieAnimation/editor/index-spec.js
@@ -175,6 +175,18 @@ describe('lottieAnimation/editor', () => {
     expect(editor.fileTypes.findByCollectionName('lottie_files').model).toBe(LottieFile);
   });
 
+  it('supports editing alt text of lottie files', () => {
+    const fileType = editor.fileTypes.findByCollectionName('lottie_files');
+
+    expect(fileType.configurationEditorInputs.map(input => input.name)).toContain('alt');
+  });
+
+  it('displays alt text in meta data of lottie files', () => {
+    const fileType = editor.fileTypes.findByCollectionName('lottie_files');
+
+    expect(fileType.metaDataAttributes.map(attribute => attribute.name)).toContain('alt');
+  });
+
   it('matches uploads of dotLottie files', () => {
     const fileType = editor.fileTypes.findByUpload({name: 'animation.lottie', type: ''});
 

--- a/entry_types/scrolled/package/src/contentElements/lottieAnimation/LottieAnimation.js
+++ b/entry_types/scrolled/package/src/contentElements/lottieAnimation/LottieAnimation.js
@@ -42,6 +42,7 @@ export function LottieAnimation({configuration}) {
               <FilePlaceholder file={lottieFile} />
               {lottieFile && shouldLoad &&
                <Player lottieFile={lottieFile}
+                       alt={lottieFile.configuration.alt}
                        loop={playbackMode === 'loop'}
                        play={isVisible}
                        seekOnScroll={playbackMode === 'scroll'}
@@ -65,7 +66,7 @@ export function LottieAnimation({configuration}) {
 }
 
 function Player({
-  lottieFile, loop, play, seekOnScroll, scrollRange, fit,
+  lottieFile, alt, loop, play, seekOnScroll, scrollRange, fit,
   cropPositionX = 50, cropPositionY = 50, onAspectRatioChange
 }) {
   const canvasRef = useRef();
@@ -142,7 +143,12 @@ function Player({
     }
   }, [play, seekOnScroll]);
 
+  // A canvas has no alt attribute.
   return (
-    <canvas ref={canvasRef} className={styles.canvas} />
+    <canvas ref={canvasRef}
+            className={styles.canvas}
+            role={alt ? 'img' : undefined}
+            aria-label={alt || undefined}
+            aria-hidden={alt ? undefined : true} />
   );
 }

--- a/entry_types/scrolled/package/src/contentElements/lottieAnimation/editor/index.js
+++ b/entry_types/scrolled/package/src/contentElements/lottieAnimation/editor/index.js
@@ -5,7 +5,11 @@ import {
   ScrollRangeSelectInputView
 } from 'pageflow-scrolled/editor';
 import {processImageModifiers} from 'pageflow-scrolled/frontend';
-import {FileInputView} from 'pageflow/editor';
+import {
+  altConfigurationEditorInput,
+  altMetaDataAttribute,
+  FileInputView
+} from 'pageflow/editor';
 import {SelectInputView, SeparatorView} from 'pageflow/ui';
 
 import {LottieFile} from './models/LottieFile';
@@ -20,6 +24,13 @@ editor.fileTypes.register('lottie_files', {
   positioningView: LottieFilePositioningView,
   previewView: LottieFilePreviewView,
   thumbnailView: LottieFileThumbnailView,
+
+  metaDataAttributes: [
+    altMetaDataAttribute
+  ],
+  configurationEditorInputs: [
+    altConfigurationEditorInput
+  ],
 
   // Browsers derive the content type of uploads from the file
   // extension. Since dotLottie is missing from their mappings, uploads

--- a/package/src/editor/api/alt.js
+++ b/package/src/editor/api/alt.js
@@ -1,0 +1,20 @@
+import {TextInputView} from 'pageflow/ui';
+
+import {TextFileMetaDataItemValueView} from '../views/TextFileMetaDataItemValueView';
+
+export const altMetaDataAttribute = {
+  name: 'alt',
+  valueView: TextFileMetaDataItemValueView,
+  valueViewOptions: {
+    fromConfiguration: true,
+    settingsDialogTabLink: 'general'
+  }
+};
+
+export const altConfigurationEditorInput = {
+  name: 'alt',
+  inputView: TextInputView,
+  inputViewOptions: {
+    maxLength: 5000
+  }
+};

--- a/package/src/editor/index.js
+++ b/package/src/editor/index.js
@@ -1,6 +1,7 @@
 import './sync';
 
 export * from './api';
+export * from './api/alt';
 
 export * from 'pageflow/ui';
 

--- a/package/src/editor/initializers/setupFileTypes.js
+++ b/package/src/editor/initializers/setupFileTypes.js
@@ -2,6 +2,8 @@ import I18n from 'i18n-js';
 
 import {IconTableCellView, SelectInputView, TextInputView, TextTableCellView} from 'pageflow/ui';
 
+import {altConfigurationEditorInput, altMetaDataAttribute} from '../api/alt';
+
 import {AudioFile} from '../models/AudioFile';
 import {ImageFile} from '../models/ImageFile';
 import {TextTrackFile} from '../models/TextTrackFile';
@@ -35,23 +37,6 @@ var textTracksSettingsDialogTab = {
     supersetCollection: function() {
       return state.textTrackFiles;
     }
-  }
-};
-
-var altMetaDataAttribute = {
-  name: 'alt',
-  valueView: TextFileMetaDataItemValueView,
-  valueViewOptions: {
-    fromConfiguration: true,
-    settingsDialogTabLink: 'general'
-  }
-};
-
-var altConfigurationEditorInput = {
-  name: 'alt',
-  inputView: TextInputView,
-  inputViewOptions: {
-    maxLength: 5000
   }
 };
 
@@ -179,10 +164,7 @@ editor.fileTypes.register('other_files', {
   matchUpload: () => true,
   priority: 100,
   configurationEditorInputs: [
-    {
-      name: 'alt',
-      inputView: TextInputView
-    }
+    altConfigurationEditorInput
   ]
 });
 


### PR DESCRIPTION
Lottie animations were the only media content element without alt text, leaving screen reader users with an unlabeled canvas. Editors can now enter alt text in the Lottie file's settings dialog just like for images, videos and audio. Animations without alt text are hidden from screen readers, matching the empty alt attribute used for decorative images.

The shared alt attribute definitions are now exported from pageflow/editor so that entry type specific file types can reuse them.