### PR TITLE
Pin json below 3

### DIFF
--- a/pageflow.gemspec
+++ b/pageflow.gemspec
@@ -48,6 +48,11 @@ Gem::Specification.new do |s|
   # Faster JSON backend
   s.add_dependency 'yajl-ruby', '~> 1.2'
 
+  # Rails calls JSON.parse in ways json 3 rejects: 8.1 passes options
+  # positionally, 7.2 passes the removed quirks_mode option. Fixed on
+  # Rails 8-0-stable and 8-1-stable, still open on 7-2-stable.
+  s.add_dependency 'json', '< 3'
+
   # Authorization
   s.add_dependency 'cancancan', '~> 3.5'
 


### PR DESCRIPTION
json 3 made JSON.parse options keyword-only and dropped quirks_mode. Every Rails version we support still relies on one or the other: 8.1 passes its options hash positionally, 7.2 passes quirks_mode. Either way ActiveSupport::JSON.decode raises, so reading any serialized JSON column fails. Rails has fixed this on 8-0-stable and 8-1-stable, but not on 7-2-stable and not in any released version yet.

Plugins inherit the constraint through their pageflow dependency, so this is the only place to unpin.